### PR TITLE
Sync cross-repo template fixes

### DIFF
--- a/docs/RELEASE-WORKFLOW-SETUP.md
+++ b/docs/RELEASE-WORKFLOW-SETUP.md
@@ -46,7 +46,9 @@ Ensure the following settings are enabled:
     - "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
     - "Stage 3: macOS Tests (.NET 6.0-10.0)"
     - "Security Scan (DevSkim)"
-    - "Security Scan (CodeQL)"
+- ✅ **CodeQL code scanning enforcement** (via `code_scanning` ruleset type, not status checks)
+  - Blocks merging on High+ severity findings
+  - Automatically skips when no supported languages are detected
 - ✅ **Require branches to be up to date before merging**
 - ✅ **Require conversation resolution before merging**
 - ✅ **Do not allow bypassing the above settings** (recommended, even for admins)

--- a/scripts/Fix-BranchRuleset.ps1
+++ b/scripts/Fix-BranchRuleset.ps1
@@ -12,16 +12,23 @@
 .PARAMETER Repository
     The repository in owner/repo format. If not provided, uses the current repository.
 
-.PARAMETER Confirm
+.PARAMETER Force
     Skip the confirmation prompt and proceed automatically. Alias: -y
+
+.PARAMETER SkipSetup
+    Skip automatic invocation of Setup-BranchRuleset.ps1 after fixing.
 
 .EXAMPLE
     .\Fix-BranchRuleset.ps1
     Inspects and fixes rulesets for the current repository with interactive confirmation
 
 .EXAMPLE
-    .\Fix-BranchRuleset.ps1 -y
+    .\Fix-BranchRuleset.ps1 -Force
     Inspects and fixes rulesets without prompting for confirmation
+
+.EXAMPLE
+    .\Fix-BranchRuleset.ps1 -Force -SkipSetup
+    Fixes rulesets non-interactively without recreating a fresh ruleset
 
 .EXAMPLE
     .\Fix-BranchRuleset.ps1 -Repository "Chris-Wolfgang/my-repo"
@@ -39,7 +46,10 @@ param(
 
     [Parameter()]
     [Alias("y")]
-    [switch]$Confirm
+    [switch]$Force,
+
+    [Parameter()]
+    [switch]$SkipSetup
 )
 
 # Check if gh CLI is installed
@@ -169,8 +179,8 @@ foreach ($item in $plan) {
 Write-Host ""
 
 # Prompt for confirmation
-if ($Confirm) {
-    Write-Host "Auto-confirmed via -Confirm flag." -ForegroundColor Green
+if ($Force) {
+    Write-Host "Auto-confirmed via -Force flag." -ForegroundColor Green
 } else {
     $response = Read-Host "Proceed with these changes? (y/N)"
     if ($response -ne 'y' -and $response -ne 'Y') {
@@ -246,7 +256,11 @@ if ($errors -gt 0) {
 
     # Invoke Setup-BranchRuleset.ps1 to create a fresh ruleset
     $setupScript = Join-Path $PSScriptRoot "Setup-BranchRuleset.ps1"
-    if (Test-Path $setupScript) {
+    if ($SkipSetup) {
+        Write-Host "Skipping Setup-BranchRuleset.ps1 (-SkipSetup specified)." -ForegroundColor Yellow
+        Write-Host "Run it manually to create a fresh ruleset:" -ForegroundColor Cyan
+        Write-Host "  pwsh -File `"$setupScript`" -Repository $Repository" -ForegroundColor Cyan
+    } elseif (Test-Path $setupScript) {
         Write-Host "Running Setup-BranchRuleset.ps1 to create a fresh ruleset..." -ForegroundColor Cyan
         Write-Host ""
         & $setupScript -Repository $Repository

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,0 +1,48 @@
+# Analyzer rules relaxed for test projects
+
+[*.cs]
+
+# AsyncFixer01: Remove async/await for single-expression methods — test methods need async for Assert.ThrowsAsync
+dotnet_diagnostic.AsyncFixer01.severity = none
+
+# MA0004: Use ConfigureAwait(false) — not needed in test code
+dotnet_diagnostic.MA0004.severity = none
+
+# MA0011: Use IFormatProvider overload of ToString — not needed in test assertions
+dotnet_diagnostic.MA0011.severity = none
+
+# MA0048: File name must match type name — test files contain multiple helper types
+dotnet_diagnostic.MA0048.severity = none
+
+# MA0051: Method is too long — test methods can be longer for readability
+dotnet_diagnostic.MA0051.severity = none
+
+# MA0074: Use StringComparison overload — not critical in tests
+dotnet_diagnostic.MA0074.severity = none
+
+# S108: Empty block of code — sometimes needed in test setup
+dotnet_diagnostic.S108.severity = none
+
+# S1215: Remove use of GC.GetTotalMemory — acceptable in perf/memory tests
+dotnet_diagnostic.S1215.severity = none
+
+# S2699: Add assertion to test case — some tests verify no-throw behavior
+dotnet_diagnostic.S2699.severity = none
+
+# S6562: Provide DateTimeKind — test data doesn't need DateTimeKind
+dotnet_diagnostic.S6562.severity = none
+
+# S6610: Use char overload of StartsWith — not critical in tests
+dotnet_diagnostic.S6610.severity = none
+
+# VSTHRD200: Use Async suffix — test methods follow xunit naming conventions
+dotnet_diagnostic.VSTHRD200.severity = none
+
+# MA0003: Name the parameter — not needed in test assertions and setup
+dotnet_diagnostic.MA0003.severity = none
+
+# S1144: Remove unused private type member — test POCOs have constructors used via reflection
+dotnet_diagnostic.S1144.severity = none
+
+# xUnit2013: Use Assert.Single instead of Assert.Equal for collection size
+dotnet_diagnostic.xUnit2013.severity = none


### PR DESCRIPTION
## Summary
- Update RELEASE-WORKFLOW-SETUP.md: CodeQL uses `code_scanning` ruleset type, not status checks
- Rename `-Confirm` to `-Force` in Fix-BranchRuleset.ps1
- Add `-SkipSetup` flag to Fix-BranchRuleset.ps1 (separate from `-Force`)
- Add `tests/.editorconfig` to suppress noisy analyzer rules (MA0074, VSTHRD200, MA0004)

## Test plan
- [ ] Verify Fix-BranchRuleset.ps1 `-Force` and `-SkipSetup` flags work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)