### PR TITLE
docs(readme): add Tested Databases matrix with status badges + bench links

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,37 @@ public class EmployeeRecord
 
 ---
 
+## 🗄️ Tested Databases
+
+`Wolfgang.Etl.DbClient` is provider-agnostic over ADO.NET (`DbConnection` / `DbCommand`),
+so any compliant provider should work. The matrix below lists the RDBMSes that are
+verified by CI on every PR. SQLite is exercised by the unit-test suite (in-memory);
+the other rows are real-container integration runs ([Testcontainers .NET](https://dotnet.testcontainers.org/))
+in the `Integration / <rdbms>` job of [pr.yaml](.github/workflows/pr.yaml).
+
+| Database | Version Tested | Driver | Integration Tests | Benchmarks |
+|---|---|---|---|---|
+| **SQLite** | in-memory | `Microsoft.Data.Sqlite` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/) |
+| **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
+| **PostgreSQL** | 16 | `Npgsql` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
+| **MySQL** | 8.0 | `MySqlConnector` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
+
+> **About these badges.** GitHub doesn't natively render a different status per matrix
+> job, so each row currently shows the *overall* `pr.yaml` status. If any of the four
+> integration jobs fails, every row in this table will go red. Click any badge to see
+> the per-RDBMS pass/fail detail in the Actions tab. Per-database dynamic badges are
+> tracked as a follow-up.
+
+> **About the charts.** Benchmark charts are published by
+> [`benchmarks.yaml`](.github/workflows/benchmarks.yaml) on every release tag and on
+> manual `workflow_dispatch`. They land on the `gh-pages` branch under
+> `dev/bench/<rdbms>/` and won't render until the first run has completed.
+
+Want to see your favourite RDBMS supported? Open an issue — adding a provider is
+typically a single fixture class plus a matrix entry in `pr.yaml` and `benchmarks.yaml`.
+
+---
+
 ## 🎯 Target Frameworks
 
 | Framework | Versions |

--- a/README.md
+++ b/README.md
@@ -104,16 +104,18 @@ public class EmployeeRecord
 
 `Wolfgang.Etl.DbClient` is provider-agnostic over ADO.NET (`DbConnection` / `DbCommand`),
 so any compliant provider should work. The matrix below lists the RDBMSes that are
-verified by CI on every PR. SQLite is exercised by the unit-test suite (in-memory);
-the other rows are real-container integration runs ([Testcontainers .NET](https://dotnet.testcontainers.org/))
-in the `Integration / <rdbms>` job of [pr.yaml](.github/workflows/pr.yaml).
+verified by CI on every PR. Every row has both unit-test coverage (xUnit, on the
+full .NET TFM matrix) **and** a real-container integration run via
+[Testcontainers .NET](https://dotnet.testcontainers.org/) in the
+`Integration / <rdbms>` job of [pr.yaml](.github/workflows/pr.yaml). SQLite uses
+an in-memory connection instead of a container.
 
-| Database | Version Tested | Driver | Integration Tests | Benchmarks |
+| Database | Version Tested | Driver | CI Status | Benchmarks |
 |---|---|---|---|---|
-| **SQLite** | in-memory | `Microsoft.Data.Sqlite` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/) |
-| **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
-| **PostgreSQL** | 16 | `Npgsql` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
-| **MySQL** | 8.0 | `MySqlConnector` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
+| **SQLite** | in-memory | `Microsoft.Data.Sqlite` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/) |
+| **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
+| **PostgreSQL** | 16 | `Npgsql` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
+| **MySQL** | 8.0 | `MySqlConnector` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
 
 > **About these badges.** GitHub doesn't natively render a different status per matrix
 > job, so each row currently shows the *overall* `pr.yaml` status. If any of the four


### PR DESCRIPTION
**Stacked on #60** (benchmarks), which is stacked on #59 (integration tests).
Review #59 and #60 first.

## Summary
Inserts a new "Tested Databases" section in `README.md` between Features and Target Frameworks. Lists the four RDBMSes exercised in CI:

| Database | Version | Driver | Integration | Benchmarks |
|---|---|---|---|---|
| SQLite | in-memory | `Microsoft.Data.Sqlite` | unit tests | chart |
| SQL Server | 2022 | `Microsoft.Data.SqlClient` | Testcontainers | chart |
| PostgreSQL | 16 | `Npgsql` | Testcontainers | chart |
| MySQL | 8.0 | `MySqlConnector` | Testcontainers | chart |

Each row shows a workflow-status badge and a link to its `dev/bench/<rdbms>/` chart on gh-pages (chart links resolve once `benchmarks.yaml` from #60 has run at least once).

## Caveat called out in the section
GitHub doesn't natively render per-matrix-job badges, so the status column currently shows the **overall** `pr.yaml` status — if any of the four integration jobs fails, every row in the table will go red. Click-through to the Actions tab shows the per-RDBMS detail. A follow-up issue can wire up per-RDBMS dynamic badges (small JSON files written to gh-pages by each matrix job + shields.io endpoint badges).

This is **PR 3 of 3**.

## Test plan
- [ ] Render the README on GitHub and confirm the section sits cleanly between Features and Target Frameworks
- [ ] All four badge links resolve (they all point to the same `pr.yaml` for now — intentional)
- [ ] All four `dev/bench/<rdbms>/` links will 404 until `benchmarks.yaml` has run at least once; that's expected and documented in the section
- [ ] After PR1+PR2 are merged, run `benchmarks.yaml` once via `workflow_dispatch` and confirm the chart links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)