### PR TITLE
Add .NET Core 3.1 SDK to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -300,6 +301,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -516,6 +518,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x


### PR DESCRIPTION
## Summary
- Add `3.1.x` to `dotnet-version` in all three release.yaml jobs (validate-release, pack-and-validate, publish-nuget)
- Matches ETL-Abstractions which includes 3.1.x for netcoreapp3.1 test target support

## Test plan
- [ ] Verify release workflow installs 3.1 SDK alongside other versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)