### PR TITLE
Ignore ReSharper inspection output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -441,3 +441,6 @@ docs/*
 !docs/WORKFLOW_SECURITY.md
 .nuget/nuget.exe
 
+
+# ReSharper inspection output
+resharper-results.xml


### PR DESCRIPTION
## Summary
- Add `resharper-results.xml` to `.gitignore` so local ReSharper inspection runs don't show up as untracked files.

## Test plan
- [x] `git status` clean after running ReSharper