### PR TITLE
Add TotalCountQuery to DbExtractor

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -264,12 +264,12 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
         if (TotalCountQuery != null)
         {
-            _totalItemCount = await TotalCountQuery(token);
+            _totalItemCount = await TotalCountQuery(token).ConfigureAwait(false);
         }
 
         long rowIndex = 0;
 
-        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction))
+        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction).ConfigureAwait(false))
         {
             token.ThrowIfCancellationRequested();
             rowIndex++;

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -51,6 +52,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     private readonly IProgressTimer? _progressTimer;
     private readonly Stopwatch _stopwatch = new();
     private bool _progressTimerWired;
+    private int? _totalItemCount;
 
 
 
@@ -181,6 +183,27 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
 
+    /// <summary>
+    /// When non-null, this function is invoked before extraction begins to determine
+    /// the total record count, which is then reported via <see cref="DbReport.TotalItemCount"/>.
+    /// Assign <see cref="DefaultTotalCountQuery"/> to use the library's built-in
+    /// <c>SELECT COUNT(*)</c> subquery, or supply a custom function for a more efficient
+    /// query. Defaults to <c>null</c> (total count is not fetched).
+    /// </summary>
+    public Func<CancellationToken, Task<int>>? TotalCountQuery { get; set; }
+
+
+
+    /// <summary>
+    /// The default total count implementation. Wraps <see cref="CommandText"/> in
+    /// <c>SELECT COUNT(*) FROM (...) AS _count</c> and executes it using the same
+    /// connection, parameters, and transaction as the extraction query.
+    /// Assign this to <see cref="TotalCountQuery"/> to enable the built-in behavior.
+    /// </summary>
+    public Func<CancellationToken, Task<int>> DefaultTotalCountQuery => ExecuteDefaultTotalCountQueryAsync;
+
+
+
     /// <inheritdoc/>
     protected override DbReport CreateProgressReport()
     {
@@ -189,7 +212,8 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
             CurrentItemCount,
             CurrentSkippedItemCount,
             _commandText,
-            _stopwatch.ElapsedMilliseconds
+            _stopwatch.ElapsedMilliseconds,
+            _totalItemCount
         );
     }
 
@@ -236,6 +260,12 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         LogExtractionStarted();
 
         var param = _parameters != null ? new DynamicParameters(_parameters) : null;
+
+        if (TotalCountQuery != null)
+        {
+            _totalItemCount = await TotalCountQuery(token);
+        }
+
         long rowIndex = 0;
 
         await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction))
