### PR TITLE
feat: per-RDBMS integration tests + benchmarks + README matrix

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -22,6 +22,12 @@ concurrency:
   group: benchmarks-${{ github.ref }}
   cancel-in-progress: false
 
+# Jobs are intentionally serialized via `needs:` so they don't race to push to
+# gh-pages. benchmark-action/github-action-benchmark commits + force-pushes the
+# benchmark history file (`data.js`) per run; parallel pushes would either
+# clobber each other or hit non-fast-forward errors. Per-provider charts each
+# live under their own `dev/bench/<rdbms>/` directory, but the action also
+# updates a shared metadata file so chaining is the safest model.
 jobs:
 
   # ============================================================================
@@ -32,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
@@ -45,7 +53,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
         with:
           name: "ExtractorBenchmarks (sqlite)"
           tool: 'benchmarkdotnet'
@@ -64,6 +72,7 @@ jobs:
   benchmark-sqlserver:
     name: "Benchmarks / sqlserver"
     runs-on: ubuntu-latest
+    needs: benchmark-sqlite
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2022-latest
@@ -79,6 +88,8 @@ jobs:
           --health-retries 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
@@ -93,7 +104,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
         with:
           name: "ExtractorBenchmarks (sqlserver)"
           tool: 'benchmarkdotnet'
@@ -112,6 +123,7 @@ jobs:
   benchmark-postgres:
     name: "Benchmarks / postgres"
     runs-on: ubuntu-latest
+    needs: benchmark-sqlserver
     services:
       postgres:
         image: postgres:16-alpine
@@ -127,6 +139,8 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
@@ -141,7 +155,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
         with:
           name: "ExtractorBenchmarks (postgres)"
           tool: 'benchmarkdotnet'
@@ -160,6 +174,7 @@ jobs:
   benchmark-mysql:
     name: "Benchmarks / mysql"
     runs-on: ubuntu-latest
+    needs: benchmark-postgres
     services:
       mysql:
         image: mysql:8.0
@@ -175,6 +190,8 @@ jobs:
           --health-retries 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
@@ -189,7 +206,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
         with:
           name: "ExtractorBenchmarks (mysql)"
           tool: 'benchmarkdotnet'

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,203 @@
+name: Benchmarks (per-RDBMS) → gh-pages
+
+# Run BenchmarkDotNet against each supported RDBMS and publish the results to
+# gh-pages so we can track perf trends over time. Charts land at
+# https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/<rdbms>/.
+#
+# Triggers:
+#   - workflow_dispatch — ad-hoc runs from the Actions tab
+#   - tag push (v*)      — auto-snapshot at release time
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write    # benchmark-action pushes commits to gh-pages
+  deployments: write # benchmark-action records a deployment
+
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+
+  # ============================================================================
+  # SQLite (no container needed)
+  # ============================================================================
+  benchmark-sqlite:
+    name: "Benchmarks / sqlite"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: sqlite
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "ExtractorBenchmarks (sqlite)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/sqlite
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # SQL Server
+  # ============================================================================
+  benchmark-sqlserver:
+    name: "Benchmarks / sqlserver"
+    runs-on: ubuntu-latest
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Bench-SA-Pass-1!"
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P Bench-SA-Pass-1! -Q 'SELECT 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: sqlserver
+          ETL_DBCLIENT_BENCHMARK_MSSQL: "Server=localhost,1433;Database=master;User Id=sa;Password=Bench-SA-Pass-1!;Encrypt=False;TrustServerCertificate=True"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "ExtractorBenchmarks (sqlserver)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/sqlserver
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # PostgreSQL
+  # ============================================================================
+  benchmark-postgres:
+    name: "Benchmarks / postgres"
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: bench
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: postgres
+          ETL_DBCLIENT_BENCHMARK_PG: "Host=localhost;Port=5432;Database=bench;Username=postgres;Password=postgres"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "ExtractorBenchmarks (postgres)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/postgres
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # MySQL
+  # ============================================================================
+  benchmark-mysql:
+    name: "Benchmarks / mysql"
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+          MYSQL_DATABASE: bench
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost -uroot -pmysql"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: mysql
+          ETL_DBCLIENT_BENCHMARK_MYSQL: "Server=localhost;Port=3306;Database=bench;User Id=root;Password=mysql;SslMode=None"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "ExtractorBenchmarks (mysql)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/mysql
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -260,11 +260,14 @@ jobs:
           #   CNAME        – Custom domain config (if present)
           #   .nojekyll    – Tells GitHub Pages not to run Jekyll
           #   versions/    – All versioned docs (v1.0.0/, latest/, etc.)
+          #   dev/         – BenchmarkDotNet charts published by benchmarks.yaml
+          #                  (lives at dev/bench/<rdbms>/ and must survive doc redeploys)
           Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
             $_.Name -ne '.git' -and
             $_.Name -ne 'CNAME' -and
             $_.Name -ne '.nojekyll' -and
-            $_.Name -ne 'versions'
+            $_.Name -ne 'versions' -and
+            $_.Name -ne 'dev'
           } | Remove-Item -Recurse -Force
 
           git -C "$WORK_DIR" add -A
@@ -347,9 +350,10 @@ jobs:
             New-Item -ItemType Directory -Force -Path $WORK_DIR | Out-Null
           }
 
-          # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME
+          # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME, dev/
+          # (dev/ holds BenchmarkDotNet charts published by benchmarks.yaml.)
           Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
-            $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions')
+            $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions', 'dev')
           } | Remove-Item -Recurse -Force
 
           # Ensure .nojekyll exists so GitHub Pages does not run Jekyll

--- a/README.md
+++ b/README.md
@@ -100,6 +100,37 @@ public class EmployeeRecord
 
 ---
 
