### PR TITLE
Address Copilot review feedback from PR #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ public class EmployeeRecord
 
 | Framework | Versions |
 |-----------|----------|
-| .NET Framework | .NET 4.6.2, .NET 4.8.1 |
+| .NET Framework | .NET 4.6.2, .NET 4.7.2, .NET 4.8, .NET 4.8.1 |
 | .NET Standard | .NET Standard 2.0 |
 | .NET | .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0, .NET 10.0 |
 

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <ExcludeByAttribute>ExcludeFromCodeCoverage</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/docfx_project/api/README.md
+++ b/docfx_project/api/README.md
@@ -16,7 +16,6 @@ When you run `docfx docfx_project/docfx.json` from the repository root, DocFX wi
 - Hand-authored files like `index.md` and this `README.md` are intentionally maintained by hand and will be preserved across DocFX runs
 - The actual API reference metadata files (`*.yml` files) will be generated automatically
 
-## Template Placeholders
+## Namespace
 
-The `index.md` file uses the following template placeholder:
-- `Wolfgang.Etl.DbClient` - Will be replaced with your project name
+The generated API documentation covers the `Wolfgang.Etl.DbClient` namespace and its sub-namespaces.

--- a/docs/README-FORMATTING.md
+++ b/docs/README-FORMATTING.md
@@ -15,13 +15,13 @@ The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 
 Run the formatting script with PowerShell Core (`pwsh`) on any supported platform:
 
 ```powershell
-.\format.ps1
+.\scripts\format.ps1
 ```
 
 Or check without making changes:
 
 ```powershell
-.\format.ps1 -Check
+.\scripts\format.ps1 -Check
 ```
 
 ### Manual Formatting

--- a/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
@@ -71,6 +71,15 @@ internal static class DbCommandBuilder
             insertColumns = columns;
         }
 
+        if (insertColumns.Count == 0)
+        {
+            throw new InvalidOperationException
+            (
+                $"Type '{type.FullName}' has no mapped columns for INSERT. " +
+                "Ensure at least one public instance property is not decorated with [NotMapped]."
+            );
+        }
+
         var columnList = string.Join(", ", insertColumns.Select(c => c.ColumnName));
         var paramList = string.Join(", ", insertColumns.Select(c => $"@{c.PropertyName}"));
 
@@ -106,6 +115,15 @@ internal static class DbCommandBuilder
         var keyNames = new HashSet<string>(keys.Select(k => k.Name), StringComparer.Ordinal);
         var setColumns = columns.Where(c => !keyNames.Contains(c.PropertyName)).ToList();
         var whereColumns = columns.Where(c => keyNames.Contains(c.PropertyName)).ToList();
+
+        if (setColumns.Count == 0)
+        {
+            throw new InvalidOperationException
+            (
+                $"Type '{type.FullName}' has no non-key columns for the SET clause. " +
+                "UPDATE requires at least one property that is not decorated with [Key]."
+            );
+        }
 
         var setClause = string.Join(", ", setColumns.Select(c => $"{c.ColumnName} = @{c.PropertyName}"));
         var whereClause = string.Join(" AND ", whereColumns.Select(c => $"{c.ColumnName} = @{c.PropertyName}"));


### PR DESCRIPTION
## Summary
Fixes 5 of 8 Copilot review comments from PR #2:

- **BuildInsert**: throw `InvalidOperationException` when no insertable columns exist (prevents `INSERT INTO T () VALUES ()`)
- **BuildUpdate**: throw `InvalidOperationException` when all mapped columns are keys (prevents `UPDATE T SET  WHERE ...`)
- **README**: add missing `net472`/`net48` to TFM table to match actual csproj TargetFrameworks
- **docs/README-FORMATTING.md**: fix script path from `format.ps1` → `scripts/format.ps1`
- **docfx_project/api/README.md**: replace stale template placeholder text with namespace description

### Not addressed (disagreed):
- Debug parameter logging — debug-level is opt-in, redacting defeats diagnostics purpose
- pr.yaml hard-fail on config changes — intentional security design across all repos
- CODE_OF_CONDUCT noreply address — GitHub noreply forwards to account, works for reports

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] 135 tests pass on net10.0
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)