### PR TITLE
ci(pr.yaml): per-RDBMS integration matrix job + filename exclusion

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -454,19 +454,26 @@ jobs:
             exit 0
           fi
 
-          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+          # Match on the filename, not the path, so an unrelated parent directory
+          # containing the substring "Tests.Integration" won't be excluded.
+          mapfile -d '' -t test_projects < <(find ./tests -type f \
+            \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) \
+            ! -name "*.Tests.Integration.csproj" \
+            ! -name "*.Tests.Integration.vbproj" \
+            ! -name "*.Tests.Integration.fsproj" \
+            -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
             echo "ℹ️  No test projects found under ./tests — skipping test stage."
             exit 0
           fi
-          
+
           echo "=========================================="
-          echo "Found test projects:"
+          echo "Found test projects (integration suites are run in a separate job):"
           echo "=========================================="
           printf '%s\n' "${test_projects[@]}"
           echo ""
-          
+
           for test_proj in "${test_projects[@]}"; do
             echo "=========================================="
             echo "Testing project: $test_proj"
@@ -597,6 +604,68 @@ jobs:
           path: |
             src/**/bin/Release
             tests/**/bin/Release
+
+  # ============================================================================
+  # RDBMS INTEGRATION: per-database job using Testcontainers (Linux only)
+  # Runs in parallel with Stage 1. Does not gate Stage 2 / Stage 3 so a flaky
+  # container start cannot block the multi-TFM unit matrix.
+  # ============================================================================
+  test-integration:
+    name: "Integration / ${{ matrix.rdbms }} (${{ matrix.tfm }})"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        rdbms: [sqlserver, postgres, mysql, sqlite]
+        tfm: [net8.0, net10.0]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Locate integration project
+        id: locate
+        shell: bash
+        run: |
+          proj=$(find ./tests -type f -name "*.Tests.Integration.csproj" | head -n1)
+          if [ -z "$proj" ]; then
+            echo "ℹ️  No integration project found — skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Integration project: $proj"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "project=$proj" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
+        if: steps.locate.outputs.found == 'true'
+        run: |
+          dotnet test "${{ steps.locate.outputs.project }}" \
+            --configuration Release \
+            --framework ${{ matrix.tfm }} \
+            --filter "Category=${{ matrix.rdbms }}" \
+            --logger "console;verbosity=normal" \
+            --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
+            --results-directory "./TestResults-Integration"
+
+      - name: Upload integration test results
+        if: always() && steps.locate.outputs.found == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-${{ matrix.rdbms }}-${{ matrix.tfm }}-trx
+          path: TestResults-Integration/
 
   # ============================================================================
   # STAGE 2: Windows - All .NET Tests (Gated by Stage 1)
@@ -734,7 +803,11 @@ jobs:
             exit 0
           }
 
