### PR TITLE
feat(benchmarks): per-RDBMS benchmark suite + gh-pages chart publishing

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -22,6 +22,12 @@ concurrency:
   group: benchmarks-${{ github.ref }}
   cancel-in-progress: false
 
+# Jobs are intentionally serialized via `needs:` so they don't race to push to
+# gh-pages. benchmark-action/github-action-benchmark commits + force-pushes the
+# benchmark history file (`data.js`) per run; parallel pushes would either
+# clobber each other or hit non-fast-forward errors. Per-provider charts each
+# live under their own `dev/bench/<rdbms>/` directory, but the action also
+# updates a shared metadata file so chaining is the safest model.
 jobs:
 
   # ============================================================================
@@ -32,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
@@ -45,7 +53,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
         with:
           name: "ExtractorBenchmarks (sqlite)"
           tool: 'benchmarkdotnet'
@@ -64,6 +72,7 @@ jobs:
   benchmark-sqlserver:
     name: "Benchmarks / sqlserver"
     runs-on: ubuntu-latest
+    needs: benchmark-sqlite
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2022-latest
@@ -79,6 +88,8 @@ jobs:
           --health-retries 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
@@ -93,7 +104,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
         with:
           name: "ExtractorBenchmarks (sqlserver)"
           tool: 'benchmarkdotnet'
@@ -112,6 +123,7 @@ jobs:
   benchmark-postgres:
     name: "Benchmarks / postgres"
     runs-on: ubuntu-latest
+    needs: benchmark-sqlserver
     services:
       postgres:
         image: postgres:16-alpine
@@ -127,6 +139,8 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
@@ -141,7 +155,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
         with:
           name: "ExtractorBenchmarks (postgres)"
           tool: 'benchmarkdotnet'
@@ -160,6 +174,7 @@ jobs:
   benchmark-mysql:
     name: "Benchmarks / mysql"
     runs-on: ubuntu-latest
+    needs: benchmark-postgres
     services:
       mysql:
         image: mysql:8.0
@@ -175,6 +190,8 @@ jobs:
           --health-retries 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
@@ -189,7 +206,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
         with:
           name: "ExtractorBenchmarks (mysql)"
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,203 @@
+name: Benchmarks (per-RDBMS) → gh-pages
+
+# Run BenchmarkDotNet against each supported RDBMS and publish the results to
+# gh-pages so we can track perf trends over time. Charts land at
+# https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/<rdbms>/.
+#
+# Triggers:
+#   - workflow_dispatch — ad-hoc runs from the Actions tab
+#   - tag push (v*)      — auto-snapshot at release time
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write    # benchmark-action pushes commits to gh-pages
+  deployments: write # benchmark-action records a deployment
+
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+
+  # ============================================================================
+  # SQLite (no container needed)
+  # ============================================================================
+  benchmark-sqlite:
+    name: "Benchmarks / sqlite"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: sqlite
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "ExtractorBenchmarks (sqlite)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/sqlite
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # SQL Server
+  # ============================================================================
+  benchmark-sqlserver:
+    name: "Benchmarks / sqlserver"
+    runs-on: ubuntu-latest
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Bench-SA-Pass-1!"
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P Bench-SA-Pass-1! -Q 'SELECT 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: sqlserver
+          ETL_DBCLIENT_BENCHMARK_MSSQL: "Server=localhost,1433;Database=master;User Id=sa;Password=Bench-SA-Pass-1!;Encrypt=False;TrustServerCertificate=True"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "ExtractorBenchmarks (sqlserver)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/sqlserver
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # PostgreSQL
+  # ============================================================================
+  benchmark-postgres:
+    name: "Benchmarks / postgres"
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: bench
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: postgres
+          ETL_DBCLIENT_BENCHMARK_PG: "Host=localhost;Port=5432;Database=bench;Username=postgres;Password=postgres"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "ExtractorBenchmarks (postgres)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/postgres
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # MySQL
+  # ============================================================================
+  benchmark-mysql:
+    name: "Benchmarks / mysql"
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+          MYSQL_DATABASE: bench
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost -uroot -pmysql"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: mysql
+          ETL_DBCLIENT_BENCHMARK_MYSQL: "Server=localhost;Port=3306;Database=bench;User Id=root;Password=mysql;SslMode=None"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "ExtractorBenchmarks (mysql)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/mysql
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -260,11 +260,14 @@ jobs:
           #   CNAME        – Custom domain config (if present)
           #   .nojekyll    – Tells GitHub Pages not to run Jekyll
           #   versions/    – All versioned docs (v1.0.0/, latest/, etc.)