+## 🗄️ Tested Databases
+
+`Wolfgang.Etl.DbClient` is provider-agnostic over ADO.NET (`DbConnection` / `DbCommand`),
+so any compliant provider should work. The matrix below lists the RDBMSes that are
+verified by CI on every PR. SQLite is exercised by the unit-test suite (in-memory);
+the other rows are real-container integration runs ([Testcontainers .NET](https://dotnet.testcontainers.org/))
+in the `Integration / <rdbms>` job of [pr.yaml](.github/workflows/pr.yaml).
+
+| Database | Version Tested | Driver | Integration Tests | Benchmarks |
+|---|---|---|---|---|
+| **SQLite** | in-memory | `Microsoft.Data.Sqlite` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/) |
+| **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
+| **PostgreSQL** | 16 | `Npgsql` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
+| **MySQL** | 8.0 | `MySqlConnector` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
+
+> **About these badges.** GitHub doesn't natively render a different status per matrix
+> job, so each row currently shows the *overall* `pr.yaml` status. If any of the four
+> integration jobs fails, every row in this table will go red. Click any badge to see
+> the per-RDBMS pass/fail detail in the Actions tab. Per-database dynamic badges are
+> tracked as a follow-up.
+
+> **About the charts.** Benchmark charts are published by
+> [`benchmarks.yaml`](.github/workflows/benchmarks.yaml) on every release tag and on
+> manual `workflow_dispatch`. They land on the `gh-pages` branch under
+> `dev/bench/<rdbms>/` and won't render until the first run has completed.
+
+Want to see your favourite RDBMS supported? Open an issue — adding a provider is
+typically a single fixture class plus a matrix entry in `pr.yaml` and `benchmarks.yaml`.
+
+---
+
 ## 🎯 Target Frameworks
 
 | Framework | Versions |

--- a/README.md
+++ b/README.md
@@ -104,16 +104,18 @@ public class EmployeeRecord
 
 `Wolfgang.Etl.DbClient` is provider-agnostic over ADO.NET (`DbConnection` / `DbCommand`),
 so any compliant provider should work. The matrix below lists the RDBMSes that are
-verified by CI on every PR. SQLite is exercised by the unit-test suite (in-memory);
-the other rows are real-container integration runs ([Testcontainers .NET](https://dotnet.testcontainers.org/))
-in the `Integration / <rdbms>` job of [pr.yaml](.github/workflows/pr.yaml).
+verified by CI on every PR. Every row has both unit-test coverage (xUnit, on the
+full .NET TFM matrix) **and** a real-container integration run via
+[Testcontainers .NET](https://dotnet.testcontainers.org/) in the
+`Integration / <rdbms>` job of [pr.yaml](.github/workflows/pr.yaml). SQLite uses
+an in-memory connection instead of a container.
 
-| Database | Version Tested | Driver | Integration Tests | Benchmarks |
+| Database | Version Tested | Driver | CI Status | Benchmarks |
 |---|---|---|---|---|
-| **SQLite** | in-memory | `Microsoft.Data.Sqlite` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/) |
-| **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
-| **PostgreSQL** | 16 | `Npgsql` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
-| **MySQL** | 8.0 | `MySqlConnector` | [![Integration](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
+| **SQLite** | in-memory | `Microsoft.Data.Sqlite` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlite/) |
+| **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
+| **PostgreSQL** | 16 | `Npgsql` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
+| **MySQL** | 8.0 | `MySqlConnector` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
 
 > **About these badges.** GitHub doesn't natively render a different status per matrix
 > job, so each row currently shows the *overall* `pr.yaml` status. If any of the four

--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -50,6 +50,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj" />
+    <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj" />
   </Folder>
 </Solution>
 

--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -20,6 +20,7 @@
     <File Path=".github/ISSUE_TEMPLATE/feature_request.yaml" />
   </Folder>
   <Folder Name="/.root/.github/workflows/">
+    <File Path=".github/workflows/benchmarks.yaml" />
     <File Path=".github/workflows/build-all-versions.yaml" />
     <File Path=".github/workflows/codeql.yaml" />
     <File Path=".github/workflows/docfx.yaml" />

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Data.Common;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Data.SqlClient;
+using MySqlConnector;
+using Npgsql;
+
+namespace Wolfgang.Etl.DbClient.Benchmarks;
+
+/// <summary>
+/// Per-RDBMS connection + DDL helper for the benchmark suite. The provider is
+/// selected at process start via the <c>ETL_DBCLIENT_BENCHMARK_RDBMS</c> env var
+/// (one of <c>sqlite</c>, <c>sqlserver</c>, <c>postgres</c>, <c>mysql</c>; defaults
+/// to <c>sqlite</c>). Connection strings come from these env vars:
+/// <list type="bullet">
+///   <item><description><c>ETL_DBCLIENT_BENCHMARK_MSSQL</c></description></item>
+///   <item><description><c>ETL_DBCLIENT_BENCHMARK_PG</c></description></item>
+///   <item><description><c>ETL_DBCLIENT_BENCHMARK_MYSQL</c></description></item>
+/// </list>
+/// </summary>
+public static class BenchmarkContext
+{
+    public static string Rdbms => (Environment.GetEnvironmentVariable("ETL_DBCLIENT_BENCHMARK_RDBMS") ?? "sqlite").Trim().ToLowerInvariant();
+
+
+
+    public static DbConnection OpenConnection()
+    {
+        DbConnection conn = Rdbms switch
+        {
+            "sqlserver" => new SqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MSSQL")),
+            "postgres"  => new NpgsqlConnection(Require("ETL_DBCLIENT_BENCHMARK_PG")),
+            "mysql"     => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MYSQL")),
+            "sqlite"    => new SqliteConnection("Data Source=:memory:"),
+            _           => throw new InvalidOperationException($"Unknown ETL_DBCLIENT_BENCHMARK_RDBMS value '{Rdbms}'. Expected one of: sqlite, sqlserver, postgres, mysql."),
+        };
+
+        conn.Open();
+        return conn;
+    }
+
+
+
+    public static async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        if (connection is null) throw new ArgumentNullException(nameof(connection));
+
+        var (drop, create) = Rdbms switch
+        {
+            "sqlserver" => ("IF OBJECT_ID('dbo.contract_items','U') IS NOT NULL DROP TABLE dbo.contract_items;",
+                            "CREATE TABLE dbo.contract_items (name NVARCHAR(100) NOT NULL, value INT NOT NULL);"),
+            "postgres"  => ("DROP TABLE IF EXISTS contract_items;",
+                            "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INTEGER NOT NULL);"),
+            "mysql"     => ("DROP TABLE IF EXISTS contract_items;",
+                            "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);"),
+            _           => ("DROP TABLE IF EXISTS contract_items;",
+                            "CREATE TABLE contract_items (name TEXT NOT NULL, value INTEGER NOT NULL);"),
+        };
+
+        await ExecuteAsync(connection, drop, cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, create, cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public static async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        if (connection is null) throw new ArgumentNullException(nameof(connection));
+
+        var paramPrefix = string.Equals(Rdbms, "postgres", StringComparison.Ordinal) ? "" : "@";
+
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"INSERT INTO contract_items (name, value) VALUES ({paramPrefix}name, {paramPrefix}value);";
+
+            var p1 = cmd.CreateParameter();
+            p1.ParameterName = $"{paramPrefix}name";
+            p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            cmd.Parameters.Add(p1);
+
+            var p2 = cmd.CreateParameter();
+            p2.ParameterName = $"{paramPrefix}value";
+            p2.Value = i * 10;
+            cmd.Parameters.Add(p2);
+
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+
+
+    private static async Task ExecuteAsync(DbConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    private static string Require(string envVar)
+    {
+        var v = Environment.GetEnvironmentVariable(envVar);
+        if (string.IsNullOrWhiteSpace(v))
+        {
+            throw new InvalidOperationException
+            (
+                $"Environment variable '{envVar}' is required when ETL_DBCLIENT_BENCHMARK_RDBMS='{Rdbms}'."
+            );
+        }
+        return v;
+    }
+}

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
@@ -70,20 +70,21 @@ public static class BenchmarkContext
     {
         if (connection is null) throw new ArgumentNullException(nameof(connection));
 
-        var paramPrefix = string.Equals(Rdbms, "postgres", StringComparison.Ordinal) ? "" : "@";
-
+        // All four providers accept the @-prefixed parameter marker syntax in the
+        // command text. Npgsql in particular allows '@name' even though Postgres'
+        // native marker is '$1' — see https://www.npgsql.org/doc/basic-usage.html.
         for (var i = 1; i <= rowCount; i++)
         {
             using var cmd = connection.CreateCommand();
-            cmd.CommandText = $"INSERT INTO contract_items (name, value) VALUES ({paramPrefix}name, {paramPrefix}value);";
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
 
             var p1 = cmd.CreateParameter();
-            p1.ParameterName = $"{paramPrefix}name";
+            p1.ParameterName = "@name";
             p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
             cmd.Parameters.Add(p1);
 
             var p2 = cmd.CreateParameter();
-            p2.ParameterName = $"{paramPrefix}value";
+            p2.ParameterName = "@value";
             p2.Value = i * 10;
             cmd.Parameters.Add(p2);
 

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkRecord.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkRecord.cs
@@ -1,9 +1,18 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Wolfgang.Etl.DbClient.Benchmarks;
 
+/// <summary>
+/// Benchmark row mapped to the cross-dialect <c>contract_items</c> schema used by
+/// both the integration suite and the benchmark suite. Lower-case identifiers
+/// avoid Postgres' unquoted-folding behaviour.
+/// </summary>
+[Table("contract_items")]
 public class BenchmarkRecord
 {
-    public int Id { get; set; }
-    public string FirstName { get; set; } = string.Empty;
-    public string LastName { get; set; } = string.Empty;
-    public int Age { get; set; }
+    [Column("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [Column("value")]
+    public int Value { get; set; }
 }

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
@@ -1,15 +1,19 @@
 using System;
+using System.Data.Common;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
 
 namespace Wolfgang.Etl.DbClient.Benchmarks;
 
+/// <summary>
+/// Streams <see cref="BenchmarkRecord"/> rows out of the configured RDBMS.
+/// Selected by <c>ETL_DBCLIENT_BENCHMARK_RDBMS</c> — defaults to in-memory SQLite.
+/// </summary>
 [MemoryDiagnoser]
-public sealed class ExtractorBenchmarks : IDisposable
+public class ExtractorBenchmarks : IDisposable
 {
-    private SqliteConnection _connection = null!;
+    private DbConnection _connection = null!;
 
 
 
@@ -21,37 +25,15 @@ public sealed class ExtractorBenchmarks : IDisposable
     [GlobalSetup]
     public async Task SetupAsync()
     {
-        _connection = new SqliteConnection("Data Source=:memory:");
-        await _connection.OpenAsync().ConfigureAwait(false);
-
-        using var cmd = _connection.CreateCommand();
-        cmd.CommandText = @"
-            CREATE TABLE People (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                first_name TEXT NOT NULL,
-                last_name TEXT NOT NULL,
-                age INTEGER NOT NULL
-            )";
-        await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
-
-        for (var i = 0; i < RecordCount; i++)
-        {
-            using var insert = _connection.CreateCommand();
-            insert.CommandText = "INSERT INTO People (first_name, last_name, age) VALUES (@fn, @ln, @age)";
-            insert.Parameters.AddWithValue("@fn", $"First{i}");
-            insert.Parameters.AddWithValue("@ln", $"Last{i}");
-            insert.Parameters.AddWithValue("@age", 20 + (i % 60));
-            await insert.ExecuteNonQueryAsync().ConfigureAwait(false);
-        }
+        _connection = BenchmarkContext.OpenConnection();
+        await BenchmarkContext.ResetSchemaAsync(_connection).ConfigureAwait(false);
+        await BenchmarkContext.SeedAsync(_connection, RecordCount).ConfigureAwait(false);
     }
 
 
 
     [GlobalCleanup]
-    public void Cleanup()
-    {
-        Dispose();
-    }
+    public void Cleanup() => Dispose();
 
 
 
@@ -68,7 +50,7 @@ public sealed class ExtractorBenchmarks : IDisposable
         var extractor = new DbExtractor<BenchmarkRecord>
         (
             _connection,
-            "SELECT id AS Id, first_name AS FirstName, last_name AS LastName, age AS Age FROM People"
+            "SELECT name AS Name, value AS Value FROM contract_items"
         );
 
         var count = 0;

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
@@ -1,15 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
 
 namespace Wolfgang.Etl.DbClient.Benchmarks;
 
+/// <summary>
+/// Bulk-loads <see cref="BenchmarkRecord"/> rows into the configured RDBMS.
+/// Selected by <c>ETL_DBCLIENT_BENCHMARK_RDBMS</c> — defaults to in-memory SQLite.
+/// </summary>
 [MemoryDiagnoser]
-public class LoaderBenchmarks
+public class LoaderBenchmarks : IDisposable
 {
+    private DbConnection _connection = null!;
     private BenchmarkRecord[] _records = Array.Empty<BenchmarkRecord>();
 
 
@@ -20,18 +25,42 @@ public class LoaderBenchmarks
 
 
     [GlobalSetup]
-    public void Setup()
+    public async Task SetupAsync()
     {
+        _connection = BenchmarkContext.OpenConnection();
+        await BenchmarkContext.ResetSchemaAsync(_connection).ConfigureAwait(false);
+
         _records = new BenchmarkRecord[RecordCount];
         for (var i = 0; i < RecordCount; i++)
         {
             _records[i] = new BenchmarkRecord
             {
-                FirstName = $"First{i}",
-                LastName = $"Last{i}",
-                Age = 20 + (i % 60),
+                Name = $"Item{i + 1}",
+                Value = (i + 1) * 10,
             };
         }
+    }
+
+
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Each Benchmark invocation should start from an empty table so timing
+        // is comparable across iterations.
+        BenchmarkContext.ResetSchemaAsync(_connection).GetAwaiter().GetResult();
+    }
+
+
+
+    [GlobalCleanup]
+    public void Cleanup() => Dispose();
+
+
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
     }
 
 
@@ -39,23 +68,10 @@ public class LoaderBenchmarks
     [Benchmark]
     public async Task LoadAsync()
     {
-        using var connection = new SqliteConnection("Data Source=:memory:");
-        await connection.OpenAsync().ConfigureAwait(false);
-
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = @"
-            CREATE TABLE People (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                first_name TEXT NOT NULL,
-                last_name TEXT NOT NULL,
-                age INTEGER NOT NULL
-            )";
-        await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
-
         var loader = new DbLoader<BenchmarkRecord>
         (
-            connection,
-            "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
+            _connection,
+            "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)"
         );
 
         await loader.LoadAsync(ToAsyncEnumerable(_records)).ConfigureAwait(false);

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
@@ -44,11 +44,14 @@ public class LoaderBenchmarks : IDisposable
 
 
     [IterationSetup]
-    public void IterationSetup()
+    public Task IterationSetupAsync()
     {
         // Each Benchmark invocation should start from an empty table so timing
-        // is comparable across iterations.
-        BenchmarkContext.ResetSchemaAsync(_connection).GetAwaiter().GetResult();
+        // is comparable across iterations. BenchmarkDotNet 0.14 supports
+        // Task-returning IterationSetup, so we no longer need to block on
+        // .GetAwaiter().GetResult() (which is banned by this repo's
+        // BannedSymbols policy).
+        return BenchmarkContext.ResetSchemaAsync(_connection);
     }
 
 

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
@@ -69,7 +69,7 @@ public class LoaderBenchmarks : IDisposable
 
 
     [Benchmark]
-    public async Task LoadAsync()
+    public Task LoadAsync()
     {
         var loader = new DbLoader<BenchmarkRecord>
         (
@@ -77,7 +77,9 @@ public class LoaderBenchmarks : IDisposable
             "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)"
         );
 
-        await loader.LoadAsync(ToAsyncEnumerable(_records)).ConfigureAwait(false);
+        // Return the Task directly — AsyncFixer01 (treated as error on Windows
+        // analyzer pack) flags `async + single await` as needless overhead.
+        return loader.LoadAsync(ToAsyncEnumerable(_records));
     }
 
 

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj
@@ -6,7 +6,10 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);MA0004;MA0048;VSTHRD200</NoWarn>
+    <!-- CA1063, S3881: BenchmarkDotNet requires non-sealed benchmark types, but the IDisposable
+         pattern analyzers want sealed or full Dispose(bool). BDN's lifecycle is fully controlled
+         by GlobalSetup/GlobalCleanup so the abbreviated Dispose() is intentional. -->
+    <NoWarn>$(NoWarn);MA0004;MA0048;VSTHRD200;CA1063;S3881</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +19,9 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -21,18 +21,24 @@
 .PARAMETER SkipSecurity
     Skip DevSkim and gitleaks scans.
 
+.PARAMETER SkipIntegration
+    Skip the per-RDBMS integration tests. By default the script runs them when
+    a Docker daemon is reachable and silently skips otherwise (with a warning).
+
 .PARAMETER CoverageThreshold
     Minimum coverage percentage required. Defaults to 90.
 
 .EXAMPLE
     pwsh ./scripts/build-pr.ps1
     pwsh ./scripts/build-pr.ps1 -SkipSecurity
+    pwsh ./scripts/build-pr.ps1 -SkipIntegration
     pwsh ./scripts/build-pr.ps1 -CoverageThreshold 80
 #>
 param(
     [switch]$SkipTests,
     [switch]$SkipCoverage,
     [switch]$SkipSecurity,
+    [switch]$SkipIntegration,
     [int]$CoverageThreshold = 90
 )
 
@@ -81,7 +87,11 @@ else {
 if (-not $SkipTests -and $failed.Count -eq 0) {
     Write-Step "Step 2: Run Tests (all target frameworks)"
 
-    $testProjects = @(Get-ChildItem -Path './tests' -Recurse -File -Include '*.csproj', '*.vbproj', '*.fsproj' -ErrorAction SilentlyContinue)
+    # Integration suites are container-backed and run in their own step below.
+    # Match on the file name (not the full path) so an unrelated directory
+    # containing the substring won't be excluded.
+    $testProjects = @(Get-ChildItem -Path './tests' -Recurse -File -Include '*.csproj', '*.vbproj', '*.fsproj' -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -notlike '*.Tests.Integration.csproj' })
 
     if ($testProjects.Count -eq 0) {
         Write-Host "No test projects found in ./tests — skipping"
@@ -203,6 +213,63 @@ if (-not $SkipTests -and -not $SkipCoverage -and $failed.Count -eq 0) {
         }
         else {
             Write-Host "Coverage report not generated — skipping threshold check"
+        }
+    }
+}
+
+# ============================================================================
+# STEP 3.5: RDBMS Integration Tests (Testcontainers, requires Docker)
+# ============================================================================
+if (-not $SkipIntegration -and -not $SkipTests -and $failed.Count -eq 0) {
+    Write-Step "Step 3.5: Integration Tests (per-RDBMS via Testcontainers)"
+
+    $integrationProj = Get-ChildItem -Path './tests' -Recurse -File -Filter '*.Tests.Integration.csproj' -ErrorAction SilentlyContinue | Select-Object -First 1
+
+    if (-not $integrationProj) {
+        Write-Host "ℹ️  No integration project found — skipping."
+    }
+    else {
+        $dockerOk = $false
+        try {
+            docker info *>$null
+            $dockerOk = ($LASTEXITCODE -eq 0)
+        }
+        catch {
+            $dockerOk = $false
+        }
+
+        # SQLite needs no Docker; the other providers do. Build the list accordingly.
+        $rdbmsList = @('sqlite')
+        if ($dockerOk) {
+            $rdbmsList += @('sqlserver', 'postgres', 'mysql')
+        }
+        else {
+            Write-Host "⚠️  Docker daemon is not reachable — running only the SQLite slice." -ForegroundColor Yellow
+            Write-Host "    Start Docker Desktop (or pass -SkipIntegration to silence this) and re-run for full coverage." -ForegroundColor Yellow
+        }
+
+        # Run every combination so a failure on one provider/TFM does not hide
+        # failures on the others. Each failure is recorded but the loop keeps going.
+        $tfmList = @('net8.0', 'net10.0')
+        foreach ($rdbms in $rdbmsList) {
+            foreach ($tfm in $tfmList) {
+                Write-Host ""
+                Write-Host "  RDBMS: $rdbms ($tfm)" -ForegroundColor Yellow
+
+                dotnet test $integrationProj.FullName `
+                    --configuration Release `
+                    --framework $tfm `
+                    --filter "Category=$rdbms" `
+                    --logger "console;verbosity=normal"
+
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Fail "  Integration tests failed for $rdbms ($tfm)"
+                    $failed += "Integration ($rdbms/$tfm)"
+                }
+                else {
+                    Write-Pass "  Integration tests passed for $rdbms ($tfm)"
+                }
+            }
         }
     }
 }

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -248,9 +248,30 @@ if (-not $SkipIntegration -and -not $SkipTests -and $failed.Count -eq 0) {
             Write-Host "    Start Docker Desktop (or pass -SkipIntegration to silence this) and re-run for full coverage." -ForegroundColor Yellow
         }
 
+        # Parse TFMs from the integration project's csproj so this step stays in
+        # sync if the project's TargetFrameworks ever change. Falls back to a
+        # built-in default if the parse fails for any reason.
+        $tfmList = @('net8.0', 'net10.0')
+        try {
+            $integrationCsprojXml = [xml](Get-Content $integrationProj.FullName -Raw)
+            $tfmRaw = $integrationCsprojXml.SelectSingleNode('//TargetFrameworks').'#text'
+            if (-not $tfmRaw) {
+                $tfmRaw = $integrationCsprojXml.SelectSingleNode('//TargetFramework').'#text'
+            }
+            if ($tfmRaw) {
+                $parsed = @($tfmRaw -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+                if ($parsed.Count -gt 0) {
+                    $tfmList = $parsed
+                    Write-Host "  Discovered integration TFMs: $($tfmList -join ', ')" -ForegroundColor DarkGray
+                }
+            }
+        }
+        catch {
+            Write-Host "  ⚠️  Could not parse TFMs from $($integrationProj.Name); falling back to defaults: $($tfmList -join ', ')" -ForegroundColor Yellow
+        }
+
         # Run every combination so a failure on one provider/TFM does not hide
         # failures on the others. Each failure is recorded but the loop keeps going.
-        $tfmList = @('net8.0', 'net10.0')
         foreach ($rdbms in $rdbmsList) {
             foreach ($tfm in $tfmList) {
                 Write-Host ""

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -256,10 +256,14 @@ if (-not $SkipIntegration -and -not $SkipTests -and $failed.Count -eq 0) {
                 Write-Host ""
                 Write-Host "  RDBMS: $rdbms ($tfm)" -ForegroundColor Yellow
 
+                # --no-build / --no-restore: Step 1 already restored + built the
+                # whole solution. Re-running them per RDBMS/TFM would add minutes.
                 dotnet test $integrationProj.FullName `
                     --configuration Release `
                     --framework $tfm `
                     --filter "Category=$rdbms" `
+                    --no-build `
+                    --no-restore `
                     --logger "console;verbosity=normal"
 
                 if ($LASTEXITCODE -ne 0) {

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -89,9 +89,10 @@ if (-not $SkipTests -and $failed.Count -eq 0) {
 
     # Integration suites are container-backed and run in their own step below.
     # Match on the file name (not the full path) so an unrelated directory
-    # containing the substring won't be excluded.
+    # containing the substring won't be excluded. Covers all three project
+    # extensions for symmetry with pr.yaml.
     $testProjects = @(Get-ChildItem -Path './tests' -Recurse -File -Include '*.csproj', '*.vbproj', '*.fsproj' -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -notlike '*.Tests.Integration.csproj' })
+        Where-Object { $_.Name -notmatch '\.Tests\.Integration\.(cs|vb|fs)proj$' })
 
     if ($testProjects.Count -eq 0) {
         Write-Host "No test projects found in ./tests — skipping"
@@ -223,7 +224,9 @@ if (-not $SkipTests -and -not $SkipCoverage -and $failed.Count -eq 0) {
 if (-not $SkipIntegration -and -not $SkipTests -and $failed.Count -eq 0) {
     Write-Step "Step 3.5: Integration Tests (per-RDBMS via Testcontainers)"
 
-    $integrationProj = Get-ChildItem -Path './tests' -Recurse -File -Filter '*.Tests.Integration.csproj' -ErrorAction SilentlyContinue | Select-Object -First 1
+    # Match all three project extensions so a future VB / F# rewrite is found.
+    $integrationProj = @(Get-ChildItem -Path './tests' -Recurse -File -Include '*.csproj', '*.vbproj', '*.fsproj' -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match '\.Tests\.Integration\.(cs|vb|fs)proj$' }) | Select-Object -First 1
 
     if (-not $integrationProj) {
         Write-Host "ℹ️  No integration project found — skipping."

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/AssemblyInfo.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+// Integration test collections each spin up their own Docker container.
+// Running them in parallel would mean multiple containers (SQL Server,
+// Postgres, MySQL) booting concurrently — slow on dev boxes and prone
+// to resource contention / flaky startup on shared CI runners. CI already
+// invokes `dotnet test` once per RDBMS via `--filter Category=...`, so the
+// parallelism gain is purely a local-dev concern, and the cost is large.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/ContractItem.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/ContractItem.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+/// <summary>
+/// Test record used by every provider's integration suite. Lower-case identifiers
+/// avoid PostgreSQL's unquoted-folding behaviour while remaining valid in
+/// SQL Server, MySQL, and SQLite.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[Table("contract_items")]
+public sealed class ContractItem : IEquatable<ContractItem>
+{
+    [Column("name")]
+    public string Name { get; set; } = string.Empty;
+
+
+
+    [Column("value")]
+    public int Value { get; set; }
+
+
+
+    public bool Equals(ContractItem? other)
+    {
+        if (other is null) return false;
+        return string.Equals(Name, other.Name, StringComparison.Ordinal) && Value == other.Value;
+    }
+
+
+
+    public override bool Equals(object? obj) => Equals(obj as ContractItem);
+
+
+
+    public override int GetHashCode() => HashCode.Combine(Name, Value);
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
@@ -21,13 +21,13 @@ public abstract class DbExtractorIntegrationTestsBase
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
 
-        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
-        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
-        await Fixture.SeedAsync(conn, rowCount: 5).ConfigureAwait(true);
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
+        await Fixture.SeedAsync(conn, rowCount: 5);
 
         var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value");
 
-        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+        var results = await extractor.ExtractAsync().ToListAsync();
 
         Assert.Equal(5, results.Count);
         Assert.Equal("Item1", results[0].Name);
@@ -43,12 +43,12 @@ public abstract class DbExtractorIntegrationTestsBase
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
 
-        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
-        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
 
         var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items");
 
-        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+        var results = await extractor.ExtractAsync().ToListAsync();
 
         Assert.Empty(results);
     }
@@ -60,16 +60,16 @@ public abstract class DbExtractorIntegrationTestsBase
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
 
-        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
-        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
-        await Fixture.SeedAsync(conn, rowCount: 5).ConfigureAwait(true);
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
+        await Fixture.SeedAsync(conn, rowCount: 5);
 
         var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value")
         {
             SkipItemCount = 2
         };
 
-        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+        var results = await extractor.ExtractAsync().ToListAsync();
 
         Assert.Equal(3, results.Count);
         Assert.Equal("Item3", results[0].Name);
@@ -82,16 +82,16 @@ public abstract class DbExtractorIntegrationTestsBase
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
 
-        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
-        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
-        await Fixture.SeedAsync(conn, rowCount: 5).ConfigureAwait(true);
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
+        await Fixture.SeedAsync(conn, rowCount: 5);
 
         var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value")
         {
             MaximumItemCount = 2
         };
 
-        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+        var results = await extractor.ExtractAsync().ToListAsync();
 
         Assert.Equal(2, results.Count);
         Assert.Equal("Item1", results[0].Name);

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+/// <summary>
+/// Reusable extractor contract: every concrete RDBMS test class derives from this
+/// and supplies its own <see cref="IDbProviderFixture"/>. Tests are skipped (not
+/// failed) when the fixture's container could not start.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public abstract class DbExtractorIntegrationTestsBase
+{
+    protected abstract IDbProviderFixture Fixture { get; }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_yields_all_seeded_rows()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        await Fixture.SeedAsync(conn, rowCount: 5).ConfigureAwait(true);
+
+        var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value");
+
+        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+
+        Assert.Equal(5, results.Count);
+        Assert.Equal("Item1", results[0].Name);
+        Assert.Equal(10, results[0].Value);
+        Assert.Equal("Item5", results[4].Name);
+        Assert.Equal(50, results[4].Value);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_table_is_empty_yields_nothing()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+
+        var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items");
+
+        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+
+        Assert.Empty(results);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_SkipItemCount_is_set_skips_initial_rows()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        await Fixture.SeedAsync(conn, rowCount: 5).ConfigureAwait(true);
+
+        var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value")
+        {
+            SkipItemCount = 2
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+
+        Assert.Equal(3, results.Count);
+        Assert.Equal("Item3", results[0].Name);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_MaximumItemCount_is_set_stops_early()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        await Fixture.SeedAsync(conn, rowCount: 5).ConfigureAwait(true);
+
+        var extractor = new DbExtractor<ContractItem>(conn, "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value")
+        {
+            MaximumItemCount = 2
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync().ConfigureAwait(true);
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Item1", results[0].Name);
+        Assert.Equal("Item2", results[1].Name);
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
@@ -27,7 +27,7 @@ public abstract class DbLoaderIntegrationTestsBase
     {
         using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT COUNT(*) FROM contract_items";
-        var result = await cmd.ExecuteScalarAsync().ConfigureAwait(true);
+        var result = await cmd.ExecuteScalarAsync();
         return Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);
     }
 
@@ -38,14 +38,14 @@ public abstract class DbLoaderIntegrationTestsBase
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
 
-        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
-        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
 
         var loader = new DbLoader<ContractItem>(conn, "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)");
 
-        await loader.LoadAsync(Source(5)).ConfigureAwait(true);
+        await loader.LoadAsync(Source(5));
 
-        Assert.Equal(5, await CountRowsAsync(conn).ConfigureAwait(true));
+        Assert.Equal(5, await CountRowsAsync(conn));
     }
 
 
@@ -55,14 +55,14 @@ public abstract class DbLoaderIntegrationTestsBase
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
 
-        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
-        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
 
         var loader = new DbLoader<ContractItem>(conn, "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)");
 
-        await loader.LoadAsync(Source(0)).ConfigureAwait(true);
+        await loader.LoadAsync(Source(0));
 
-        Assert.Equal(0, await CountRowsAsync(conn).ConfigureAwait(true));
+        Assert.Equal(0, await CountRowsAsync(conn));
     }
 
 
@@ -72,16 +72,16 @@ public abstract class DbLoaderIntegrationTestsBase
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
 
-        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
-        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
 
         var loader = new DbLoader<ContractItem>(conn, "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)")
         {
             MaximumItemCount = 3
         };
 
-        await loader.LoadAsync(Source(10)).ConfigureAwait(true);
+        await loader.LoadAsync(Source(10));
 
-        Assert.Equal(3, await CountRowsAsync(conn).ConfigureAwait(true));
+        Assert.Equal(3, await CountRowsAsync(conn));
     }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+/// <summary>
+/// Reusable loader contract: every concrete RDBMS test class derives from this
+/// and supplies its own <see cref="IDbProviderFixture"/>. Tests are skipped (not
+/// failed) when the fixture's container could not start.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public abstract class DbLoaderIntegrationTestsBase
+{
+    protected abstract IDbProviderFixture Fixture { get; }
+
+
+
+    private static IAsyncEnumerable<ContractItem> Source(int count) =>
+        Enumerable.Range(1, count)
+            .Select(i => new ContractItem { Name = $"Item{i}", Value = i * 10 })
+            .ToAsyncEnumerable();
+
+
+
+    private static async Task<int> CountRowsAsync(System.Data.Common.DbConnection conn)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM contract_items";
+        var result = await cmd.ExecuteScalarAsync().ConfigureAwait(true);
+        return Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+
+
+    [SkippableFact]
+    public async Task LoadAsync_inserts_all_rows()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+
+        var loader = new DbLoader<ContractItem>(conn, "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)");
+
+        await loader.LoadAsync(Source(5)).ConfigureAwait(true);
+
+        Assert.Equal(5, await CountRowsAsync(conn).ConfigureAwait(true));
+    }
+
+
+
+    [SkippableFact]
+    public async Task LoadAsync_when_source_is_empty_inserts_nothing()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+
+        var loader = new DbLoader<ContractItem>(conn, "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)");
+
+        await loader.LoadAsync(Source(0)).ConfigureAwait(true);
+
+        Assert.Equal(0, await CountRowsAsync(conn).ConfigureAwait(true));
+    }
+
+
+
+    [SkippableFact]
+    public async Task LoadAsync_when_MaximumItemCount_is_set_stops_at_limit()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync().ConfigureAwait(true);
+        await Fixture.ResetSchemaAsync(conn).ConfigureAwait(true);
+
+        var loader = new DbLoader<ContractItem>(conn, "INSERT INTO contract_items (name, value) VALUES (@Name, @Value)")
+        {
+            MaximumItemCount = 3
+        };
+
+        await loader.LoadAsync(Source(10)).ConfigureAwait(true);
+
+        Assert.Equal(3, await CountRowsAsync(conn).ConfigureAwait(true));
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
@@ -34,11 +34,19 @@ public abstract class DbProviderFixtureBase : IAsyncLifetime, IDbProviderFixture
         // Pre-probe Docker availability. Only "Docker daemon unreachable" should
         // turn into a skip — every other StartAsync failure (bad image tag,
         // schema regression, etc.) must propagate so CI fails loudly.
-        if (RequiresDocker && !await IsDockerReachableAsync().ConfigureAwait(false))
+        if (RequiresDocker)
         {
-            Available = false;
-            UnavailableReason = $"{ProviderName} unavailable: Docker daemon is not reachable.";
-            return;
+            var probe = await ProbeDockerAsync().ConfigureAwait(false);
+            if (probe is not null)
+            {
+                Available = false;
+                // Include the probe exception's type+message so a "skipped"
+                // test still gives the reader enough to diagnose TLS,
+                // permission, or socket-path problems — not just an
+                // unhelpful "not reachable".
+                UnavailableReason = $"{ProviderName} unavailable: Docker probe failed — {probe.GetType().Name}: {probe.Message}";
+                return;
+            }
         }
 
         try
@@ -65,18 +73,22 @@ public abstract class DbProviderFixtureBase : IAsyncLifetime, IDbProviderFixture
 
 
 
-    private static async Task<bool> IsDockerReachableAsync()
+    /// <summary>
+    /// Pings the Docker daemon. Returns null on success, or the exception that
+    /// caused the probe to fail (TLS, permission, daemon-down, socket-path, ...).
+    /// </summary>
+    private static async Task<Exception?> ProbeDockerAsync()
     {
         try
         {
             using var cfg = new DockerClientConfiguration();
             using var client = cfg.CreateClient();
             await client.System.PingAsync().ConfigureAwait(false);
-            return true;
+            return null;
         }
-        catch
+        catch (Exception ex)
         {
-            return false;
+            return ex;
         }
     }
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
@@ -1,0 +1,85 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Shared plumbing for container-backed fixtures: catches container-start failures
+/// during xunit's <see cref="IAsyncLifetime.InitializeAsync"/> so tests can be skipped
+/// with a clear reason instead of crashing the whole collection.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public abstract class DbProviderFixtureBase : IAsyncLifetime, IDbProviderFixture
+{
+    public abstract string ProviderName { get; }
+
+    public bool Available { get; private set; }
+
+    public string? UnavailableReason { get; private set; }
+
+
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            await StartAsync().ConfigureAwait(false);
+            Available = true;
+        }
+        catch (Exception ex)
+        {
+            Available = false;
+            UnavailableReason = $"{ProviderName} unavailable: {ex.GetType().Name}: {ex.Message}";
+        }
+    }
+
+
+
+    public async Task DisposeAsync()
+    {
+        if (!Available)
+        {
+            return;
+        }
+
+        try
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort teardown — never fail a test pass because a container
+            // refused to stop cleanly.
+        }
+    }
+
+
+
+    /// <summary>Provision the backing container / database. Throw on failure.</summary>
+    protected abstract Task StartAsync();
+
+
+
+    /// <summary>Tear down the backing container / database. May throw — caller swallows.</summary>
+    protected abstract Task StopAsync();
+
+
+
+    public abstract Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default);
+
+    public abstract Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default);
+
+    public abstract Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default);
+
+
+
+    protected static async Task ExecuteAsync(DbConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        if (connection is null) throw new ArgumentNullException(nameof(connection));
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
+using Docker.DotNet;
 using Xunit;
 
 namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
@@ -20,21 +21,35 @@ public abstract class DbProviderFixtureBase : IAsyncLifetime, IDbProviderFixture
 
 
 
+    /// <summary>
+    /// True when this fixture needs Docker to be reachable. SQLite overrides this
+    /// to false since it uses an in-memory connection.
+    /// </summary>
+    protected virtual bool RequiresDocker => true;
+
+
+
     public async Task InitializeAsync()
     {
+        // Pre-probe Docker availability. Only "Docker daemon unreachable" should
+        // turn into a skip — every other StartAsync failure (bad image tag,
+        // schema regression, etc.) must propagate so CI fails loudly.
+        if (RequiresDocker && !await IsDockerReachableAsync().ConfigureAwait(false))
+        {
+            Available = false;
+            UnavailableReason = $"{ProviderName} unavailable: Docker daemon is not reachable.";
+            return;
+        }
+
         try
         {
             await StartAsync().ConfigureAwait(false);
             Available = true;
         }
-        catch (Exception ex)
+        catch
         {
-            Available = false;
-            UnavailableReason = $"{ProviderName} unavailable: {ex.GetType().Name}: {ex.Message}";
-
-            // StartAsync may have allocated a partially-initialised container
-            // before throwing. Attempt best-effort cleanup so a failed init does
-            // not leak resources on the host.
+            // Real failure: best-effort cleanup, then rethrow so the test run
+            // surfaces the error instead of silently skipping every test.
             try
             {
                 await StopAsync().ConfigureAwait(false);
@@ -43,6 +58,25 @@ public abstract class DbProviderFixtureBase : IAsyncLifetime, IDbProviderFixture
             {
                 // Swallow secondary failures during emergency cleanup.
             }
+
+            throw;
+        }
+    }
+
+
+
+    private static async Task<bool> IsDockerReachableAsync()
+    {
+        try
+        {
+            using var cfg = new DockerClientConfiguration();
+            using var client = cfg.CreateClient();
+            await client.System.PingAsync().ConfigureAwait(false);
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
@@ -31,6 +31,18 @@ public abstract class DbProviderFixtureBase : IAsyncLifetime, IDbProviderFixture
         {
             Available = false;
             UnavailableReason = $"{ProviderName} unavailable: {ex.GetType().Name}: {ex.Message}";
+
+            // StartAsync may have allocated a partially-initialised container
+            // before throwing. Attempt best-effort cleanup so a failed init does
+            // not leak resources on the host.
+            try
+            {
+                await StopAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Swallow secondary failures during emergency cleanup.
+            }
         }
     }
 
@@ -38,11 +50,8 @@ public abstract class DbProviderFixtureBase : IAsyncLifetime, IDbProviderFixture
 
     public async Task DisposeAsync()
     {
-        if (!Available)
-        {
-            return;
-        }
-
+        // Always attempt teardown. StopAsync implementations are responsible
+        // for tolerating a never-started state (e.g. _container is null).
         try
         {
             await StopAsync().ConfigureAwait(false);

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/IDbProviderFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/IDbProviderFixture.cs
@@ -1,0 +1,53 @@
+using System.Data.Common;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Common contract every per-RDBMS fixture exposes to the contract-style test bases.
+/// </summary>
+public interface IDbProviderFixture
+{
+    /// <summary>
+    /// Friendly provider name used in test output ("sqlserver", "postgres", ...).
+    /// </summary>
+    string ProviderName { get; }
+
+
+
+    /// <summary>
+    /// True when the underlying environment (e.g. Docker daemon) was reachable
+    /// and the schema was provisioned. Tests <c>Skip.IfNot(Available, ...)</c> on
+    /// this so a developer without Docker can still run the rest of the suite.
+    /// </summary>
+    bool Available { get; }
+
+
+
+    /// <summary>
+    /// Optional reason explaining why <see cref="Available"/> is false.
+    /// </summary>
+    string? UnavailableReason { get; }
+
+
+
+    /// <summary>
+    /// Open a fresh connection to the per-fixture test database. Caller owns disposal.
+    /// </summary>
+    Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default);
+
+
+
+    /// <summary>
+    /// Drop and recreate the <c>contract_items</c> table so each test starts from a
+    /// known empty state. Implementations should be safe to call repeatedly.
+    /// </summary>
+    Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default);
+
+
+
+    /// <summary>
+    /// Seed the <c>contract_items</c> table with <paramref name="rowCount"/> rows
+    /// where each row is <c>Name="Item{i}"</c>, <c>Value=i*10</c> (1-based).
+    /// </summary>
+    Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default);
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MySqlFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MySqlFixture.cs
@@ -1,0 +1,69 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using MySqlConnector;
+using Testcontainers.MySql;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+[ExcludeFromCodeCoverage]
+public sealed class MySqlFixture : DbProviderFixtureBase
+{
+    private MySqlContainer? _container;
+
+    public override string ProviderName => "mysql";
+
+
+
+    protected override async Task StartAsync()
+    {
+        _container = new MySqlBuilder()
+            .WithImage("mysql:8.0")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+    }
+
+
+
+    protected override async Task StopAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var conn = new MySqlConnection(_container!.GetConnectionString());
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "DROP TABLE IF EXISTS contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "@name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "@value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MySqlFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MySqlFixture.cs
@@ -17,8 +17,10 @@ public sealed class MySqlFixture : DbProviderFixtureBase
 
     protected override async Task StartAsync()
     {
+        // Pinned patch tag for reproducible CI. Bump deliberately when
+        // moving to a new minor.
         _container = new MySqlBuilder()
-            .WithImage("mysql:8.0")
+            .WithImage("mysql:8.0.39")
             .Build();
 
         await _container.StartAsync().ConfigureAwait(false);

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/PostgresFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/PostgresFixture.cs
@@ -1,0 +1,69 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+[ExcludeFromCodeCoverage]
+public sealed class PostgresFixture : DbProviderFixtureBase
+{
+    private PostgreSqlContainer? _container;
+
+    public override string ProviderName => "postgres";
+
+
+
+    protected override async Task StartAsync()
+    {
+        _container = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+    }
+
+
+
+    protected override async Task StopAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var conn = new NpgsqlConnection(_container!.GetConnectionString());
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "DROP TABLE IF EXISTS contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INTEGER NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/PostgresFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/PostgresFixture.cs
@@ -17,8 +17,10 @@ public sealed class PostgresFixture : DbProviderFixtureBase
 
     protected override async Task StartAsync()
     {
+        // Pinned patch tag for reproducible CI. Bump deliberately when
+        // moving to a new minor.
         _container = new PostgreSqlBuilder()
-            .WithImage("postgres:16-alpine")
+            .WithImage("postgres:16.4-alpine")
             .Build();
 
         await _container.StartAsync().ConfigureAwait(false);

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqlServerFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqlServerFixture.cs
@@ -17,8 +17,10 @@ public sealed class SqlServerFixture : DbProviderFixtureBase
 
     protected override async Task StartAsync()
     {
+        // Pinned tag for reproducible CI. Bump deliberately when you want
+        // to validate against a new CU.
         _container = new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+            .WithImage("mcr.microsoft.com/mssql/server:2022-CU20-ubuntu-22.04")
             .Build();
 
         await _container.StartAsync().ConfigureAwait(false);

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqlServerFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqlServerFixture.cs
@@ -1,0 +1,69 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.Data.SqlClient;
+using Testcontainers.MsSql;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+[ExcludeFromCodeCoverage]
+public sealed class SqlServerFixture : DbProviderFixtureBase
+{
+    private MsSqlContainer? _container;
+
+    public override string ProviderName => "sqlserver";
+
+
+
+    protected override async Task StartAsync()
+    {
+        _container = new MsSqlBuilder()
+            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+    }
+
+
+
+    protected override async Task StopAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var conn = new SqlConnection(_container!.GetConnectionString());
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "IF OBJECT_ID('dbo.contract_items','U') IS NOT NULL DROP TABLE dbo.contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE dbo.contract_items (name NVARCHAR(100) NOT NULL, value INT NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO dbo.contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "@name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "@value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
@@ -20,6 +20,9 @@ public sealed class SqliteFixture : DbProviderFixtureBase
 
     public override string ProviderName => "sqlite";
 
+    // SQLite uses an in-memory connection; no Docker daemon required.
+    protected override bool RequiresDocker => false;
+
 
 
     protected override Task StartAsync()

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
@@ -1,0 +1,76 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+/// <summary>
+/// SQLite "integration" fixture — uses an in-memory shared-cache database so
+/// SQLite gets the same matrix row treatment as the container-backed providers.
+/// No Docker required, so this fixture is always <c>Available</c>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Lifetime is managed by xunit via IAsyncLifetime.DisposeAsync, which disposes _holdOpen in StopAsync.")]
+public sealed class SqliteFixture : DbProviderFixtureBase
+{
+    private string _connectionString = string.Empty;
+    private SqliteConnection? _holdOpen;
+
+    public override string ProviderName => "sqlite";
+
+
+
+    protected override Task StartAsync()
+    {
+        // shared-cache + a named in-memory DB lets multiple connections see the
+        // same data; the "hold open" connection keeps the DB alive between tests.
+        _connectionString = $"Data Source=file:integration-{Guid.NewGuid():N}?mode=memory&cache=shared";
+        _holdOpen = new SqliteConnection(_connectionString);
+        _holdOpen.Open();
+        return Task.CompletedTask;
+    }
+
+
+
+    protected override Task StopAsync()
+    {
+        _holdOpen?.Dispose();
+        _holdOpen = null;
+        return Task.CompletedTask;
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "DROP TABLE IF EXISTS contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE contract_items (name TEXT NOT NULL, value INTEGER NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "@name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "@value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
@@ -25,14 +25,13 @@ public sealed class SqliteFixture : DbProviderFixtureBase
 
 
 
-    protected override Task StartAsync()
+    protected override async Task StartAsync()
     {
         // shared-cache + a named in-memory DB lets multiple connections see the
         // same data; the "hold open" connection keeps the DB alive between tests.
         _connectionString = $"Data Source=file:integration-{Guid.NewGuid():N}?mode=memory&cache=shared";
         _holdOpen = new SqliteConnection(_connectionString);
-        _holdOpen.Open();
-        return Task.CompletedTask;
+        await _holdOpen.OpenAsync().ConfigureAwait(false);
     }
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/MySqlTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/MySqlTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("MySql")]
+public class MySqlCollection : ICollectionFixture<MySqlFixture> { }
+
+
+
+[Collection("MySql")]
+[Trait("Category", "mysql")]
+[ExcludeFromCodeCoverage]
+public sealed class MySqlExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly MySqlFixture _fixture;
+    public MySqlExtractorTests(MySqlFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("MySql")]
+[Trait("Category", "mysql")]
+[ExcludeFromCodeCoverage]
+public sealed class MySqlLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly MySqlFixture _fixture;
+    public MySqlLoaderTests(MySqlFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/PostgresTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/PostgresTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("Postgres")]
+public class PostgresCollection : ICollectionFixture<PostgresFixture> { }
+
+
+
+[Collection("Postgres")]
+[Trait("Category", "postgres")]
+[ExcludeFromCodeCoverage]
+public sealed class PostgresExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly PostgresFixture _fixture;
+    public PostgresExtractorTests(PostgresFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("Postgres")]
+[Trait("Category", "postgres")]
+[ExcludeFromCodeCoverage]
+public sealed class PostgresLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly PostgresFixture _fixture;
+    public PostgresLoaderTests(PostgresFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/SqlServerTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/SqlServerTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("SqlServer")]
+public class SqlServerCollection : ICollectionFixture<SqlServerFixture> { }
+
+
+
+[Collection("SqlServer")]
+[Trait("Category", "sqlserver")]
+[ExcludeFromCodeCoverage]
+public sealed class SqlServerExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly SqlServerFixture _fixture;
+    public SqlServerExtractorTests(SqlServerFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("SqlServer")]
+[Trait("Category", "sqlserver")]
+[ExcludeFromCodeCoverage]
+public sealed class SqlServerLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly SqlServerFixture _fixture;
+    public SqlServerLoaderTests(SqlServerFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/SqliteTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/SqliteTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("Sqlite")]
+public class SqliteCollection : ICollectionFixture<SqliteFixture> { }
+
+
+
+[Collection("Sqlite")]
+[Trait("Category", "sqlite")]
+[ExcludeFromCodeCoverage]
+public sealed class SqliteExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly SqliteFixture _fixture;
+    public SqliteExtractorTests(SqliteFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("Sqlite")]
+[Trait("Category", "sqlite")]
+[ExcludeFromCodeCoverage]
+public sealed class SqliteLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly SqliteFixture _fixture;
+    public SqliteLoaderTests(SqliteFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -46,6 +46,10 @@
     <PackageReference Include="Testcontainers.MsSql" Version="4.4.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
     <PackageReference Include="Testcontainers.MySql" Version="4.4.0" />
+    <!-- Pulled in transitively by Testcontainers but referenced directly from
+         DbProviderFixtureBase for the Docker availability probe. Pin explicitly
+         so a future Testcontainers update can't silently break compilation. -->
+    <PackageReference Include="Docker.DotNet.Enhanced" Version="3.126.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Version>0.2.0</Version>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1812;CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.DbClient\Wolfgang.Etl.DbClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.4.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="4.4.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Originally opened as the per-RDBMS integration test project, this PR accreted the benchmark and README content from the squash-merges of #60 and #61 into its branch. Title and description updated to reflect what actually merges. Three logical chunks:

## 1. Integration test project (this PR's original scope — #59 split)
`Wolfgang.Etl.DbClient.Tests.Integration` — class-fixture-based suites for SQL Server, PostgreSQL, MySQL, and SQLite running against real containers via [Testcontainers .NET](https://dotnet.testcontainers.org/). SQLite uses an in-memory connection (no container).

- Docker availability is pre-probed (`Docker.DotNet.System.PingAsync`); only "daemon unreachable" turns into a skip with a diagnostic reason. Schema regressions / bad image tags fail loud instead of silently skipping.
- Container images pinned to specific patches for CI reproducibility (`mssql 2022-CU20-ubuntu-22.04`, `postgres:16.4-alpine`, `mysql:8.0.39`).
- Assembly-level `[CollectionBehavior(DisableTestParallelization = true)]` so a plain `dotnet test` locally won't spin three containers concurrently.
- Companion changes: `Wolfgang.Etl.DbClient.slnx` adds the project; `scripts/build-pr.ps1` gains a "Step 3.5" that detects Docker and runs the per-RDBMS × per-TFM matrix locally.

## 2. Benchmarks: per-RDBMS suite (originally #60, merged into this branch)
`Wolfgang.Etl.DbClient.Benchmarks` refactored so the same Extractor/Loader benchmarks run against any of the four RDBMSes, selected at runtime via `ETL_DBCLIENT_BENCHMARK_RDBMS`. New `BenchmarkContext` centralises provider factory + per-dialect DDL + seeding. `LoaderBenchmarks.IterationSetup` is async and returns the Task directly (no `.GetAwaiter().GetResult()`, no `async + single await`).

## 3. README "Tested Databases" section (originally #61, merged into this branch)
Inserted between Features and Target Frameworks. Lists every RDBMS with version, driver, a workflow-status badge, and a link to the per-RDBMS benchmark chart on gh-pages. Column header reads "CI Status" (workflow-wide); per-RDBMS dynamic badges remain a follow-up issue.

## Local verification (Windows + Docker)
- `dotnet build -c Release`: 0 warnings, 0 errors
- Unit tests: 141 / 141 ✅
- Integration tests (net10.0): 28 / 28 ✅ across SQL Server 2022 / Postgres 16 / MySQL 8 / SQLite
- Integration tests (net8.0): SQLite + Postgres slices verified 7 / 7 each
- Docker-down skip path: 28 / 28 cleanly skipped with diagnostic reason

## Follow-up issues
- #62: extend matrix to MariaDB / Oracle / CockroachDB
- #63: per-RDBMS dynamic CI status badges (replace the workflow-wide badge in the README matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)