### PR TITLE
Drop TProgress generic parameter, hardcode DbReport

### DIFF
--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Data.Sqlite;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.DbClient;
 
 namespace Wolfgang.Etl.DbClient.Benchmarks;
@@ -66,7 +65,7 @@ public sealed class ExtractorBenchmarks : IDisposable
     [Benchmark]
     public async Task<int> ExtractAsync()
     {
-        var extractor = new DbExtractor<BenchmarkRecord, Report>
+        var extractor = new DbExtractor<BenchmarkRecord>
         (
             _connection,
             "SELECT id AS Id, first_name AS FirstName, last_name AS LastName, age AS Age FROM People"

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Data.Sqlite;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.DbClient;
 
 namespace Wolfgang.Etl.DbClient.Benchmarks;
@@ -53,7 +52,7 @@ public class LoaderBenchmarks
             )";
         await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 
-        var loader = new DbLoader<BenchmarkRecord, Report>
+        var loader = new DbLoader<BenchmarkRecord>
         (
             connection,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"

--- a/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Program.cs
@@ -32,7 +32,7 @@ Console.WriteLine();
 
 // LOAD: Auto-generates INSERT INTO Products (name, category, price) VALUES (@Name, @Category, @Price)
 // Note: the [Key] + [DatabaseGenerated(Identity)] column 'product_id' is excluded from INSERT.
-var loader = new DbLoader<ProductRecord, DbReport>(connection, WriteMode.Insert);
+var loader = new DbLoader<ProductRecord>(connection, WriteMode.Insert);
 Console.WriteLine($"Loader SQL: {loader.CommandText}");
 Console.WriteLine();
 
@@ -60,7 +60,7 @@ static async IAsyncEnumerable<ProductRecord> SeedProducts()
 Console.WriteLine();
 
 // EXTRACT: Auto-generates SELECT product_id AS Id, name AS Name, category AS Category, price AS Price FROM Products
-var extractor = new DbExtractor<ProductRecord, DbReport>(connection);
+var extractor = new DbExtractor<ProductRecord>(connection);
 Console.WriteLine($"Extractor SQL: {extractor.CommandText}");
 Console.WriteLine();
 

--- a/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Wolfgang.Etl.DbClient.Example.AutoSql.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Wolfgang.Etl.DbClient.Example.AutoSql.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <NoWarn>MA0004</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Program.cs
@@ -47,7 +47,7 @@ using var transaction = await connection.BeginTransactionAsync();
 // Auto-generates:
 // UPDATE Inventory SET product_name = @ProductName, quantity = @Quantity, last_updated = @LastUpdated
 // WHERE sku = @Sku
-var loader = new DbLoader<InventoryRecord, DbReport>(
+var loader = new DbLoader<InventoryRecord>(
     connection,
     WriteMode.Update,
     transaction

--- a/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <NoWarn>MA0004</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Wolfgang.Etl.DbClient.Example/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example/Program.cs
@@ -42,7 +42,7 @@ Console.WriteLine("=== ETL Pipeline: Employees → HighEarners (salary > 80000) 
 Console.WriteLine();
 
 // EXTRACT: Read employees with salary > 80000
-var extractor = new DbExtractor<EmployeeRecord, DbReport>
+var extractor = new DbExtractor<EmployeeRecord>
 (
     connection,
     "SELECT id AS Id, first_name AS FirstName, last_name AS LastName, salary AS Salary FROM Employees WHERE salary > @MinSalary",
@@ -50,7 +50,7 @@ var extractor = new DbExtractor<EmployeeRecord, DbReport>
 );
 
 // LOAD: Insert into HighEarners table
-var loader = new DbLoader<HighEarnerRecord, DbReport>
+var loader = new DbLoader<HighEarnerRecord>
 (
     connection,
     "INSERT INTO HighEarners (full_name, salary) VALUES (@FullName, @Salary)"

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -21,10 +21,6 @@ namespace Wolfgang.Etl.DbClient;
 /// The POCO type representing a single row. Properties are mapped from result set
 /// columns by name or <c>[Column("name")]</c> attribute.
 /// </typeparam>
-/// <typeparam name="TProgress">
-/// The type of the progress object reported during extraction.
-/// Use <see cref="DbReport"/> for the default implementation.
-/// </typeparam>
 /// <remarks>
 /// <para>
 /// The caller owns the <see cref="DbConnection"/> lifetime — the extractor does not
@@ -36,9 +32,8 @@ namespace Wolfgang.Etl.DbClient;
 /// The extractor never commits or rolls back the transaction.
 /// </para>
 /// </remarks>
-public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
+public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     where TRecord : notnull
-    where TProgress : notnull
 {
     // ------------------------------------------------------------------
     // Fields
@@ -71,7 +66,7 @@ public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
     // ------------------------------------------------------------------
 
     /// <summary>
-    /// Initializes a new <see cref="DbExtractor{TRecord,TProgress}"/> with a SQL command.
+    /// Initializes a new <see cref="DbExtractor{TRecord}"/> with a SQL command.
     /// </summary>
     /// <param name="connection">An open <see cref="DbConnection"/>. The caller owns its lifetime.</param>
     /// <param name="commandText">The SQL query to execute.</param>
@@ -85,7 +80,7 @@ public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
         DbConnection connection,
         string commandText,
         DbTransaction? transaction = null,
-        ILogger<DbExtractor<TRecord, TProgress>>? logger = null
+        ILogger<DbExtractor<TRecord>>? logger = null
     )
     {
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -97,7 +92,7 @@ public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
 
 
     /// <summary>
-    /// Initializes a new <see cref="DbExtractor{TRecord,TProgress}"/> with a parameterized SQL command.
+    /// Initializes a new <see cref="DbExtractor{TRecord}"/> with a parameterized SQL command.
     /// </summary>
     /// <param name="connection">An open <see cref="DbConnection"/>. The caller owns its lifetime.</param>
     /// <param name="commandText">The SQL query to execute.</param>
@@ -113,7 +108,7 @@ public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
         string commandText,
         IDictionary<string, object> parameters,
         DbTransaction? transaction = null,
-        ILogger<DbExtractor<TRecord, TProgress>>? logger = null
+        ILogger<DbExtractor<TRecord>>? logger = null
     )
     {
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -126,7 +121,7 @@ public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
 
 
     /// <summary>
-    /// Initializes a new <see cref="DbExtractor{TRecord,TProgress}"/> that auto-generates
+    /// Initializes a new <see cref="DbExtractor{TRecord}"/> that auto-generates
     /// a SELECT statement from <c>[Table]</c> and <c>[Column]</c> attributes on
     /// <typeparamref name="TRecord"/>.
     /// </summary>
@@ -141,7 +136,7 @@ public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
     (
         DbConnection connection,
         DbTransaction? transaction = null,
-        ILogger<DbExtractor<TRecord, TProgress>>? logger = null
+        ILogger<DbExtractor<TRecord>>? logger = null
     )
     {
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -160,7 +155,7 @@ public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
         DbConnection connection,
         string commandText,
         IProgressTimer timer,
-        ILogger<DbExtractor<TRecord, TProgress>>? logger = null
+        ILogger<DbExtractor<TRecord>>? logger = null
     )
     {
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -183,23 +178,14 @@ public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
 
 
     /// <inheritdoc/>
-    protected override TProgress CreateProgressReport()
+    protected override DbReport CreateProgressReport()
     {
-        if (typeof(TProgress) == typeof(DbReport) || typeof(TProgress) == typeof(Report))
-        {
-            return (TProgress)(object)new DbReport
-            (
-                CurrentItemCount,
-                CurrentSkippedItemCount,
-                _commandText,
-                _stopwatch.ElapsedMilliseconds
-            );
-        }
-
-        throw new NotSupportedException
+        return new DbReport
         (
-            $"Override {nameof(CreateProgressReport)} to supply a " +
-            $"{typeof(TProgress).Name} instance."
+            CurrentItemCount,
+            CurrentSkippedItemCount,
+            _commandText,
+            _stopwatch.ElapsedMilliseconds
         );
     }
 
@@ -208,12 +194,12 @@ public class DbExtractor<TRecord, TProgress> : ExtractorBase<TRecord, TProgress>
     /// <summary>
     /// Returns a snapshot progress report. Visible to the test assembly via InternalsVisibleTo.
     /// </summary>
-    internal TProgress GetProgressReport() => CreateProgressReport();
+    internal DbReport GetProgressReport() => CreateProgressReport();
 
 
 
     /// <inheritdoc/>
-    protected override IProgressTimer CreateProgressTimer(IProgress<TProgress> progress)
+    protected override IProgressTimer CreateProgressTimer(IProgress<DbReport> progress)
     {
         if (_progressTimer != null)
         {

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -20,10 +20,6 @@ namespace Wolfgang.Etl.DbClient;
 /// The POCO type representing a single row. Properties are mapped to command
 /// parameters by name or <c>[Column("name")]</c> attribute.
 /// </typeparam>
-/// <typeparam name="TProgress">
-/// The type of the progress object reported during loading.
-/// Use <see cref="DbReport"/> for the default implementation.
-/// </typeparam>
 /// <remarks>
 /// <para>
 /// Two transaction modes are supported:
@@ -42,9 +38,8 @@ namespace Wolfgang.Etl.DbClient;
 /// <c>LoadAsync</c>.
 /// </para>
 /// </remarks>
-public class DbLoader<TRecord, TProgress> : LoaderBase<TRecord, TProgress>
+public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
     where TRecord : notnull
-    where TProgress : notnull
 {
     // ------------------------------------------------------------------
     // Fields
@@ -66,7 +61,7 @@ public class DbLoader<TRecord, TProgress> : LoaderBase<TRecord, TProgress>
     // ------------------------------------------------------------------
 
     /// <summary>
-    /// Initializes a new <see cref="DbLoader{TRecord,TProgress}"/> with a custom SQL command.
+    /// Initializes a new <see cref="DbLoader{TRecord}"/> with a custom SQL command.
     /// </summary>
     /// <param name="connection">An open <see cref="DbConnection"/>. The caller owns its lifetime.</param>
     /// <param name="commandText">The SQL INSERT or UPDATE command to execute per record.</param>
@@ -83,7 +78,7 @@ public class DbLoader<TRecord, TProgress> : LoaderBase<TRecord, TProgress>
         DbConnection connection,
         string commandText,
         DbTransaction? transaction = null,
-        ILogger<DbLoader<TRecord, TProgress>>? logger = null
+        ILogger<DbLoader<TRecord>>? logger = null
     )
     {
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -96,7 +91,7 @@ public class DbLoader<TRecord, TProgress> : LoaderBase<TRecord, TProgress>
 
 
     /// <summary>
-    /// Initializes a new <see cref="DbLoader{TRecord,TProgress}"/> that auto-generates
+    /// Initializes a new <see cref="DbLoader{TRecord}"/> that auto-generates
     /// an INSERT statement from <c>[Table]</c> and <c>[Column]</c> attributes on
     /// <typeparamref name="TRecord"/>.
     /// </summary>
@@ -118,7 +113,7 @@ public class DbLoader<TRecord, TProgress> : LoaderBase<TRecord, TProgress>
         DbConnection connection,
         WriteMode writeMode,
         DbTransaction? transaction = null,
-        ILogger<DbLoader<TRecord, TProgress>>? logger = null
+        ILogger<DbLoader<TRecord>>? logger = null
     )
     {
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -140,7 +135,7 @@ public class DbLoader<TRecord, TProgress> : LoaderBase<TRecord, TProgress>
         DbConnection connection,
         string commandText,
         IProgressTimer timer,
-        ILogger<DbLoader<TRecord, TProgress>>? logger = null
+        ILogger<DbLoader<TRecord>>? logger = null
     )
     {
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -164,23 +159,14 @@ public class DbLoader<TRecord, TProgress> : LoaderBase<TRecord, TProgress>
 
 
     /// <inheritdoc/>
-    protected override TProgress CreateProgressReport()
+    protected override DbReport CreateProgressReport()
     {
-        if (typeof(TProgress) == typeof(DbReport) || typeof(TProgress) == typeof(Report))
-        {
-            return (TProgress)(object)new DbReport
-            (
-                CurrentItemCount,
-                CurrentSkippedItemCount,
-                _commandText,
-                _stopwatch.ElapsedMilliseconds
-            );
-        }
-
-        throw new NotSupportedException
+        return new DbReport
         (
-            $"Override {nameof(CreateProgressReport)} to supply a " +
-            $"{typeof(TProgress).Name} instance."
+            CurrentItemCount,
+            CurrentSkippedItemCount,
+            _commandText,
+            _stopwatch.ElapsedMilliseconds
         );
     }
 
@@ -189,12 +175,12 @@ public class DbLoader<TRecord, TProgress> : LoaderBase<TRecord, TProgress>
     /// <summary>
     /// Returns a snapshot progress report. Visible to the test assembly via InternalsVisibleTo.
     /// </summary>
-    internal TProgress GetProgressReport() => CreateProgressReport();
+    internal DbReport GetProgressReport() => CreateProgressReport();
 
 
 
     /// <inheritdoc/>
-    protected override IProgressTimer CreateProgressTimer(IProgress<TProgress> progress)
+    protected override IProgressTimer CreateProgressTimer(IProgress<DbReport> progress)
     {
         if (_progressTimer != null)
         {

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.0.0</Version>
+    <Version>0.1.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.1.0</Version>
+    <Version>0.0.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Wolfgang.Etl.DbClient/WriteMode.cs
+++ b/src/Wolfgang.Etl.DbClient/WriteMode.cs
@@ -1,7 +1,7 @@
 namespace Wolfgang.Etl.DbClient;
 
 /// <summary>
-/// Specifies the type of SQL command the <see cref="DbLoader{TRecord,TProgress}"/>
+/// Specifies the type of SQL command the <see cref="DbLoader{TRecord}"/>
 /// auto-generates from attribute metadata.
 /// </summary>
 public enum WriteMode

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorLoggingTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorLoggingTests.cs
@@ -8,9 +8,9 @@ public class DbExtractorLoggingTests
     [Fact]
     public async Task ExtractAsync_logs_Information_at_start_and_completion()
     {
-        var logger = new SpyLogger<DbExtractor<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbExtractor<ContractRecord>>();
         using var conn = TestDb.CreateContractConnection(3);
-        var extractor = new DbExtractor<ContractRecord, DbReport>
+        var extractor = new DbExtractor<ContractRecord>
         (
             conn,
             "SELECT Name, Value FROM ContractItems",
@@ -31,9 +31,9 @@ public class DbExtractorLoggingTests
     [Fact]
     public async Task ExtractAsync_logs_Debug_per_row()
     {
-        var logger = new SpyLogger<DbExtractor<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbExtractor<ContractRecord>>();
         using var conn = TestDb.CreateContractConnection(3);
-        var extractor = new DbExtractor<ContractRecord, DbReport>
+        var extractor = new DbExtractor<ContractRecord>
         (
             conn,
             "SELECT Name, Value FROM ContractItems",
@@ -54,9 +54,9 @@ public class DbExtractorLoggingTests
     [Fact]
     public async Task ExtractAsync_logs_Debug_parameters()
     {
-        var logger = new SpyLogger<DbExtractor<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbExtractor<ContractRecord>>();
         using var conn = TestDb.CreateContractConnection(5);
-        var extractor = new DbExtractor<ContractRecord, DbReport>
+        var extractor = new DbExtractor<ContractRecord>
         (
             conn,
             "SELECT Name, Value FROM ContractItems WHERE Value > @MinValue",
@@ -79,9 +79,9 @@ public class DbExtractorLoggingTests
     [Fact]
     public async Task ExtractAsync_when_SkipItemCount_set_logs_Debug_skipped()
     {
-        var logger = new SpyLogger<DbExtractor<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbExtractor<ContractRecord>>();
         using var conn = TestDb.CreateContractConnection(5);
-        var extractor = new DbExtractor<ContractRecord, DbReport>
+        var extractor = new DbExtractor<ContractRecord>
         (
             conn,
             "SELECT Name, Value FROM ContractItems",
@@ -104,9 +104,9 @@ public class DbExtractorLoggingTests
     [Fact]
     public async Task ExtractAsync_when_MaximumItemCount_reached_logs_Debug()
     {
-        var logger = new SpyLogger<DbExtractor<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbExtractor<ContractRecord>>();
         using var conn = TestDb.CreateContractConnection(5);
-        var extractor = new DbExtractor<ContractRecord, DbReport>
+        var extractor = new DbExtractor<ContractRecord>
         (
             conn,
             "SELECT Name, Value FROM ContractItems",
@@ -130,7 +130,7 @@ public class DbExtractorLoggingTests
     public async Task ExtractAsync_when_no_logger_does_not_throw()
     {
         using var conn = TestDb.CreateContractConnection(3);
-        var extractor = new DbExtractor<ContractRecord, DbReport>
+        var extractor = new DbExtractor<ContractRecord>
         (
             conn,
             "SELECT Name, Value FROM ContractItems"

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -6,7 +6,7 @@ namespace Wolfgang.Etl.DbClient.Tests.Unit;
 
 public class DbExtractorTests
     : ExtractorBaseContractTests<
-        DbExtractor<ContractRecord, DbReport>,
+        DbExtractor<ContractRecord>,
         ContractRecord,
         DbReport>
 {
@@ -26,10 +26,10 @@ public class DbExtractorTests
 
 
     /// <inheritdoc/>
-    protected override DbExtractor<ContractRecord, DbReport> CreateSut(int itemCount)
+    protected override DbExtractor<ContractRecord> CreateSut(int itemCount)
     {
         var conn = TestDb.CreateContractConnection(itemCount);
-        return new DbExtractor<ContractRecord, DbReport>
+        return new DbExtractor<ContractRecord>
         (
             conn,
             "SELECT Name, Value FROM ContractItems ORDER BY Value"
@@ -44,10 +44,10 @@ public class DbExtractorTests
 
 
     /// <inheritdoc/>
-    protected override DbExtractor<ContractRecord, DbReport> CreateSutWithTimer(IProgressTimer timer)
+    protected override DbExtractor<ContractRecord> CreateSutWithTimer(IProgressTimer timer)
     {
         var conn = TestDb.CreateContractConnection(5);
-        return new DbExtractor<ContractRecord, DbReport>
+        return new DbExtractor<ContractRecord>
         (
             conn,
             "SELECT Name, Value FROM ContractItems ORDER BY Value",
@@ -65,7 +65,7 @@ public class DbExtractorTests
     {
         Assert.Throws<ArgumentNullException>
         (
-            () => new DbExtractor<PersonRecord, DbReport>(null!, "SELECT 1")
+            () => new DbExtractor<PersonRecord>(null!, "SELECT 1")
         );
     }
 
@@ -77,7 +77,7 @@ public class DbExtractorTests
         using var conn = TestDb.CreateConnection();
         Assert.Throws<ArgumentNullException>
         (
-            () => new DbExtractor<PersonRecord, DbReport>(conn, (string)null!)
+            () => new DbExtractor<PersonRecord>(conn, (string)null!)
         );
     }
 
@@ -89,7 +89,7 @@ public class DbExtractorTests
         using var conn = TestDb.CreateConnection();
         Assert.Throws<ArgumentNullException>
         (
-            () => new DbExtractor<PersonRecord, DbReport>(conn, "SELECT 1", (Dictionary<string, object>)null!)
+            () => new DbExtractor<PersonRecord>(conn, "SELECT 1", (Dictionary<string, object>)null!)
         );
     }
 
@@ -103,7 +103,7 @@ public class DbExtractorTests
     public async Task ExtractAsync_returns_all_rows()
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(3);
-        var extractor = new DbExtractor<PersonRecord, DbReport>
+        var extractor = new DbExtractor<PersonRecord>
         (
             conn,
             "SELECT id, first_name, last_name, age FROM People ORDER BY id"
@@ -123,7 +123,7 @@ public class DbExtractorTests
     public async Task ExtractAsync_with_empty_result_set_returns_no_items()
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(0);
-        var extractor = new DbExtractor<PersonRecord, DbReport>
+        var extractor = new DbExtractor<PersonRecord>
         (
             conn,
             "SELECT id, first_name, last_name, age FROM People"
@@ -144,7 +144,7 @@ public class DbExtractorTests
     public async Task ExtractAsync_with_parameters_filters_correctly()
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(5);
-        var extractor = new DbExtractor<PersonRecord, DbReport>
+        var extractor = new DbExtractor<PersonRecord>
         (
             conn,
             "SELECT id, first_name, last_name, age FROM People WHERE age > @MinAge",
@@ -167,7 +167,7 @@ public class DbExtractorTests
     public async Task ExtractAsync_with_auto_generated_select_returns_all_rows()
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(3);
-        var extractor = new DbExtractor<PersonRecord, DbReport>(conn);
+        var extractor = new DbExtractor<PersonRecord>(conn);
 
         var results = await extractor.ExtractAsync().ToListAsync();
 
@@ -180,7 +180,7 @@ public class DbExtractorTests
     public void CommandText_with_auto_generated_select_contains_table_name()
     {
         using var conn = TestDb.CreateConnection();
-        var extractor = new DbExtractor<PersonRecord, DbReport>(conn);
+        var extractor = new DbExtractor<PersonRecord>(conn);
 
         Assert.Contains("People", extractor.CommandText, StringComparison.Ordinal);
     }
@@ -195,7 +195,7 @@ public class DbExtractorTests
     public async Task ExtractAsync_when_SkipItemCount_is_set_skips_rows()
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(5);
-        var extractor = new DbExtractor<PersonRecord, DbReport>
+        var extractor = new DbExtractor<PersonRecord>
         (
             conn,
             "SELECT id, first_name, last_name, age FROM People ORDER BY id"
@@ -214,7 +214,7 @@ public class DbExtractorTests
     public async Task ExtractAsync_when_MaximumItemCount_is_set_stops_early()
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(5);
-        var extractor = new DbExtractor<PersonRecord, DbReport>
+        var extractor = new DbExtractor<PersonRecord>
         (
             conn,
             "SELECT id, first_name, last_name, age FROM People ORDER BY id"
@@ -241,7 +241,7 @@ public class DbExtractorTests
 #else
         using var transaction = await conn.BeginTransactionAsync();
 #endif
-        var extractor = new DbExtractor<PersonRecord, DbReport>
+        var extractor = new DbExtractor<PersonRecord>
         (
             conn,
             "SELECT id, first_name, last_name, age FROM People ORDER BY id",
@@ -263,7 +263,7 @@ public class DbExtractorTests
     public async Task GetProgressReport_returns_DbReport_with_counts()
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(3);
-        var extractor = new DbExtractor<PersonRecord, DbReport>
+        var extractor = new DbExtractor<PersonRecord>
         (
             conn,
             "SELECT id, first_name, last_name, age FROM People"
@@ -276,16 +276,5 @@ public class DbExtractorTests
         Assert.Equal(3, report.CurrentItemCount);
         Assert.Contains("People", report.CommandText, StringComparison.Ordinal);
         Assert.True(report.ElapsedMilliseconds >= 0);
-    }
-
-
-
-    [Fact]
-    public void GetProgressReport_when_TProgress_is_not_DbReport_throws_NotSupportedException()
-    {
-        using var conn = TestDb.CreateConnection();
-        var extractor = new DbExtractor<PersonRecord, Exception>(conn, "SELECT 1");
-
-        Assert.Throws<NotSupportedException>(extractor.GetProgressReport);
     }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderLoggingTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderLoggingTests.cs
@@ -20,9 +20,9 @@ public class DbLoaderLoggingTests
     [Fact]
     public async Task LoadAsync_logs_Information_at_start_and_completion()
     {
-        var logger = new SpyLogger<DbLoader<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbLoader<ContractRecord>>();
         using var conn = TestDb.CreateContractLoaderConnection();
-        var loader = new DbLoader<ContractRecord, DbReport>
+        var loader = new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",
@@ -43,9 +43,9 @@ public class DbLoaderLoggingTests
     [Fact]
     public async Task LoadAsync_logs_Debug_per_record()
     {
-        var logger = new SpyLogger<DbLoader<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbLoader<ContractRecord>>();
         using var conn = TestDb.CreateContractLoaderConnection();
-        var loader = new DbLoader<ContractRecord, DbReport>
+        var loader = new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",
@@ -66,9 +66,9 @@ public class DbLoaderLoggingTests
     [Fact]
     public async Task LoadAsync_logs_Debug_transaction_lifecycle()
     {
-        var logger = new SpyLogger<DbLoader<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbLoader<ContractRecord>>();
         using var conn = TestDb.CreateContractLoaderConnection();
-        var loader = new DbLoader<ContractRecord, DbReport>
+        var loader = new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",
@@ -96,9 +96,9 @@ public class DbLoaderLoggingTests
     [Fact]
     public async Task LoadAsync_on_failure_logs_Debug_rollback()
     {
-        var logger = new SpyLogger<DbLoader<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbLoader<ContractRecord>>();
         using var conn = TestDb.CreateContractLoaderConnection();
-        var loader = new DbLoader<ContractRecord, DbReport>
+        var loader = new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",
@@ -123,9 +123,9 @@ public class DbLoaderLoggingTests
     [Fact]
     public async Task LoadAsync_logs_auto_managed_transaction_mode()
     {
-        var logger = new SpyLogger<DbLoader<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbLoader<ContractRecord>>();
         using var conn = TestDb.CreateContractLoaderConnection();
-        var loader = new DbLoader<ContractRecord, DbReport>
+        var loader = new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",
@@ -143,14 +143,14 @@ public class DbLoaderLoggingTests
     [Fact]
     public async Task LoadAsync_with_caller_transaction_logs_caller_managed()
     {
-        var logger = new SpyLogger<DbLoader<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbLoader<ContractRecord>>();
         using var conn = TestDb.CreateContractLoaderConnection();
 #if NETFRAMEWORK
         using var transaction = conn.BeginTransaction();
 #else
         using var transaction = await conn.BeginTransactionAsync();
 #endif
-        var loader = new DbLoader<ContractRecord, DbReport>
+        var loader = new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",
@@ -175,7 +175,7 @@ public class DbLoaderLoggingTests
     public async Task LoadAsync_when_no_logger_does_not_throw()
     {
         using var conn = TestDb.CreateContractLoaderConnection();
-        var loader = new DbLoader<ContractRecord, DbReport>
+        var loader = new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)"
@@ -191,9 +191,9 @@ public class DbLoaderLoggingTests
     [Fact]
     public async Task LoadAsync_when_SkipItemCount_set_logs_Debug_skipped()
     {
-        var logger = new SpyLogger<DbLoader<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbLoader<ContractRecord>>();
         using var conn = TestDb.CreateContractLoaderConnection();
-        var loader = new DbLoader<ContractRecord, DbReport>
+        var loader = new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",
@@ -216,9 +216,9 @@ public class DbLoaderLoggingTests
     [Fact]
     public async Task LoadAsync_when_MaximumItemCount_reached_logs_Debug()
     {
-        var logger = new SpyLogger<DbLoader<ContractRecord, DbReport>>();
+        var logger = new SpyLogger<DbLoader<ContractRecord>>();
         using var conn = TestDb.CreateContractLoaderConnection();
-        var loader = new DbLoader<ContractRecord, DbReport>
+        var loader = new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -6,7 +6,7 @@ namespace Wolfgang.Etl.DbClient.Tests.Unit;
 
 public class DbLoaderTests
     : LoaderBaseContractTests<
-        DbLoader<ContractRecord, DbReport>,
+        DbLoader<ContractRecord>,
         ContractRecord,
         DbReport>
 {
@@ -15,10 +15,10 @@ public class DbLoaderTests
     // ------------------------------------------------------------------
 
     /// <inheritdoc/>
-    protected override DbLoader<ContractRecord, DbReport> CreateSut(int itemCount)
+    protected override DbLoader<ContractRecord> CreateSut(int itemCount)
     {
         var conn = TestDb.CreateContractLoaderConnection();
-        return new DbLoader<ContractRecord, DbReport>
+        return new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)"
@@ -40,10 +40,10 @@ public class DbLoaderTests
 
 
     /// <inheritdoc/>
-    protected override DbLoader<ContractRecord, DbReport> CreateSutWithTimer(IProgressTimer timer)
+    protected override DbLoader<ContractRecord> CreateSutWithTimer(IProgressTimer timer)
     {
         var conn = TestDb.CreateContractLoaderConnection();
-        return new DbLoader<ContractRecord, DbReport>
+        return new DbLoader<ContractRecord>
         (
             conn,
             "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",
@@ -61,7 +61,7 @@ public class DbLoaderTests
     {
         Assert.Throws<ArgumentNullException>
         (
-            () => new DbLoader<PersonRecord, DbReport>(null!, "INSERT INTO X VALUES (1)")
+            () => new DbLoader<PersonRecord>(null!, "INSERT INTO X VALUES (1)")
         );
     }
 
@@ -73,7 +73,7 @@ public class DbLoaderTests
         using var conn = TestDb.CreateConnection();
         Assert.Throws<ArgumentNullException>
         (
-            () => new DbLoader<PersonRecord, DbReport>(conn, (string)null!)
+            () => new DbLoader<PersonRecord>(conn, (string)null!)
         );
     }
 
@@ -89,7 +89,7 @@ public class DbLoaderTests
         using var conn = TestDb.CreateConnection();
         await TestDb.CreateEmptyTableAsync(conn);
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
@@ -112,7 +112,7 @@ public class DbLoaderTests
         using var conn = TestDb.CreateConnection();
         await TestDb.CreateEmptyTableAsync(conn);
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
@@ -138,7 +138,7 @@ public class DbLoaderTests
         using var conn = TestDb.CreateConnection();
         await TestDb.CreateEmptyTableAsync(conn);
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             WriteMode.Insert
@@ -158,7 +158,7 @@ public class DbLoaderTests
     public void CommandText_with_auto_generated_insert_contains_table_name()
     {
         using var conn = TestDb.CreateConnection();
-        var loader = new DbLoader<PersonRecord, DbReport>(conn, WriteMode.Insert);
+        var loader = new DbLoader<PersonRecord>(conn, WriteMode.Insert);
 
         Assert.Contains("People", loader.CommandText, StringComparison.Ordinal);
         Assert.Contains("INSERT", loader.CommandText, StringComparison.OrdinalIgnoreCase);
@@ -176,7 +176,7 @@ public class DbLoaderTests
         using var conn = TestDb.CreateConnection();
         await TestDb.CreateEmptyTableAsync(conn);
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
@@ -199,7 +199,7 @@ public class DbLoaderTests
         using var conn = TestDb.CreateConnection();
         await TestDb.CreateEmptyTableAsync(conn);
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
@@ -226,7 +226,7 @@ public class DbLoaderTests
         using var conn = TestDb.CreateConnection();
         await TestDb.CreateEmptyTableAsync(conn);
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
@@ -249,7 +249,7 @@ public class DbLoaderTests
         using var conn = TestDb.CreateConnection();
         await TestDb.CreateEmptyTableAsync(conn);
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
@@ -282,7 +282,7 @@ public class DbLoaderTests
         using var transaction = await conn.BeginTransactionAsync();
 #endif
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)",
@@ -316,7 +316,7 @@ public class DbLoaderTests
         using var transaction = await conn.BeginTransactionAsync();
 #endif
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)",
@@ -350,7 +350,7 @@ public class DbLoaderTests
         using var conn = TestDb.CreateConnection();
         await TestDb.CreateEmptyTableAsync(conn);
 
-        var loader = new DbLoader<PersonRecord, DbReport>
+        var loader = new DbLoader<PersonRecord>
         (
             conn,
             "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
@@ -366,21 +366,6 @@ public class DbLoaderTests
         Assert.Equal(3, report.CurrentItemCount);
         Assert.Contains("INSERT", report.CommandText, StringComparison.OrdinalIgnoreCase);
         Assert.True(report.ElapsedMilliseconds >= 0);
-    }
-
-
-
-    // ------------------------------------------------------------------
-    // Progress report — NotSupportedException
-    // ------------------------------------------------------------------
-
-    [Fact]
-    public void GetProgressReport_when_TProgress_is_not_DbReport_throws_NotSupportedException()
-    {
-        using var conn = TestDb.CreateConnection();
-        var loader = new DbLoader<PersonRecord, Exception>(conn, "INSERT INTO X VALUES (1)");
-
-        Assert.Throws<NotSupportedException>(loader.GetProgressReport);
     }
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbUpdateTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbUpdateTests.cs
@@ -14,7 +14,7 @@ public class DbUpdateTests
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(3);
 
-        var loader = new DbLoader<PersonRecord, DbReport>(conn, WriteMode.Update);
+        var loader = new DbLoader<PersonRecord>(conn, WriteMode.Update);
 
         var updates = new[]
         {
@@ -41,7 +41,7 @@ public class DbUpdateTests
     public void CommandText_with_WriteMode_Update_contains_update_and_where()
     {
         using var conn = TestDb.CreateConnection();
-        var loader = new DbLoader<PersonRecord, DbReport>(conn, WriteMode.Update);
+        var loader = new DbLoader<PersonRecord>(conn, WriteMode.Update);
 
         Assert.Contains("UPDATE", loader.CommandText, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("WHERE", loader.CommandText, StringComparison.OrdinalIgnoreCase);
@@ -54,7 +54,7 @@ public class DbUpdateTests
     public void CommandText_with_WriteMode_Update_excludes_key_from_set_clause()
     {
         using var conn = TestDb.CreateConnection();
-        var loader = new DbLoader<PersonRecord, DbReport>(conn, WriteMode.Update);
+        var loader = new DbLoader<PersonRecord>(conn, WriteMode.Update);
 
         // id should be in WHERE, not in SET
         var setClause = loader.CommandText.Split(new[] { "WHERE" }, StringSplitOptions.None)[0];


### PR DESCRIPTION
## Description

- Removed the `TProgress` generic type parameter from `DbExtractor` and `DbLoader`, hardcoding `DbReport` instead
- Updated all tests, benchmarks, and examples to use the simplified single-parameter generics
- Simplifies the public API — all consumers used `DbReport`, so the extra type parameter added noise without value
- Restored package version to `0.1.0`

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor

## How Has This Been Tested?

- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test --configuration Release --framework net10.0` — 136 tests pass

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

<!-- Please add any screenshots or gifs to help reviewers understand your changes. -->

## Additional context

<!-- Add any other context about the pull request here. -->