@@ -263,6 +293,20 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         }
 
         LogExtractionCompleted();
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Private helpers
+    // ------------------------------------------------------------------
+
+    private Task<int> ExecuteDefaultTotalCountQueryAsync(CancellationToken token)
+    {
+        var countSql = $"SELECT COUNT(*) FROM ({_commandText}) AS _count";
+        var param = _parameters != null ? new DynamicParameters(_parameters) : null;
+        return _connection.ExecuteScalarAsync<int>(
+            new CommandDefinition(countSql, param, _transaction, cancellationToken: token));
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -257,6 +257,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 #pragma warning restore MA0051
     {
         _stopwatch.Restart();
+        _totalItemCount = null;
         LogExtractionStarted();
 
         var param = _parameters != null ? new DynamicParameters(_parameters) : null;
@@ -303,10 +304,41 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
     private Task<int> ExecuteDefaultTotalCountQueryAsync(CancellationToken token)
     {
-        var countSql = $"SELECT COUNT(*) FROM ({_commandText}) AS _count";
+        var sanitized = SanitizeCommandTextForCount(_commandText);
+        var countSql = $"SELECT COUNT(*) FROM ({sanitized}) AS _count";
         var param = _parameters != null ? new DynamicParameters(_parameters) : null;
         return _connection.ExecuteScalarAsync<int>(
             new CommandDefinition(countSql, param, _transaction, cancellationToken: token));
+    }
+
+
+
+    /// <summary>
+    /// Strips trailing semicolons from the command text so it can be safely
+    /// wrapped in a <c>SELECT COUNT(*) FROM (...)</c> subquery.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The command text is empty or whitespace-only.
+    /// </exception>
+    private static string SanitizeCommandTextForCount(string commandText)
+    {
+        if (string.IsNullOrWhiteSpace(commandText))
+        {
+            throw new InvalidOperationException
+            (
+                "The default total count query requires a non-empty command text. " +
+                "Provide a custom TotalCountQuery when the extractor command text cannot be wrapped safely."
+            );
+        }
+
+        var sanitized = commandText.Trim();
+
+        while (sanitized.EndsWith(";", StringComparison.Ordinal))
+        {
+            sanitized = sanitized.Substring(0, sanitized.Length - 1).TrimEnd();
+        }
+
+        return sanitized;
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbReport.cs
+++ b/src/Wolfgang.Etl.DbClient/DbReport.cs
@@ -15,18 +15,24 @@ public record DbReport : Report
     /// <param name="currentSkippedItemCount">The number of records skipped so far.</param>
     /// <param name="commandText">The SQL command text being executed.</param>
     /// <param name="elapsedMilliseconds">The wall clock time since execution started.</param>
+    /// <param name="totalItemCount">
+    /// The total number of records available, or <c>null</c> if
+    /// <see cref="DbExtractor{TRecord}.TotalCountQuery"/> was not set.
+    /// </param>
     public DbReport
     (
         int currentItemCount,
         int currentSkippedItemCount,
         string commandText,
-        long elapsedMilliseconds
+        long elapsedMilliseconds,
+        int? totalItemCount = null
     )
         : base(currentItemCount)
     {
         CurrentSkippedItemCount = currentSkippedItemCount;
         CommandText = commandText;
         ElapsedMilliseconds = elapsedMilliseconds;
+        TotalItemCount = totalItemCount;
     }
 
 
@@ -49,4 +55,12 @@ public record DbReport : Report
     /// The wall clock time in milliseconds since the operation started.
     /// </summary>
     public long ElapsedMilliseconds { get; }
+
+
+
+    /// <summary>
+    /// The total number of records available for extraction, or <c>null</c> if
+    /// <see cref="DbExtractor{TRecord}.TotalCountQuery"/> was not set.
+    /// </summary>
+    public int? TotalItemCount { get; }
 }

--- a/src/Wolfgang.Etl.DbClient/DbReport.cs
+++ b/src/Wolfgang.Etl.DbClient/DbReport.cs
@@ -15,6 +15,26 @@ public record DbReport : Report
     /// <param name="currentSkippedItemCount">The number of records skipped so far.</param>
     /// <param name="commandText">The SQL command text being executed.</param>
     /// <param name="elapsedMilliseconds">The wall clock time since execution started.</param>
+    public DbReport
+    (
+        int currentItemCount,
+        int currentSkippedItemCount,
+        string commandText,
+        long elapsedMilliseconds
+    )
+        : this(currentItemCount, currentSkippedItemCount, commandText, elapsedMilliseconds, totalItemCount: null)
+    {
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="DbReport"/> snapshot with a total item count.
+    /// </summary>
+    /// <param name="currentItemCount">The number of records processed so far.</param>
+    /// <param name="currentSkippedItemCount">The number of records skipped so far.</param>
+    /// <param name="commandText">The SQL command text being executed.</param>
+    /// <param name="elapsedMilliseconds">The wall clock time since execution started.</param>
     /// <param name="totalItemCount">
     /// The total number of records available, or <c>null</c> if
     /// <see cref="DbExtractor{TRecord}.TotalCountQuery"/> was not set.
@@ -25,7 +45,7 @@ public record DbReport : Report
         int currentSkippedItemCount,
         string commandText,
         long elapsedMilliseconds,
-        int? totalItemCount = null
+        int? totalItemCount
     )
         : base(currentItemCount)
     {

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -1,3 +1,4 @@
+using Dapper;
 using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.TestKit.Xunit;
 using Xunit;
@@ -276,5 +277,81 @@ public class DbExtractorTests
         Assert.Equal(3, report.CurrentItemCount);
         Assert.Contains("People", report.CommandText, StringComparison.Ordinal);
         Assert.True(report.ElapsedMilliseconds >= 0);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // TotalCountQuery
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task TotalCountQuery_when_null_TotalItemCount_is_null()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(3);
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT id, first_name, last_name, age FROM People"
+        );
+
+        await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Null(extractor.GetProgressReport().TotalItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task TotalCountQuery_using_default_TotalItemCount_equals_row_count()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(3);
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT id, first_name, last_name, age FROM People"
+        );
+        extractor.TotalCountQuery = extractor.DefaultTotalCountQuery;
+
+        await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(3, extractor.GetProgressReport().TotalItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task TotalCountQuery_using_default_with_parameterized_query_returns_filtered_count()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(5);
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT id, first_name, last_name, age FROM People WHERE age > @MinAge",
+            new Dictionary<string, object>(StringComparer.Ordinal) { { "MinAge", 23 } }
+        );
+        extractor.TotalCountQuery = extractor.DefaultTotalCountQuery;
+
+        await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(2, extractor.GetProgressReport().TotalItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task TotalCountQuery_using_custom_func_returns_custom_count()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(3);
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT id, first_name, last_name, age FROM People"
+        );
+        extractor.TotalCountQuery = _ => conn.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM People");
+
+        await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(3, extractor.GetProgressReport().TotalItemCount);
     }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbReportTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbReportTests.cs
@@ -13,6 +13,17 @@ public class DbReportTests
         Assert.Equal(2, report.CurrentSkippedItemCount);
         Assert.Equal("SELECT 1", report.CommandText);
         Assert.Equal(500, report.ElapsedMilliseconds);
+        Assert.Null(report.TotalItemCount);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_totalItemCount_sets_TotalItemCount()
+    {
+        var report = new DbReport(10, 2, "SELECT 1", 500, 100);
+
+        Assert.Equal(100, report.TotalItemCount);
     }
 
 


### PR DESCRIPTION
## Summary

- Adds `Func<CancellationToken, Task<int>>? TotalCountQuery` property to `DbExtractor<TRecord>` — opt-in, defaults to `null` so there is no overhead for existing usage
- Adds `DefaultTotalCountQuery` property exposing a built-in delegate that wraps `CommandText` in `SELECT COUNT(*) FROM (...) AS _count`, using the same connection, parameters, and transaction
- Adds `int? TotalItemCount` to `DbReport` — `null` when `TotalCountQuery` is not set, populated before streaming begins when it is

## Usage

```csharp
// Use built-in subquery count
extractor.TotalCountQuery = extractor.DefaultTotalCountQuery;

// Or supply a more efficient custom query
extractor.TotalCountQuery = _ => conn.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM People");

// Read from any progress report
report.TotalItemCount  // int? — null if TotalCountQuery was not set
```

## Test plan

- [ ] `TotalCountQuery_when_null_TotalItemCount_is_null`
- [ ] `TotalCountQuery_using_default_TotalItemCount_equals_row_count`
- [ ] `TotalCountQuery_using_default_with_parameterized_query_returns_filtered_count`
- [ ] `TotalCountQuery_using_custom_func_returns_custom_count`
- [ ] `Constructor_with_totalItemCount_sets_TotalItemCount`
- [ ] All 141 tests passing across 13 target frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)