+          #   dev/         – BenchmarkDotNet charts published by benchmarks.yaml
+          #                  (lives at dev/bench/<rdbms>/ and must survive doc redeploys)
           Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
             $_.Name -ne '.git' -and
             $_.Name -ne 'CNAME' -and
             $_.Name -ne '.nojekyll' -and
-            $_.Name -ne 'versions'
+            $_.Name -ne 'versions' -and
+            $_.Name -ne 'dev'
           } | Remove-Item -Recurse -Force
 
           git -C "$WORK_DIR" add -A
@@ -347,9 +350,10 @@ jobs:
             New-Item -ItemType Directory -Force -Path $WORK_DIR | Out-Null
           }
 
-          # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME
+          # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME, dev/
+          # (dev/ holds BenchmarkDotNet charts published by benchmarks.yaml.)
           Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
-            $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions')
+            $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions', 'dev')
           } | Remove-Item -Recurse -Force
 
           # Ensure .nojekyll exists so GitHub Pages does not run Jekyll

--- a/README.md
+++ b/README.md
@@ -100,6 +100,37 @@ public class EmployeeRecord
 
 ---
 
+## 🗄️ Tested Databases
+
+`Wolfgang.Etl.DbClient` is provider-agnostic over ADO.NET (`DbConnection` / `DbCommand`),
+so any compliant provider should work. The matrix below lists the RDBMSes that are
+verified by CI on every PR. SQLite is exercised by the unit-test suite (in-memory);
+the other rows are real-container integration runs ([Testcontainers .NET](https://dotnet.testcontainers.org/))
+in the `Integration / <rdbms>` job of [pr.yaml](.github/workflows/pr.yaml).
+
+| Database | Version Tested | Driver | Integration Tests | Benchmarks |
+|---|---|---|---|---|
+| **SQLite** | in-memory | `Microsoft.Data.Sqlite` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/) |
+| **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
+| **PostgreSQL** | 16 | `Npgsql` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
+| **MySQL** | 8.0 | `MySqlConnector` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
+
+> **About these badges.** GitHub doesn't natively render a different status per matrix
+> job, so each row currently shows the *overall* `pr.yaml` status. If any of the four
+> integration jobs fails, every row in this table will go red. Click any badge to see
+> the per-RDBMS pass/fail detail in the Actions tab. Per-database dynamic badges are
+> tracked as a follow-up.
+
+> **About the charts.** Benchmark charts are published by
+> [`benchmarks.yaml`](.github/workflows/benchmarks.yaml) on every release tag and on
+> manual `workflow_dispatch`. They land on the `gh-pages` branch under
+> `dev/bench/<rdbms>/` and won't render until the first run has completed.
+
+Want to see your favourite RDBMS supported? Open an issue — adding a provider is
+typically a single fixture class plus a matrix entry in `pr.yaml` and `benchmarks.yaml`.
+
+---
+
 ## 🎯 Target Frameworks
 
 | Framework | Versions |

--- a/README.md
+++ b/README.md
@@ -104,16 +104,18 @@ public class EmployeeRecord
 
 `Wolfgang.Etl.DbClient` is provider-agnostic over ADO.NET (`DbConnection` / `DbCommand`),
 so any compliant provider should work. The matrix below lists the RDBMSes that are
-verified by CI on every PR. SQLite is exercised by the unit-test suite (in-memory);
-the other rows are real-container integration runs ([Testcontainers .NET](https://dotnet.testcontainers.org/))
-in the `Integration / <rdbms>` job of [pr.yaml](.github/workflows/pr.yaml).
+verified by CI on every PR. Every row has both unit-test coverage (xUnit, on the
+full .NET TFM matrix) **and** a real-container integration run via
+[Testcontainers .NET](https://dotnet.testcontainers.org/) in the
+`Integration / <rdbms>` job of [pr.yaml](.github/workflows/pr.yaml). SQLite uses
+an in-memory connection instead of a container.
 
-| Database | Version Tested | Driver | Integration Tests | Benchmarks |
+| Database | Version Tested | Driver | CI Status | Benchmarks |
 |---|---|---|---|---|
-| **SQLite** | in-memory | `Microsoft.Data.Sqlite` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/) |
-| **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
-| **PostgreSQL** | 16 | `Npgsql` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
-| **MySQL** | 8.0 | `MySqlConnector` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
+| **SQLite** | in-memory | `Microsoft.Data.Sqlite` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/) |
+| **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
+| **PostgreSQL** | 16 | `Npgsql` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
+| **MySQL** | 8.0 | `MySqlConnector` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
 
 > **About these badges.** GitHub doesn't natively render a different status per matrix
 > job, so each row currently shows the *overall* `pr.yaml` status. If any of the four

--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -20,6 +20,7 @@
     <File Path=".github/ISSUE_TEMPLATE/feature_request.yaml" />
   </Folder>
   <Folder Name="/.root/.github/workflows/">
+    <File Path=".github/workflows/benchmarks.yaml" />
     <File Path=".github/workflows/build-all-versions.yaml" />
     <File Path=".github/workflows/codeql.yaml" />
     <File Path=".github/workflows/docfx.yaml" />

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Data.Common;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Data.SqlClient;
+using MySqlConnector;
+using Npgsql;
+
+namespace Wolfgang.Etl.DbClient.Benchmarks;
+
+/// <summary>
+/// Per-RDBMS connection + DDL helper for the benchmark suite. The provider is
+/// selected at process start via the <c>ETL_DBCLIENT_BENCHMARK_RDBMS</c> env var
+/// (one of <c>sqlite</c>, <c>sqlserver</c>, <c>postgres</c>, <c>mysql</c>; defaults
+/// to <c>sqlite</c>). Connection strings come from these env vars:
+/// <list type="bullet">
+///   <item><description><c>ETL_DBCLIENT_BENCHMARK_MSSQL</c></description></item>
+///   <item><description><c>ETL_DBCLIENT_BENCHMARK_PG</c></description></item>
+///   <item><description><c>ETL_DBCLIENT_BENCHMARK_MYSQL</c></description></item>
+/// </list>
+/// </summary>
+public static class BenchmarkContext
+{
+    public static string Rdbms => (Environment.GetEnvironmentVariable("ETL_DBCLIENT_BENCHMARK_RDBMS") ?? "sqlite").Trim().ToLowerInvariant();
+
+
+
+    public static DbConnection OpenConnection()
+    {
+        DbConnection conn = Rdbms switch
+        {
+            "sqlserver" => new SqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MSSQL")),
+            "postgres"  => new NpgsqlConnection(Require("ETL_DBCLIENT_BENCHMARK_PG")),
+            "mysql"     => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MYSQL")),
+            "sqlite"    => new SqliteConnection("Data Source=:memory:"),
+            _           => throw new InvalidOperationException($"Unknown ETL_DBCLIENT_BENCHMARK_RDBMS value '{Rdbms}'. Expected one of: sqlite, sqlserver, postgres, mysql."),
+        };
+
+        conn.Open();
+        return conn;
+    }
+
+
+
+    public static async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        if (connection is null) throw new ArgumentNullException(nameof(connection));
+
+        var (drop, create) = Rdbms switch
+        {
+            "sqlserver" => ("IF OBJECT_ID('dbo.contract_items','U') IS NOT NULL DROP TABLE dbo.contract_items;",
+                            "CREATE TABLE dbo.contract_items (name NVARCHAR(100) NOT NULL, value INT NOT NULL);"),
+            "postgres"  => ("DROP TABLE IF EXISTS contract_items;",
+                            "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INTEGER NOT NULL);"),
+            "mysql"     => ("DROP TABLE IF EXISTS contract_items;",
+                            "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);"),
+            _           => ("DROP TABLE IF EXISTS contract_items;",
+                            "CREATE TABLE contract_items (name TEXT NOT NULL, value INTEGER NOT NULL);"),
+        };
+
+        await ExecuteAsync(connection, drop, cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, create, cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public static async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        if (connection is null) throw new ArgumentNullException(nameof(connection));
+
+        var paramPrefix = string.Equals(Rdbms, "postgres", StringComparison.Ordinal) ? "" : "@";
+
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"INSERT INTO contract_items (name, value) VALUES ({paramPrefix}name, {paramPrefix}value);";
+
+            var p1 = cmd.CreateParameter();
+            p1.ParameterName = $"{paramPrefix}name";
+            p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            cmd.Parameters.Add(p1);
+
+            var p2 = cmd.CreateParameter();
+            p2.ParameterName = $"{paramPrefix}value";
+            p2.Value = i * 10;
+            cmd.Parameters.Add(p2);
+
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+
+
+    private static async Task ExecuteAsync(DbConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    private static string Require(string envVar)
+    {
+        var v = Environment.GetEnvironmentVariable(envVar);
+        if (string.IsNullOrWhiteSpace(v))
+        {
+            throw new InvalidOperationException
+            (
+                $"Environment variable '{envVar}' is required when ETL_DBCLIENT_BENCHMARK_RDBMS='{Rdbms}'."
+            );
+        }
+        return v;
+    }
+}

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
@@ -70,20 +70,21 @@ public static class BenchmarkContext
     {
         if (connection is null) throw new ArgumentNullException(nameof(connection));
 
-        var paramPrefix = string.Equals(Rdbms, "postgres", StringComparison.Ordinal) ? "" : "@";
-
+        // All four providers accept the @-prefixed parameter marker syntax in the
+        // command text. Npgsql in particular allows '@name' even though Postgres'
+        // native marker is '$1' — see https://www.npgsql.org/doc/basic-usage.html.
         for (var i = 1; i <= rowCount; i++)
         {
             using var cmd = connection.CreateCommand();
-            cmd.CommandText = $"INSERT INTO contract_items (name, value) VALUES ({paramPrefix}name, {paramPrefix}value);";
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
 
             var p1 = cmd.CreateParameter();
-            p1.ParameterName = $"{paramPrefix}name";
+            p1.ParameterName = "@name";
             p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
             cmd.Parameters.Add(p1);
 
             var p2 = cmd.CreateParameter();
-            p2.ParameterName = $"{paramPrefix}value";
+            p2.ParameterName = "@value";
             p2.Value = i * 10;
             cmd.Parameters.Add(p2);
 

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkRecord.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkRecord.cs
@@ -1,9 +1,18 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Wolfgang.Etl.DbClient.Benchmarks;
 
+/// <summary>
+/// Benchmark row mapped to the cross-dialect <c>contract_items</c> schema used by
+/// both the integration suite and the benchmark suite. Lower-case identifiers
+/// avoid Postgres' unquoted-folding behaviour.
+/// </summary>
+[Table("contract_items")]
 public class BenchmarkRecord
 {
-    public int Id { get; set; }
-    public string FirstName { get; set; } = string.Empty;
-    public string LastName { get; set; } = string.Empty;
-    public int Age { get; set; }
+    [Column("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [Column("value")]
+    public int Value { get; set; }
 }

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
@@ -1,15 +1,19 @@
 using System;
+using System.Data.Common;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
 
 namespace Wolfgang.Etl.DbClient.Benchmarks;
 
+/// <summary>
+/// Streams <see cref="BenchmarkRecord"/> rows out of the configured RDBMS.
+/// Selected by <c>ETL_DBCLIENT_BENCHMARK_RDBMS</c> — defaults to in-memory SQLite.
+/// </summary>
 [MemoryDiagnoser]
-public sealed class ExtractorBenchmarks : IDisposable
+public class ExtractorBenchmarks : IDisposable
 {
-    private SqliteConnection _connection = null!;
+    private DbConnection _connection = null!;
 
 
 
@@ -21,37 +25,15 @@ public sealed class ExtractorBenchmarks : IDisposable
     [GlobalSetup]
     public async Task SetupAsync()
     {
-        _connection = new SqliteConnection("Data Source=:memory:");
-        await _connection.OpenAsync().ConfigureAwait(false);
-
-        using var cmd = _connection.CreateCommand();
-        cmd.CommandText = @"
-            CREATE TABLE People (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                first_name TEXT NOT NULL,
-                last_name TEXT NOT NULL,
-                age INTEGER NOT NULL
-            )";
-        await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
-
-        for (var i = 0; i < RecordCount; i++)
-        {
-            using var insert = _connection.CreateCommand();
-            insert.CommandText = "INSERT INTO People (first_name, last_name, age) VALUES (@fn, @ln, @age)";
-            insert.Parameters.AddWithValue("@fn", $"First{i}");
-            insert.Parameters.AddWithValue("@ln", $"Last{i}");
-            insert.Parameters.AddWithValue("@age", 20 + (i % 60));
-            await insert.ExecuteNonQueryAsync().ConfigureAwait(false);
-        }
+        _connection = BenchmarkContext.OpenConnection();
+        await BenchmarkContext.ResetSchemaAsync(_connection).ConfigureAwait(false);
+        await BenchmarkContext.SeedAsync(_connection, RecordCount).ConfigureAwait(false);
     }
 
 
 
     [GlobalCleanup]
-    public void Cleanup()
-    {
-        Dispose();
-    }
+    public void Cleanup() => Dispose();
 
 
 
@@ -68,7 +50,7 @@ public sealed class ExtractorBenchmarks : IDisposable
         var extractor = new DbExtractor<BenchmarkRecord>
         (
             _connection,
-            "SELECT id AS Id, first_name AS FirstName, last_name AS LastName, age AS Age FROM People"
+            "SELECT name AS Name, value AS Value FROM contract_items"
         );
 
         var count = 0;

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
@@ -1,15 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
 
 namespace Wolfgang.Etl.DbClient.Benchmarks;
 
+/// <summary>
+/// Bulk-loads <see cref="BenchmarkRecord"/> rows into the configured RDBMS.
+/// Selected by <c>ETL_DBCLIENT_BENCHMARK_RDBMS</c> — defaults to in-memory SQLite.
+/// </summary>
 [MemoryDiagnoser]
-public class LoaderBenchmarks
+public class LoaderBenchmarks : IDisposable
 {
+    private DbConnection _connection = null!;
     private BenchmarkRecord[] _records = Array.Empty<BenchmarkRecord>();
 
 
@@ -20,18 +25,42 @@ public class LoaderBenchmarks
 
 
     [GlobalSetup]
-    public void Setup()
+    public async Task SetupAsync()
     {
+        _connection = BenchmarkContext.OpenConnection();
+        await BenchmarkContext.ResetSchemaAsync(_connection).ConfigureAwait(false);
+
         _records = new BenchmarkRecord[RecordCount];
         for (var i = 0; i < RecordCount; i++)
         {
             _records[i] = new BenchmarkRecord
             {
-                FirstName = $"First{i}",
-                LastName = $"Last{i}",
-                Age = 20 + (i % 60),
+                Name = $"Item{i + 1}",
+                Value = (i + 1) * 10,
             };
         }
+    }
+
+
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Each Benchmark invocation should start from an empty table so timing
+        // is comparable across iterations.
+        BenchmarkContext.ResetSchemaAsync(_connection).GetAwaiter().GetResult();
+    }
+
+
+
+    [GlobalCleanup]
+    public void Cleanup() => Dispose();
+
+
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
     }
 
 
@@ -39,23 +68,10 @@ public class LoaderBenchmarks
     [Benchmark]
     public async Task LoadAsync()
     {
-        using var connection = new SqliteConnection("Data Source=:memory:");
-        await connection.OpenAsync().ConfigureAwait(false);
-
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = @"
-            CREATE TABLE People (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                first_name TEXT NOT NULL,
-                last_name TEXT NOT NULL,
-                age INTEGER NOT NULL
-            )";
-        await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
-
         var loader = new DbLoader<BenchmarkRecord>
         (
-            connection,
-            "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
+            _connection,
+            "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)"
         );
 
         await loader.LoadAsync(ToAsyncEnumerable(_records)).ConfigureAwait(false);

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj
@@ -6,7 +6,10 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);MA0004;MA0048;VSTHRD200</NoWarn>
+    <!-- CA1063, S3881: BenchmarkDotNet requires non-sealed benchmark types, but the IDisposable
+         pattern analyzers want sealed or full Dispose(bool). BDN's lifecycle is fully controlled
+         by GlobalSetup/GlobalCleanup so the abbreviated Dispose() is intentional. -->
+    <NoWarn>$(NoWarn);MA0004;MA0048;VSTHRD200;CA1063;S3881</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +19,9 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->


### PR DESCRIPTION
**Stacked on #59** (integration tests). Review #59 first.

## Summary
- Refactors the BenchmarkDotNet suite so the same `ExtractorBenchmarks` / `LoaderBenchmarks` run against any of SQLite, SQL Server, PostgreSQL, or MySQL, selected at process start via `ETL_DBCLIENT_BENCHMARK_RDBMS` env var. Schema (`contract_items`) and credentials env vars match the integration suite from #59.
- New `BenchmarkContext` centralizes provider factory + per-dialect DDL + seeding so the benchmark classes stay clean.
- New `.github/workflows/benchmarks.yaml`: four jobs (one per RDBMS) with `services:` blocks. Each runs `ExtractorBenchmarks`, exports JSON via `--exporters json --artifacts BDN_OUT`, and publishes to gh-pages at `dev/bench/<rdbms>/` via `benchmark-action/github-action-benchmark@v1`.
- Triggers: `workflow_dispatch` and `push: tags: ['v*']` — zero impact on PR runs.
- **docfx.yaml fix**: the existing "clean stale gh-pages root files" step nukes everything outside an allow-list. Added `dev` to that allow-list in both cleanup steps so a release-time docs redeploy does not wipe accumulated benchmark history.

This is **PR 2 of 3**. Next: README "Tested Databases" section with per-DB CI status badges + benchmark-chart links.

## Chart URLs (after first run)
- `https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/`
- `https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/`
- `https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/`
- `https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/`

## Local verification
- `dotnet build -c Release`: 0 warnings, 0 errors
- Dry-run `ExtractorBenchmarks` against SQLite → expected JSON appears at `BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json`

## Test plan
- [ ] `workflow_dispatch` of `benchmarks.yaml` against this branch — confirm all four jobs go green and the four `dev/bench/<rdbms>/` directories appear on `gh-pages`
- [ ] Push a throwaway `v0.0.0-bench-smoke` tag to a fork; confirm the tag trigger fires the same four jobs
- [ ] After a routine docs redeploy via `release.yaml` / `docfx.yaml`, verify `dev/bench/*/` is still present on `gh-pages`
- [ ] `pr.yaml` is untouched; existing PR jobs behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)