### PR TITLE
Improve code quality: thread safety, documentation, and nullability

### DIFF
--- a/src/Wolfgang.Etl.DbClient/ColumnAttributeTypeMapper.cs
+++ b/src/Wolfgang.Etl.DbClient/ColumnAttributeTypeMapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
@@ -11,16 +12,31 @@ namespace Wolfgang.Etl.DbClient;
 /// result set columns to POCO properties. Without this, Dapper only matches
 /// by property name.
 /// </summary>
+/// <remarks>
+/// Column name matching is case-insensitive (<see cref="StringComparison.OrdinalIgnoreCase"/>),
+/// consistent with Dapper's default behavior and the default collation of SQL Server, SQLite,
+/// and MySQL. PostgreSQL lowercases unquoted identifiers, so case-insensitive matching is also
+/// correct for standard PostgreSQL usage.
+/// </remarks>
 internal static class ColumnAttributeTypeMapper
 {
+    private static readonly ConcurrentDictionary<Type, byte> RegisteredTypes = new();
+
+
+
     /// <summary>
     /// Registers a custom type map for <typeparamref name="T"/> that checks
     /// <see cref="ColumnAttribute"/> first, then falls back to Dapper's default
-    /// name-based matching.
+    /// name-based matching. Thread-safe — each type is registered at most once.
     /// </summary>
     internal static void Register<T>()
     {
         var type = typeof(T);
+
+        if (!RegisteredTypes.TryAdd(type, 0))
+        {
+            return;
+        }
 
         // Only register if the type has any [Column] attributes
         var hasColumnAttributes = type
@@ -39,7 +55,7 @@ internal static class ColumnAttributeTypeMapper
             {
                 var props = t.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
-                // First try [Column("name")] match
+                // First try [Column("name")] match (case-insensitive)
                 var prop = props.FirstOrDefault(p =>
                 {
                     var attr = p.GetCustomAttribute<ColumnAttribute>();

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -32,9 +32,8 @@ namespace Wolfgang.Etl.DbClient;
 /// The extractor never commits or rolls back the transaction.
 /// </para>
 /// <para>
-/// Command timeout is currently inherited from the <see cref="DbConnection.ConnectionTimeout"/>
-/// default (typically 30 seconds). A dedicated <c>CommandTimeout</c> property is planned
-/// (see GitHub issue #25).
+/// Command timeout uses the Dapper/ADO.NET default (typically 30 seconds).
+/// A dedicated <c>CommandTimeout</c> property is planned (see GitHub issue #25).
 /// </para>
 /// </remarks>
 public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -31,6 +31,11 @@ namespace Wolfgang.Etl.DbClient;
 /// An optional <see cref="DbTransaction"/> can be provided for isolation level control.
 /// The extractor never commits or rolls back the transaction.
 /// </para>
+/// <para>
+/// Command timeout is currently inherited from the <see cref="DbConnection.ConnectionTimeout"/>
+/// default (typically 30 seconds). A dedicated <c>CommandTimeout</c> property is planned
+/// (see GitHub issue #25).
+/// </para>
 /// </remarks>
 public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     where TRecord : notnull

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -38,9 +38,8 @@ namespace Wolfgang.Etl.DbClient;
 /// <c>LoadAsync</c>.
 /// </para>
 /// <para>
-/// Command timeout is currently inherited from the <see cref="DbConnection.ConnectionTimeout"/>
-/// default (typically 30 seconds). A dedicated <c>CommandTimeout</c> property is planned
-/// (see GitHub issue #25).
+/// Command timeout uses the Dapper/ADO.NET default (typically 30 seconds).
+/// A dedicated <c>CommandTimeout</c> property is planned (see GitHub issue #25).
 /// </para>
 /// </remarks>
 public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
@@ -310,7 +309,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 #if NET5_0_OR_GREATER
         var transaction = await _connection.BeginTransactionAsync(token).ConfigureAwait(false);
 #else
-        _ = token; // Suppresses CS1998 — the token is used in the #if branch above
+        _ = token; // Suppress unused parameter warning — token is used in the #if branch above
         var transaction = _connection.BeginTransaction();
         await System.Threading.Tasks.Task.CompletedTask.ConfigureAwait(false);
 #endif
@@ -325,7 +324,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 #if NET5_0_OR_GREATER
         await transaction.CommitAsync(token).ConfigureAwait(false);
 #else
-        _ = token; // Suppresses CS1998 — the token is used in the #if branch above
+        _ = token; // Suppress unused parameter warning — token is used in the #if branch above
         transaction.Commit();
         await System.Threading.Tasks.Task.CompletedTask.ConfigureAwait(false);
 #endif
@@ -334,12 +333,13 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 
 
 
-    /// <remarks>
+    /// <summary>
+    /// Attempts to roll back an auto-managed transaction after an error.
     /// If the rollback itself fails, the rollback exception is logged at Error level
     /// and the original exception (which triggered the rollback) is allowed to propagate
     /// unchanged. This avoids masking the root cause while still surfacing the rollback
     /// failure in logs.
-    /// </remarks>
+    /// </summary>
     private async Task RollbackAutoTransactionAsync(DbTransaction transaction, CancellationToken token)
     {
         try
@@ -347,7 +347,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 #if NET5_0_OR_GREATER
             await transaction.RollbackAsync(token).ConfigureAwait(false);
 #else
-            _ = token; // Suppresses CS1998 — the token is used in the #if branch above
+            _ = token; // Suppress unused parameter warning — token is used in the #if branch above
             transaction.Rollback();
             await System.Threading.Tasks.Task.CompletedTask.ConfigureAwait(false);
 #endif

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -37,6 +37,11 @@ namespace Wolfgang.Etl.DbClient;
 /// open, close, or dispose it. The connection must be open before calling
 /// <c>LoadAsync</c>.
 /// </para>
+/// <para>
+/// Command timeout is currently inherited from the <see cref="DbConnection.ConnectionTimeout"/>
+/// default (typically 30 seconds). A dedicated <c>CommandTimeout</c> property is planned
+/// (see GitHub issue #25).
+/// </para>
 /// </remarks>
 public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
     where TRecord : notnull
@@ -305,7 +310,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 #if NET5_0_OR_GREATER
         var transaction = await _connection.BeginTransactionAsync(token).ConfigureAwait(false);
 #else
-        _ = token; // Used on net8.0+
+        _ = token; // Suppresses CS1998 — the token is used in the #if branch above
         var transaction = _connection.BeginTransaction();
         await System.Threading.Tasks.Task.CompletedTask.ConfigureAwait(false);
 #endif
@@ -320,7 +325,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 #if NET5_0_OR_GREATER
         await transaction.CommitAsync(token).ConfigureAwait(false);
 #else
-        _ = token; // Used on net8.0+
+        _ = token; // Suppresses CS1998 — the token is used in the #if branch above
         transaction.Commit();
         await System.Threading.Tasks.Task.CompletedTask.ConfigureAwait(false);
 #endif
@@ -329,6 +334,12 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 
 
 
+    /// <remarks>
+    /// If the rollback itself fails, the rollback exception is logged at Error level
+    /// and the original exception (which triggered the rollback) is allowed to propagate
+    /// unchanged. This avoids masking the root cause while still surfacing the rollback
+    /// failure in logs.
+    /// </remarks>
     private async Task RollbackAutoTransactionAsync(DbTransaction transaction, CancellationToken token)
     {
         try
@@ -336,7 +347,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 #if NET5_0_OR_GREATER
             await transaction.RollbackAsync(token).ConfigureAwait(false);
 #else
-            _ = token; // Used on net8.0+
+            _ = token; // Suppresses CS1998 — the token is used in the #if branch above
             transaction.Rollback();
             await System.Threading.Tasks.Task.CompletedTask.ConfigureAwait(false);
 #endif
@@ -347,7 +358,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
             _logger.LogError
             (
                 rollbackEx,
-                "Failed to rollback transaction after error"
+                "Failed to rollback transaction after error. The original exception will propagate"
             );
         }
     }

--- a/src/Wolfgang.Etl.DbClient/DbReport.cs
+++ b/src/Wolfgang.Etl.DbClient/DbReport.cs
@@ -39,9 +39,9 @@ public record DbReport : Report
 
 
     /// <summary>
-    /// The SQL command text being executed.
+    /// The SQL command text being executed. Never null — always assigned by the constructor.
     /// </summary>
-    public string CommandText { get; }
+    public string CommandText { get; } = string.Empty;
 
 
 


### PR DESCRIPTION
## Summary

Code review findings addressing SOLID principles and best practices:

1. **Thread-safe type registration** — `ColumnAttributeTypeMapper` now uses `ConcurrentDictionary` to guarantee each type is registered exactly once, eliminating a race condition in the static initializer
2. **Case-insensitive column matching documented** — Added `<remarks>` explaining why `OrdinalIgnoreCase` is the correct default across SQL Server, SQLite, MySQL, and PostgreSQL
3. **Rollback error handling clarified** — Improved log message in `RollbackAutoTransactionAsync` to explicitly state the original exception propagates
4. **Token discard comments fixed** — Changed misleading "Used on net8.0+" comments to accurately explain they suppress CS1998 in the `#else` branch
5. **CommandTimeout limitation documented** — Added XML doc remarks on both `DbExtractor` and `DbLoader` noting the 30-second default and reference to issue #25
6. **DbReport.CommandText nullability** — Added `= string.Empty` default initializer for defensive clarity

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] 136 tests pass on net10.0
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)