-          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj')
+          # Integration suites (*.Tests.Integration.csproj) live in a separate Linux-only
+          # job that provisions database containers via Testcontainers; not run here.
+          # Filter by file name, not path, so an unrelated parent directory containing the
+          # substring "Tests.Integration" won't be excluded.
+          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' | Where-Object { $_.Name -notlike '*.Tests.Integration.csproj' })
 
           if (@($testProjects).Count -eq 0) {
             Write-Host "ℹ️  No test projects found under ./tests — skipping test stage."
@@ -1118,7 +1191,12 @@ jobs:
           test_projects=()
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
-          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+          done < <(find ./tests -type f \
+            \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) \
+            ! -name "*.Tests.Integration.csproj" \
+            ! -name "*.Tests.Integration.vbproj" \
+            ! -name "*.Tests.Integration.fsproj" \
+            -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
             echo "ℹ️  No test projects found under ./tests — skipping test stage."

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -613,6 +613,9 @@ jobs:
   test-integration:
     name: "Integration / ${{ matrix.rdbms }} (${{ matrix.tfm }})"
     runs-on: ubuntu-latest
+    # Ceiling protects against a stuck container start (esp. mssql / mysql)
+    # consuming the default 6-hour GitHub Actions limit per matrix cell.
+    timeout-minutes: 25
     needs: detect-projects
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     strategy:
@@ -639,7 +642,12 @@ jobs:
         id: locate
         shell: bash
         run: |
-          proj=$(find ./tests -type f -name "*.Tests.Integration.csproj" | head -n1)
+          # Match all three project extensions so a future VB/F# rewrite is found.
+          proj=$(find ./tests -type f \
+            \( -name "*.Tests.Integration.csproj" \
+            -o -name "*.Tests.Integration.vbproj" \
+            -o -name "*.Tests.Integration.fsproj" \) \
+            | head -n1)
           if [ -z "$proj" ]; then
             echo "ℹ️  No integration project found — skipping."
             echo "found=false" >> "$GITHUB_OUTPUT"
@@ -807,7 +815,7 @@ jobs:
           # job that provisions database containers via Testcontainers; not run here.
           # Filter by file name, not path, so an unrelated parent directory containing the
           # substring "Tests.Integration" won't be excluded.
-          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' | Where-Object { $_.Name -notlike '*.Tests.Integration.csproj' })
+          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' | Where-Object { $_.Name -notmatch '\.Tests\.Integration\.(cs|vb|fs)proj$' })
 
           if (@($testProjects).Count -eq 0) {
             Write-Host "ℹ️  No test projects found under ./tests — skipping test stage."


### PR DESCRIPTION
**Replaces #59 (part 1 of 2). Targets `main` directly.** This PR contains only the `.github/workflows/pr.yaml` change. It will trip the `detect-projects` protected-files guard and requires a maintainer admin-bypass-merge.

## Summary
Adds the `test-integration` matrix job and tightens the Stage 1 / 2 / 3 test-loop exclusions in `pr.yaml`:

- **New `test-integration` job** — Linux-only, parallel to Stage 1, **non-gating** so a flaky container start can't block the multi-TFM unit matrix.
  - Matrix: `rdbms ∈ {sqlserver, postgres, mysql, sqlite} × tfm ∈ {net8.0, net10.0}` = 8 jobs.
  - Job-name pattern `Integration / <rdbms> (<tfm>)` so per-RDBMS / per-TFM CI feedback is visible at a glance.
  - `timeout-minutes: 25` per cell so a stuck container start fails fast instead of burning the default 6-hour ceiling.
  - The "Locate integration project" step matches `*.Tests.Integration.{cs,vb,fs}proj` and sets `found=false` if missing — so the job is a clean no-op until the integration project lands in #64.
- **Stage 1 / Stage 2 / Stage 3 test loops** now exclude any project named `*.Tests.Integration.{cs,vb,fs}proj` (filename match, not path substring) so the integration project only runs in its dedicated Linux job — no time wasted spinning up Linux containers from a Windows or macOS runner.

## Backward compatibility
The pr.yaml change is safe to merge **before** #64. The integration project doesn't exist yet on main, so:
- The `Locate` step finds nothing → all 8 matrix cells skip cleanly (each as a green no-op).
- The Stage 1 / 2 / 3 exclusion filters have nothing to exclude → existing unit tests run unchanged.

Once #64 merges next, the very next PR will actually exercise the matrix.

## Why merge first?
Workflow files trip `detect-projects` regardless of which order they merge in. Merging this PR first means #64 (the test project) can ride a CI greenlight against the *new* `pr.yaml` — its integration project goes straight into the dedicated `test-integration` job instead of slowing down Stage 1's unit-test loop.

## Test plan
- [ ] Workflow YAML lints / renders correctly (verified by GitHub on push).
- [ ] All 8 `Integration / <rdbms> (<tfm>)` matrix cells appear and report "skipped" (no integration project) on this PR's CI run.
- [ ] After merge, kick off a no-op PR and confirm all eight cells still show skipped (still no integration project on main).
- [ ] After #64 merges, the next PR will exercise the 8 cells against the real integration project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)