### PR TITLE
Address Copilot review round 2: whereColumns validation and tests

### DIFF
--- a/docs/README-FORMATTING.md
+++ b/docs/README-FORMATTING.md
@@ -46,7 +46,7 @@ All pull requests are automatically checked for proper formatting. PRs with form
 
 ### If CI Fails
 
-1. Run `.\format.ps1` locally
+1. Run `.\scripts\format.ps1` locally
 2. Review the changes
 3. Commit and push the formatted code
 

--- a/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
@@ -125,6 +125,15 @@ internal static class DbCommandBuilder
             );
         }
 
+        if (whereColumns.Count == 0)
+        {
+            throw new InvalidOperationException
+            (
+                $"Type '{type.FullName}' has [Key] properties but none are mapped columns. " +
+                "Ensure key properties are not decorated with [NotMapped]."
+            );
+        }
+
         var setClause = string.Join(", ", setColumns.Select(c => $"{c.ColumnName} = @{c.PropertyName}"));
         var whereClause = string.Join(" AND ", whereColumns.Select(c => $"{c.ColumnName} = @{c.PropertyName}"));
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbCommandBuilderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbCommandBuilderTests.cs
@@ -95,6 +95,35 @@ public class DbCommandBuilderTests
 
 
 
+    [ExcludeFromCodeCoverage]
+    [Table("AllKeysOnly")]
+    private class AllKeysOnlyRecord
+    {
+        [Key]
+        [Column("key_a")]
+        public int KeyA { get; set; }
+
+        [Key]
+        [Column("key_b")]
+        public int KeyB { get; set; }
+    }
+
+
+
+    [ExcludeFromCodeCoverage]
+    [Table("NotMappedKey")]
+    private class NotMappedKeyRecord
+    {
+        [Key]
+        [NotMapped]
+        public int Id { get; set; }
+
+        [Column("value")]
+        public string Value { get; set; } = string.Empty;
+    }
+
+
+
     // ------------------------------------------------------------------
     // BuildSelect
     // ------------------------------------------------------------------
@@ -198,6 +227,23 @@ public class DbCommandBuilderTests
 
 
 
+    [Fact]
+    public void BuildInsert_when_all_properties_are_NotMapped_throws_InvalidOperationException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>
+        (
+            DbCommandBuilder.BuildInsert<AllNotMappedRecord>
+        );
+
+        Assert.Contains
+        (
+            "no mapped columns",
+            ex.Message
+        );
+    }
+
+
+
     // ------------------------------------------------------------------
     // BuildUpdate
     // ------------------------------------------------------------------
@@ -244,6 +290,40 @@ public class DbCommandBuilderTests
         Assert.Throws<InvalidOperationException>
         (
             DbCommandBuilder.BuildUpdate<NoTableRecord>
+        );
+    }
+
+
+
+    [Fact]
+    public void BuildUpdate_when_all_columns_are_keys_throws_InvalidOperationException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>
+        (
+            DbCommandBuilder.BuildUpdate<AllKeysOnlyRecord>
+        );
+
+        Assert.Contains
+        (
+            "no non-key columns",
+            ex.Message
+        );
+    }
+
+
+
+    [Fact]
+    public void BuildUpdate_when_key_properties_are_NotMapped_throws_InvalidOperationException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>
+        (
+            DbCommandBuilder.BuildUpdate<NotMappedKeyRecord>
+        );
+
+        Assert.Contains
+        (
+            "none are mapped",
+            ex.Message
         );
     }
 }


### PR DESCRIPTION
## Summary
Follow-up fixes from Copilot review on PR #18 (merged before these were pushed):

- **BuildUpdate**: validate `whereColumns` is not empty when `[Key]` properties are all `[NotMapped]`
- **Tests**: add 3 new tests for edge cases:
  - `BuildInsert` with all `[NotMapped]` properties → throws
  - `BuildUpdate` with all columns being keys (empty SET) → throws
  - `BuildUpdate` with `[NotMapped]` key properties (empty WHERE) → throws
- **docs/README-FORMATTING.md**: fix remaining `.\format.ps1` → `.\scripts\format.ps1` in "If CI Fails" section

## Test plan
- [x] 138 tests pass on net10.0 (3 new)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)