### PR TITLE
Pass coverlet.runsettings to dotnet test in CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,6 +88,7 @@ jobs:
             "Directory.Build.props"
             "Directory.Build.targets"
             "BannedSymbols.txt"
+            "coverlet.runsettings"
             "*.globalconfig"
             "*.ruleset"
           )
@@ -138,6 +139,7 @@ jobs:
             "Directory.Build.props"
             "Directory.Build.targets"
             "BannedSymbols.txt"
+            "coverlet.runsettings"
           )
           
           for config_file in "${exact_files[@]}"; do
@@ -212,6 +214,7 @@ jobs:
             "Directory.Build.props"
             "Directory.Build.targets"
             "BannedSymbols.txt"
+            "coverlet.runsettings"
             "*.globalconfig"
             "*.ruleset"
           )
@@ -255,6 +258,7 @@ jobs:
             "Directory.Build.props"
             "Directory.Build.targets"
             "BannedSymbols.txt"
+            "coverlet.runsettings"
             "*.globalconfig"
             "*.ruleset"
           )
@@ -434,7 +438,7 @@ jobs:
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
-                --collect:"XPlat Code Coverage" \
+                --collect "XPlat Code Coverage" \
                 --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=minimal" || exit 1
@@ -713,7 +717,7 @@ jobs:
                 dotnet test $testProj.FullName `
                   --configuration Release `
                   --framework $fw `
-                  --collect:"XPlat Code Coverage" `
+                  --collect "XPlat Code Coverage" `
                   --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
                   --logger "console;verbosity=normal"
@@ -845,6 +849,7 @@ jobs:
             "Directory.Build.props"
             "Directory.Build.targets"
             "BannedSymbols.txt"
+            "coverlet.runsettings"
             "*.globalconfig"
             "*.ruleset"
           )
@@ -888,6 +893,7 @@ jobs:
             "Directory.Build.props"
             "Directory.Build.targets"
             "BannedSymbols.txt"
+            "coverlet.runsettings"
             "*.globalconfig"
             "*.ruleset"
           )
@@ -1062,7 +1068,7 @@ jobs:
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
-                --collect:"XPlat Code Coverage" \
+                --collect "XPlat Code Coverage" \
                 --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=normal" || exit 1
@@ -1198,6 +1204,7 @@ jobs:
             "Directory.Build.props"
             "Directory.Build.targets"
             "BannedSymbols.txt"
+            "coverlet.runsettings"
             "*.globalconfig"
             "*.ruleset"
           )
@@ -1241,6 +1248,7 @@ jobs:
             "Directory.Build.props"
             "Directory.Build.targets"
             "BannedSymbols.txt"
+            "coverlet.runsettings"
             "*.globalconfig"
             "*.ruleset"
           )

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -435,6 +435,7 @@ jobs:
                 --configuration Release \
                 --framework "$fw" \
                 --collect:"XPlat Code Coverage" \
+                --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=minimal" || exit 1
             done <<< "$frameworks"
@@ -713,6 +714,7 @@ jobs:
                   --configuration Release `
                   --framework $fw `
                   --collect:"XPlat Code Coverage" `
+                  --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
                   --logger "console;verbosity=normal"
               } else {
@@ -1061,6 +1063,7 @@ jobs:
                 --configuration Release \
                 --framework "$fw" \
                 --collect:"XPlat Code Coverage" \
+                --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=normal" || exit 1
             done <<< "$frameworks"


### PR DESCRIPTION
## Summary

The `pr.yaml` workflow collected coverage via `--collect:"XPlat Code Coverage"` but never passed `--settings coverlet.runsettings`. This meant `ExcludeByAttribute=ExcludeFromCodeCoverage` was not taking effect in CI, potentially causing coverage numbers to differ between local and CI runs.

Added `--settings coverlet.runsettings` to all three coverage-collecting stages:
- Stage 1: Linux
- Stage 2: Windows (coverage branch only)
- Stage 3: macOS

## Test plan
- [ ] CI passes — coverage numbers may shift slightly as exclusions now take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)