### PR TITLE
feat(tests): per-RDBMS integration tests via Testcontainers

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -454,7 +454,14 @@ jobs:
             exit 0
           fi
 
-          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -path "*Tests.Integration*" -print0)
+          # Match on the filename, not the path, so an unrelated parent directory
+          # containing the substring "Tests.Integration" won't be excluded.
+          mapfile -d '' -t test_projects < <(find ./tests -type f \
+            \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) \
+            ! -name "*.Tests.Integration.csproj" \
+            ! -name "*.Tests.Integration.vbproj" \
+            ! -name "*.Tests.Integration.fsproj" \
+            -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
             echo "ℹ️  No test projects found under ./tests — skipping test stage."
@@ -796,9 +803,11 @@ jobs:
             exit 0
           }
 
-          # Integration suites (Tests.Integration) live in a separate Linux-only job that
-          # provisions database containers via Testcontainers; they are not run here.
-          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' | Where-Object { $_.FullName -notmatch 'Tests\.Integration' })
+          # Integration suites (*.Tests.Integration.csproj) live in a separate Linux-only
+          # job that provisions database containers via Testcontainers; not run here.
+          # Filter by file name, not path, so an unrelated parent directory containing the
+          # substring "Tests.Integration" won't be excluded.
+          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' | Where-Object { $_.Name -notlike '*.Tests.Integration.csproj' })
 
           if (@($testProjects).Count -eq 0) {
             Write-Host "ℹ️  No test projects found under ./tests — skipping test stage."
@@ -1182,7 +1191,12 @@ jobs:
           test_projects=()
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
-          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -path "*Tests.Integration*" -print0)
+          done < <(find ./tests -type f \
+            \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) \
+            ! -name "*.Tests.Integration.csproj" \
+            ! -name "*.Tests.Integration.vbproj" \
+            ! -name "*.Tests.Integration.fsproj" \
+            -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
             echo "ℹ️  No test projects found under ./tests — skipping test stage."

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -454,19 +454,19 @@ jobs:
             exit 0
           fi
 
-          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -path "*Tests.Integration*" -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
             echo "ℹ️  No test projects found under ./tests — skipping test stage."
             exit 0
           fi
-          
+
           echo "=========================================="
-          echo "Found test projects:"
+          echo "Found test projects (integration suites are run in a separate job):"
           echo "=========================================="
           printf '%s\n' "${test_projects[@]}"
           echo ""
-          
+
           for test_proj in "${test_projects[@]}"; do
             echo "=========================================="
             echo "Testing project: $test_proj"
@@ -597,6 +597,67 @@ jobs:
           path: |
             src/**/bin/Release
             tests/**/bin/Release
+
+  # ============================================================================
+  # RDBMS INTEGRATION: per-database job using Testcontainers (Linux only)
+  # Runs in parallel with Stage 1. Does not gate Stage 2 / Stage 3 so a flaky
+  # container start cannot block the multi-TFM unit matrix.
+  # ============================================================================
+  test-integration:
+    name: "Integration / ${{ matrix.rdbms }}"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        rdbms: [sqlserver, postgres, mysql, sqlite]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Locate integration project
+        id: locate
+        shell: bash
+        run: |
+          proj=$(find ./tests -type f -name "*.Tests.Integration.csproj" | head -n1)
+          if [ -z "$proj" ]; then
+            echo "ℹ️  No integration project found — skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Integration project: $proj"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "project=$proj" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ${{ matrix.rdbms }} integration tests
+        if: steps.locate.outputs.found == 'true'
+        run: |
+          dotnet test "${{ steps.locate.outputs.project }}" \
+            --configuration Release \
+            --framework net10.0 \
+            --filter "Category=${{ matrix.rdbms }}" \
+            --logger "console;verbosity=normal" \
+            --logger "trx;LogFileName=integration-${{ matrix.rdbms }}.trx" \
+            --results-directory "./TestResults-Integration"
+
+      - name: Upload integration test results
+        if: always() && steps.locate.outputs.found == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-${{ matrix.rdbms }}-trx
+          path: TestResults-Integration/
 
   # ============================================================================
   # STAGE 2: Windows - All .NET Tests (Gated by Stage 1)
