### PR TITLE
Bump version to 0.2.0 and upgrade Wolfgang.Etl dependencies

### DIFF
--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -52,7 +52,7 @@
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.12.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Version>0.2.0</Version>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
@@ -27,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 
   <!-- netcoreapp3.1 -->
@@ -42,7 +43,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 
   <!-- net5.0 -->
@@ -57,7 +58,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 
   <!-- net6.0; net7.0 -->
@@ -72,7 +73,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 
   <!-- net8.0; net9.0; net10.0 -->
@@ -87,7 +88,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 
   <!-- net5.0; net6.0; net7.0; net8.0; net9.0; net10.0 (coverlet) -->
@@ -100,13 +101,13 @@
 
   <!-- Shared dependencies (all TFMs) -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.10" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.5.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.5.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.7.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.6.0" />
   </ItemGroup>
 
   <!-- Copy native SQLite DLL to output for .NET Framework (no RID-based probing) -->


### PR DESCRIPTION
## Summary
- Bumps `Wolfgang.Etl.DbClient` from 0.1.0 to 0.2.0.
- Adds matching `<Version>0.2.0</Version>` to the test project.
- Upgrades `Wolfgang.Etl.Abstractions` PackageReference: 0.12.0 → 0.13.0.
- Upgrades `Wolfgang.Etl.TestKit` PackageReference: 0.5.0 → 0.7.0 (skips 0.6.0).
- Upgrades `Wolfgang.Etl.TestKit.Xunit` PackageReference: 0.5.0 → 0.6.0.
- Bumps test project `Microsoft.Bcl.AsyncInterfaces` 10.0.5 → 10.0.7 and `System.Linq.Async` 7.0.0 → 7.0.1 across all 5 conditional ItemGroups (mirrors fix from ETL-Json#51 to avoid NU1605).

## Test plan
- [ ] CI builds and tests pass on all target frameworks
- [ ] Restore picks up Abstractions 0.13.0, TestKit 0.7.0, TestKit.Xunit 0.6.0 from NuGet