@@ -734,7 +795,9 @@ jobs:
             exit 0
           }
 
-          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj')
+          # Integration suites (Tests.Integration) live in a separate Linux-only job that
+          # provisions database containers via Testcontainers; they are not run here.
+          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' | Where-Object { $_.FullName -notmatch 'Tests\.Integration' })
 
           if (@($testProjects).Count -eq 0) {
             Write-Host "ℹ️  No test projects found under ./tests — skipping test stage."
@@ -1118,7 +1181,7 @@ jobs:
           test_projects=()
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
-          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -path "*Tests.Integration*" -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
             echo "ℹ️  No test projects found under ./tests — skipping test stage."

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -604,7 +604,7 @@ jobs:
   # container start cannot block the multi-TFM unit matrix.
   # ============================================================================
   test-integration:
-    name: "Integration / ${{ matrix.rdbms }}"
+    name: "Integration / ${{ matrix.rdbms }} (${{ matrix.tfm }})"
     runs-on: ubuntu-latest
     needs: detect-projects
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
@@ -612,6 +612,7 @@ jobs:
       fail-fast: false
       matrix:
         rdbms: [sqlserver, postgres, mysql, sqlite]
+        tfm: [net8.0, net10.0]
 
     steps:
       - name: Checkout code
@@ -641,22 +642,22 @@ jobs:
             echo "project=$proj" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run ${{ matrix.rdbms }} integration tests
+      - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
         if: steps.locate.outputs.found == 'true'
         run: |
           dotnet test "${{ steps.locate.outputs.project }}" \
             --configuration Release \
-            --framework net10.0 \
+            --framework ${{ matrix.tfm }} \
             --filter "Category=${{ matrix.rdbms }}" \
             --logger "console;verbosity=normal" \
-            --logger "trx;LogFileName=integration-${{ matrix.rdbms }}.trx" \
+            --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
             --results-directory "./TestResults-Integration"
 
       - name: Upload integration test results
         if: always() && steps.locate.outputs.found == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: integration-${{ matrix.rdbms }}-trx
+          name: integration-${{ matrix.rdbms }}-${{ matrix.tfm }}-trx
           path: TestResults-Integration/
 
   # ============================================================================

--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -50,6 +50,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj" />
+    <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj" />
   </Folder>
 </Solution>
 

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -242,23 +242,26 @@ if (-not $SkipIntegration -and -not $SkipTests -and $failed.Count -eq 0) {
         }
         else {
             $rdbmsList = @('sqlite', 'sqlserver', 'postgres', 'mysql')
-            foreach ($rdbms in $rdbmsList) {
-                Write-Host ""
-                Write-Host "  RDBMS: $rdbms" -ForegroundColor Yellow
+            $tfmList   = @('net8.0', 'net10.0')
+            :outer foreach ($rdbms in $rdbmsList) {
+                foreach ($tfm in $tfmList) {
+                    Write-Host ""
+                    Write-Host "  RDBMS: $rdbms ($tfm)" -ForegroundColor Yellow
 
-                dotnet test $integrationProj.FullName `
-                    --configuration Release `
-                    --framework net10.0 `
-                    --filter "Category=$rdbms" `
-                    --logger "console;verbosity=normal"
+                    dotnet test $integrationProj.FullName `
+                        --configuration Release `
+                        --framework $tfm `
+                        --filter "Category=$rdbms" `
+                        --logger "console;verbosity=normal"
 
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Fail "  Integration tests failed for $rdbms"
-                    $failed += "Integration ($rdbms)"
-                    break
-                }
-                else {
-                    Write-Pass "  Integration tests passed for $rdbms"
+                    if ($LASTEXITCODE -ne 0) {
+                        Write-Fail "  Integration tests failed for $rdbms ($tfm)"
+                        $failed += "Integration ($rdbms/$tfm)"
+                        break outer
+                    }
+                    else {
+                        Write-Pass "  Integration tests passed for $rdbms ($tfm)"
+                    }
                 }
             }
         }

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -21,18 +21,24 @@
 .PARAMETER SkipSecurity
     Skip DevSkim and gitleaks scans.
 
+.PARAMETER SkipIntegration
+    Skip the per-RDBMS integration tests. By default the script runs them when
+    a Docker daemon is reachable and silently skips otherwise (with a warning).
+
 .PARAMETER CoverageThreshold
     Minimum coverage percentage required. Defaults to 90.
 
 .EXAMPLE
     pwsh ./scripts/build-pr.ps1
     pwsh ./scripts/build-pr.ps1 -SkipSecurity
+    pwsh ./scripts/build-pr.ps1 -SkipIntegration
     pwsh ./scripts/build-pr.ps1 -CoverageThreshold 80
 #>
 param(
     [switch]$SkipTests,
     [switch]$SkipCoverage,
     [switch]$SkipSecurity,
+    [switch]$SkipIntegration,
     [int]$CoverageThreshold = 90
 )
 
@@ -81,7 +87,9 @@ else {
 if (-not $SkipTests -and $failed.Count -eq 0) {
     Write-Step "Step 2: Run Tests (all target frameworks)"
 
-    $testProjects = @(Get-ChildItem -Path './tests' -Recurse -File -Include '*.csproj', '*.vbproj', '*.fsproj' -ErrorAction SilentlyContinue)
+    # Integration suites are container-backed and run in their own step below.
+    $testProjects = @(Get-ChildItem -Path './tests' -Recurse -File -Include '*.csproj', '*.vbproj', '*.fsproj' -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch 'Tests\.Integration' })
 
     if ($testProjects.Count -eq 0) {
         Write-Host "No test projects found in ./tests — skipping"
@@ -203,6 +211,56 @@ if (-not $SkipTests -and -not $SkipCoverage -and $failed.Count -eq 0) {
         }
         else {
             Write-Host "Coverage report not generated — skipping threshold check"
+        }
+    }
+}
+
+# ============================================================================
+# STEP 3.5: RDBMS Integration Tests (Testcontainers, requires Docker)
+# ============================================================================
+if (-not $SkipIntegration -and -not $SkipTests -and $failed.Count -eq 0) {
+    Write-Step "Step 3.5: Integration Tests (per-RDBMS via Testcontainers)"
+
+    $integrationProj = Get-ChildItem -Path './tests' -Recurse -File -Filter '*.Tests.Integration.csproj' -ErrorAction SilentlyContinue | Select-Object -First 1
+
+    if (-not $integrationProj) {
+        Write-Host "ℹ️  No integration project found — skipping."
+    }
+    else {
+        $dockerOk = $false
+        try {
+            docker info *>$null
+            $dockerOk = ($LASTEXITCODE -eq 0)
+        }
+        catch {
+            $dockerOk = $false
+        }
+
+        if (-not $dockerOk) {
+            Write-Host "⚠️  Docker daemon is not reachable — skipping integration tests." -ForegroundColor Yellow
+            Write-Host "    Start Docker Desktop (or pass -SkipIntegration to silence this) and re-run." -ForegroundColor Yellow
+        }
+        else {
+            $rdbmsList = @('sqlite', 'sqlserver', 'postgres', 'mysql')
+            foreach ($rdbms in $rdbmsList) {
+                Write-Host ""
+                Write-Host "  RDBMS: $rdbms" -ForegroundColor Yellow
+
+                dotnet test $integrationProj.FullName `
+                    --configuration Release `
+                    --framework net10.0 `
+                    --filter "Category=$rdbms" `
+                    --logger "console;verbosity=normal"
+
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Fail "  Integration tests failed for $rdbms"
+                    $failed += "Integration ($rdbms)"
+                    break
+                }
+                else {
+                    Write-Pass "  Integration tests passed for $rdbms"
+                }
+            }
         }
     }
 }

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -88,8 +88,10 @@ if (-not $SkipTests -and $failed.Count -eq 0) {
     Write-Step "Step 2: Run Tests (all target frameworks)"
 
     # Integration suites are container-backed and run in their own step below.
+    # Match on the file name (not the full path) so an unrelated directory
+    # containing the substring won't be excluded.
     $testProjects = @(Get-ChildItem -Path './tests' -Recurse -File -Include '*.csproj', '*.vbproj', '*.fsproj' -ErrorAction SilentlyContinue |
-        Where-Object { $_.FullName -notmatch 'Tests\.Integration' })
+        Where-Object { $_.Name -notlike '*.Tests.Integration.csproj' })
 
     if ($testProjects.Count -eq 0) {
         Write-Host "No test projects found in ./tests — skipping"
@@ -236,32 +238,36 @@ if (-not $SkipIntegration -and -not $SkipTests -and $failed.Count -eq 0) {
             $dockerOk = $false
         }
 
-        if (-not $dockerOk) {
-            Write-Host "⚠️  Docker daemon is not reachable — skipping integration tests." -ForegroundColor Yellow
-            Write-Host "    Start Docker Desktop (or pass -SkipIntegration to silence this) and re-run." -ForegroundColor Yellow
+        # SQLite needs no Docker; the other providers do. Build the list accordingly.
+        $rdbmsList = @('sqlite')
+        if ($dockerOk) {
+            $rdbmsList += @('sqlserver', 'postgres', 'mysql')
         }
         else {
-            $rdbmsList = @('sqlite', 'sqlserver', 'postgres', 'mysql')
-            $tfmList   = @('net8.0', 'net10.0')
-            :outer foreach ($rdbms in $rdbmsList) {
-                foreach ($tfm in $tfmList) {
-                    Write-Host ""
-                    Write-Host "  RDBMS: $rdbms ($tfm)" -ForegroundColor Yellow
+            Write-Host "⚠️  Docker daemon is not reachable — running only the SQLite slice." -ForegroundColor Yellow
+            Write-Host "    Start Docker Desktop (or pass -SkipIntegration to silence this) and re-run for full coverage." -ForegroundColor Yellow
+        }
 
-                    dotnet test $integrationProj.FullName `
-                        --configuration Release `
-                        --framework $tfm `
-                        --filter "Category=$rdbms" `
-                        --logger "console;verbosity=normal"
+        # Run every combination so a failure on one provider/TFM does not hide
+        # failures on the others. Each failure is recorded but the loop keeps going.
+        $tfmList = @('net8.0', 'net10.0')
+        foreach ($rdbms in $rdbmsList) {
+            foreach ($tfm in $tfmList) {
+                Write-Host ""
+                Write-Host "  RDBMS: $rdbms ($tfm)" -ForegroundColor Yellow
 
-                    if ($LASTEXITCODE -ne 0) {
-                        Write-Fail "  Integration tests failed for $rdbms ($tfm)"
-                        $failed += "Integration ($rdbms/$tfm)"
-                        break outer
-                    }
-                    else {
-                        Write-Pass "  Integration tests passed for $rdbms ($tfm)"
-                    }
+                dotnet test $integrationProj.FullName `
+                    --configuration Release `
+                    --framework $tfm `
+                    --filter "Category=$rdbms" `
+                    --logger "console;verbosity=normal"
+
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Fail "  Integration tests failed for $rdbms ($tfm)"
+                    $failed += "Integration ($rdbms/$tfm)"
+                }
+                else {
+                    Write-Pass "  Integration tests passed for $rdbms ($tfm)"
                 }
             }
         }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/ContractItem.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/ContractItem.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+/// <summary>
+/// Test record used by every provider's integration suite. Lower-case identifiers
+/// avoid PostgreSQL's unquoted-folding behaviour while remaining valid in
+/// SQL Server, MySQL, and SQLite.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[Table("contract_items")]
+public sealed class ContractItem : IEquatable<ContractItem>
+{
+    [Column("name")]
+    public string Name { get; set; } = string.Empty;
+
+
+
+    [Column("value")]
+    public int Value { get; set; }
+
+
+
+    public bool Equals(ContractItem? other)
+    {
+        if (other is null) return false;
+        return string.Equals(Name, other.Name, StringComparison.Ordinal) && Value == other.Value;
+    }
+
+
+
+    public override bool Equals(object? obj) => Equals(obj as ContractItem);
+
+
+
+    public override int GetHashCode() => HashCode.Combine(Name, Value);
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+/// <summary>
+/// Reusable extractor contract: every concrete RDBMS test class derives from this
+/// and supplies its own <see cref="IDbProviderFixture"/>. Tests are skipped (not
+/// failed) when the fixture's container could not start.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public abstract class DbExtractorIntegrationTestsBase
+{
+    protected abstract IDbProviderFixture Fixture { get; }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_yields_all_seeded_rows()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        await Fixture.SeedAsync(conn, rowCount: 5).ConfigureAwait(true);
+
+        var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value");
+
+        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+
+        Assert.Equal(5, results.Count);
+        Assert.Equal("Item1", results[0].Name);
+        Assert.Equal(10, results[0].Value);
+        Assert.Equal("Item5", results[4].Name);
+        Assert.Equal(50, results[4].Value);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_table_is_empty_yields_nothing()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+
+        var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items");
+
+        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+
+        Assert.Empty(results);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_SkipItemCount_is_set_skips_initial_rows()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        await Fixture.SeedAsync(conn, rowCount: 5).ConfigureAwait(true);
+
+        var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value")
+        {
+            SkipItemCount = 2
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+
+        Assert.Equal(3, results.Count);
+        Assert.Equal("Item3", results[0].Name);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_MaximumItemCount_is_set_stops_early()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        await Fixture.SeedAsync(conn, rowCount: 5).ConfigureAwait(true);
+
+        var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value")
+        {
+            MaximumItemCount = 2
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Item1", results[0].Name);
+        Assert.Equal("Item2", results[1].Name);
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+/// <summary>
+/// Reusable loader contract: every concrete RDBMS test class derives from this
+/// and supplies its own <see cref="IDbProviderFixture"/>. Tests are skipped (not
+/// failed) when the fixture's container could not start.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public abstract class DbLoaderIntegrationTestsBase
+{
+    protected abstract IDbProviderFixture Fixture { get; }
+
+
+
+    private static async IAsyncEnumerable<ContractItem> Source(int count)
+    {
+        for (var i = 1; i <= count; i++)
+        {
+            yield return new ContractItem { Name = $"Item{i}", Value = i * 10 };
+        }
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+
+
+    private static async Task<int> CountRowsAsync(System.Data.Common.DbConnection conn)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM contract_items";
+        var result = await cmd.ExecuteScalarAsync().ConfigureAwait(true);
+        return Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+
+
+    [SkippableFact]
+    public async Task LoadAsync_inserts_all_rows()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+
+        var loader = new DbLoader<ContractItem>(conn, "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)");
+
+        await loader.LoadAsync(Source(5)).ConfigureAwait(true);
+
+        Assert.Equal(5, await CountRowsAsync(conn).ConfigureAwait(true));
+    }
+
+
+
+    [SkippableFact]
+    public async Task LoadAsync_when_source_is_empty_inserts_nothing()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+
+        var loader = new DbLoader<ContractItem>(conn, "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)");
+
+        await loader.LoadAsync(Source(0)).ConfigureAwait(true);
+
+        Assert.Equal(0, await CountRowsAsync(conn).ConfigureAwait(true));
+    }
+
+
+
+    [SkippableFact]
+    public async Task LoadAsync_when_MaximumItemCount_is_set_stops_at_limit()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+
+        var loader = new DbLoader<ContractItem>(conn, "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)")
+        {
+            MaximumItemCount = 3
+        };
+
+        await loader.LoadAsync(Source(10)).ConfigureAwait(true);
+
+        Assert.Equal(3, await CountRowsAsync(conn).ConfigureAwait(true));
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
@@ -16,14 +16,10 @@ public abstract class DbLoaderIntegrationTestsBase
 
 
 
-    private static async IAsyncEnumerable<ContractItem> Source(int count)
-    {
-        for (var i = 1; i <= count; i++)
-        {
-            yield return new ContractItem { Name = $"Item{i}", Value = i * 10 };
-        }
-        await Task.CompletedTask.ConfigureAwait(false);
-    }
+    private static IAsyncEnumerable<ContractItem> Source(int count) =>
+        Enumerable.Range(1, count)
+            .Select(i => new ContractItem { Name = $"Item{i}", Value = i * 10 })
+            .ToAsyncEnumerable();
 
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
@@ -1,0 +1,85 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Shared plumbing for container-backed fixtures: catches container-start failures
+/// during xunit's <see cref="IAsyncLifetime.InitializeAsync"/> so tests can be skipped
+/// with a clear reason instead of crashing the whole collection.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public abstract class DbProviderFixtureBase : IAsyncLifetime, IDbProviderFixture
+{
+    public abstract string ProviderName { get; }
+
+    public bool Available { get; private set; }
+
+    public string? UnavailableReason { get; private set; }
+
+
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            await StartAsync().ConfigureAwait(false);
+            Available = true;
+        }
+        catch (Exception ex)
+        {
+            Available = false;
+            UnavailableReason = $"{ProviderName} unavailable: {ex.GetType().Name}: {ex.Message}";
+        }
+    }
+
+
+
+    public async Task DisposeAsync()
+    {
+        if (!Available)
+        {
+            return;
+        }
+
+        try
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort teardown — never fail a test pass because a container
+            // refused to stop cleanly.
+        }
+    }
+
+
+
+    /// <summary>Provision the backing container / database. Throw on failure.</summary>
+    protected abstract Task StartAsync();
+
+
+
+    /// <summary>Tear down the backing container / database. May throw — caller swallows.</summary>
+    protected abstract Task StopAsync();
+
+
+
+    public abstract Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default);
+
+    public abstract Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default);
+
+    public abstract Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default);
+
+
+
+    protected static async Task ExecuteAsync(DbConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        if (connection is null) throw new ArgumentNullException(nameof(connection));
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/IDbProviderFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/IDbProviderFixture.cs
@@ -1,0 +1,53 @@
+using System.Data.Common;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Common contract every per-RDBMS fixture exposes to the contract-style test bases.
+/// </summary>
+public interface IDbProviderFixture
+{
+    /// <summary>
+    /// Friendly provider name used in test output ("sqlserver", "postgres", ...).
+    /// </summary>
+    string ProviderName { get; }
+
+
+
+    /// <summary>
+    /// True when the underlying environment (e.g. Docker daemon) was reachable
+    /// and the schema was provisioned. Tests <c>Skip.IfNot(Available, ...)</c> on
+    /// this so a developer without Docker can still run the rest of the suite.
+    /// </summary>
+    bool Available { get; }
+
+
+
+    /// <summary>
+    /// Optional reason explaining why <see cref="Available"/> is false.
+    /// </summary>
+    string? UnavailableReason { get; }
+
+
+
+    /// <summary>
+    /// Open a fresh connection to the per-fixture test database. Caller owns disposal.
+    /// </summary>
+    Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default);
+
+
+
+    /// <summary>
+    /// Drop and recreate the <c>contract_items</c> table so each test starts from a
+    /// known empty state. Implementations should be safe to call repeatedly.
+    /// </summary>
+    Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default);
+
+
+
+    /// <summary>
+    /// Seed the <c>contract_items</c> table with <paramref name="rowCount"/> rows
+    /// where each row is <c>Name="Item{i}"</c>, <c>Value=i*10</c> (1-based).
+    /// </summary>
+    Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default);
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MySqlFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MySqlFixture.cs
@@ -1,0 +1,69 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using MySqlConnector;
+using Testcontainers.MySql;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+[ExcludeFromCodeCoverage]
+public sealed class MySqlFixture : DbProviderFixtureBase
+{
+    private MySqlContainer? _container;
+
+    public override string ProviderName => "mysql";
+
+
+
+    protected override async Task StartAsync()
+    {
+        _container = new MySqlBuilder()
+            .WithImage("mysql:8.0")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+    }
+
+
+
+    protected override async Task StopAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var conn = new MySqlConnection(_container!.GetConnectionString());
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "DROP TABLE IF EXISTS contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "@name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "@value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/PostgresFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/PostgresFixture.cs
@@ -1,0 +1,69 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+[ExcludeFromCodeCoverage]
+public sealed class PostgresFixture : DbProviderFixtureBase
+{
+    private PostgreSqlContainer? _container;
+
+    public override string ProviderName => "postgres";
+
+
+
+    protected override async Task StartAsync()
+    {
+        _container = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+    }
+
+
+
+    protected override async Task StopAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var conn = new NpgsqlConnection(_container!.GetConnectionString());
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "DROP TABLE IF EXISTS contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INTEGER NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqlServerFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqlServerFixture.cs
@@ -1,0 +1,69 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.Data.SqlClient;
+using Testcontainers.MsSql;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+[ExcludeFromCodeCoverage]
+public sealed class SqlServerFixture : DbProviderFixtureBase
+{
+    private MsSqlContainer? _container;
+
+    public override string ProviderName => "sqlserver";
+
+
+
+    protected override async Task StartAsync()
+    {
+        _container = new MsSqlBuilder()
+            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+    }
+
+
+
+    protected override async Task StopAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var conn = new SqlConnection(_container!.GetConnectionString());
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "IF OBJECT_ID('dbo.contract_items','U') IS NOT NULL DROP TABLE dbo.contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE dbo.contract_items (name NVARCHAR(100) NOT NULL, value INT NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO dbo.contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "@name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "@value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
@@ -1,0 +1,76 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+/// <summary>
+/// SQLite "integration" fixture — uses an in-memory shared-cache database so
+/// SQLite gets the same matrix row treatment as the container-backed providers.
+/// No Docker required, so this fixture is always <c>Available</c>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Lifetime is managed by xunit via IAsyncLifetime.DisposeAsync, which disposes _holdOpen in StopAsync.")]
+public sealed class SqliteFixture : DbProviderFixtureBase
+{
+    private string _connectionString = string.Empty;
+    private SqliteConnection? _holdOpen;
+
+    public override string ProviderName => "sqlite";
+
+
+
+    protected override Task StartAsync()
+    {
+        // shared-cache + a named in-memory DB lets multiple connections see the
+        // same data; the "hold open" connection keeps the DB alive between tests.
+        _connectionString = $"Data Source=file:integration-{Guid.NewGuid():N}?mode=memory&cache=shared";
+        _holdOpen = new SqliteConnection(_connectionString);
+        _holdOpen.Open();
+        return Task.CompletedTask;
+    }
+
+
+
+    protected override Task StopAsync()
+    {
+        _holdOpen?.Dispose();
+        _holdOpen = null;
+        return Task.CompletedTask;
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "DROP TABLE IF EXISTS contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE contract_items (name TEXT NOT NULL, value INTEGER NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "@name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "@value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/MySqlTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/MySqlTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("MySql")]
+public class MySqlCollection : ICollectionFixture<MySqlFixture> { }
+
+
+
+[Collection("MySql")]
+[Trait("Category", "mysql")]
+[ExcludeFromCodeCoverage]
+public sealed class MySqlExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly MySqlFixture _fixture;
+    public MySqlExtractorTests(MySqlFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("MySql")]
+[Trait("Category", "mysql")]
+[ExcludeFromCodeCoverage]
+public sealed class MySqlLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly MySqlFixture _fixture;
+    public MySqlLoaderTests(MySqlFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/PostgresTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/PostgresTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("Postgres")]
+public class PostgresCollection : ICollectionFixture<PostgresFixture> { }
+
+
+
+[Collection("Postgres")]
+[Trait("Category", "postgres")]
+[ExcludeFromCodeCoverage]
+public sealed class PostgresExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly PostgresFixture _fixture;
+    public PostgresExtractorTests(PostgresFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("Postgres")]
+[Trait("Category", "postgres")]
+[ExcludeFromCodeCoverage]
+public sealed class PostgresLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly PostgresFixture _fixture;
+    public PostgresLoaderTests(PostgresFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/SqlServerTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/SqlServerTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("SqlServer")]
+public class SqlServerCollection : ICollectionFixture<SqlServerFixture> { }
+
+
+
+[Collection("SqlServer")]
+[Trait("Category", "sqlserver")]
+[ExcludeFromCodeCoverage]
+public sealed class SqlServerExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly SqlServerFixture _fixture;
+    public SqlServerExtractorTests(SqlServerFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("SqlServer")]
+[Trait("Category", "sqlserver")]
+[ExcludeFromCodeCoverage]
+public sealed class SqlServerLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly SqlServerFixture _fixture;
+    public SqlServerLoaderTests(SqlServerFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/SqliteTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/SqliteTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("Sqlite")]
+public class SqliteCollection : ICollectionFixture<SqliteFixture> { }
+
+
+
+[Collection("Sqlite")]
+[Trait("Category", "sqlite")]
+[ExcludeFromCodeCoverage]
+public sealed class SqliteExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly SqliteFixture _fixture;
+    public SqliteExtractorTests(SqliteFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("Sqlite")]
+[Trait("Category", "sqlite")]
+[ExcludeFromCodeCoverage]
+public sealed class SqliteLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly SqliteFixture _fixture;
+    public SqliteLoaderTests(SqliteFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Version>0.2.0</Version>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1812;CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.DbClient\Wolfgang.Etl.DbClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.4.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="4.4.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- New `Wolfgang.Etl.DbClient.Tests.Integration` project — class-fixture-based suites for SQL Server, PostgreSQL, MySQL, and SQLite, running against real containers via [Testcontainers .NET](https://dotnet.testcontainers.org/).
- New `test-integration` matrix job in `pr.yaml` (Linux-only, parallel to Stage 1, non-gating). Per-RDBMS job names produce stable badge URLs for a follow-up README PR.
- `build-pr.ps1` gains a "Step 3.5" that auto-detects Docker and runs the same per-RDBMS slices locally, so contributors get the same feedback before pushing.
- Tests are **skipped, not failed**, when the Docker daemon is unreachable — safe to run on any dev box.
- This is **PR 1 of 3**. Follow-ups:
  - PR 2: BenchmarkDotNet benchmarks parameterized by RDBMS, with a `benchmarks.yaml` workflow that publishes per-DB charts to gh-pages on release tag / `workflow_dispatch`.
  - PR 3: README "Tested Databases" section with per-DB CI status badges + links to the benchmark charts.

## Provider matrix
| Provider | Image | Driver |
|---|---|---|
| SQL Server | `mcr.microsoft.com/mssql/server:2022-latest` | `Microsoft.Data.SqlClient` |
| PostgreSQL | `postgres:16-alpine` | `Npgsql` |
| MySQL | `mysql:8.0` | `MySqlConnector` |
| SQLite | (in-memory shared-cache) | `Microsoft.Data.Sqlite` |

MariaDB and Oracle are tracked as follow-up issues.

## Local verification
Verified on Windows + Docker Desktop, net10.0:
- Full `dotnet build -c Release`: 0 warnings, 0 errors
- Unit tests: 141/141 ✅
- Integration tests: **28/28 ✅** across all four providers
- Docker-down skip path: 28/28 cleanly skipped with a clear reason

## Test plan
- [ ] CI Stage 1 (Linux Tests + Coverage Gate) still green on this branch
- [ ] All four `Integration / <rdbms>` matrix jobs pass on Linux
- [ ] Stage 2 (Windows) and Stage 3 (macOS) loops do **not** pick up `Tests.Integration`
- [ ] `pwsh ./scripts/build-pr.ps1` runs the integration step locally when Docker is up, and skips it with a warning when Docker is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)