### PR TITLE
ci: add benchmarks.yaml + protect dev/ in docfx gh-pages cleanup

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,220 @@
+name: Benchmarks (per-RDBMS) → gh-pages
+
+# Run BenchmarkDotNet against each supported RDBMS and publish the results to
+# gh-pages so we can track perf trends over time. Charts land at
+# https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/<rdbms>/.
+#
+# Triggers:
+#   - workflow_dispatch — ad-hoc runs from the Actions tab
+#   - tag push (v*)      — auto-snapshot at release time
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write    # benchmark-action pushes commits to gh-pages
+  deployments: write # benchmark-action records a deployment
+
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: false
+
+# Jobs are intentionally serialized via `needs:` so they don't race to push to
+# gh-pages. benchmark-action/github-action-benchmark commits + force-pushes the
+# benchmark history file (`data.js`) per run; parallel pushes would either
+# clobber each other or hit non-fast-forward errors. Per-provider charts each
+# live under their own `dev/bench/<rdbms>/` directory, but the action also
+# updates a shared metadata file so chaining is the safest model.
+jobs:
+
+  # ============================================================================
+  # SQLite (no container needed)
+  # ============================================================================
+  benchmark-sqlite:
+    name: "Benchmarks / sqlite"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: sqlite
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        with:
+          name: "ExtractorBenchmarks (sqlite)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/sqlite
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # SQL Server
+  # ============================================================================
+  benchmark-sqlserver:
+    name: "Benchmarks / sqlserver"
+    runs-on: ubuntu-latest
+    needs: benchmark-sqlite
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Bench-SA-Pass-1!"
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P Bench-SA-Pass-1! -Q 'SELECT 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: sqlserver
+          ETL_DBCLIENT_BENCHMARK_MSSQL: "Server=localhost,1433;Database=master;User Id=sa;Password=Bench-SA-Pass-1!;Encrypt=False;TrustServerCertificate=True"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        with:
+          name: "ExtractorBenchmarks (sqlserver)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/sqlserver
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # PostgreSQL
+  # ============================================================================
+  benchmark-postgres:
+    name: "Benchmarks / postgres"
+    runs-on: ubuntu-latest
+    needs: benchmark-sqlserver
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: bench
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: postgres
+          ETL_DBCLIENT_BENCHMARK_PG: "Host=localhost;Port=5432;Database=bench;Username=postgres;Password=postgres"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        with:
+          name: "ExtractorBenchmarks (postgres)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/postgres
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # MySQL
+  # ============================================================================
+  benchmark-mysql:
+    name: "Benchmarks / mysql"
+    runs-on: ubuntu-latest
+    needs: benchmark-postgres
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+          MYSQL_DATABASE: bench
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost -uroot -pmysql"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: mysql
+          ETL_DBCLIENT_BENCHMARK_MYSQL: "Server=localhost;Port=3306;Database=bench;User Id=root;Password=mysql;SslMode=None"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        with:
+          name: "ExtractorBenchmarks (mysql)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/mysql
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -260,11 +260,14 @@ jobs:
           #   CNAME        – Custom domain config (if present)
           #   .nojekyll    – Tells GitHub Pages not to run Jekyll
           #   versions/    – All versioned docs (v1.0.0/, latest/, etc.)
+          #   dev/         – BenchmarkDotNet charts published by benchmarks.yaml
+          #                  (lives at dev/bench/<rdbms>/ and must survive doc redeploys)
           Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
             $_.Name -ne '.git' -and
             $_.Name -ne 'CNAME' -and
             $_.Name -ne '.nojekyll' -and
-            $_.Name -ne 'versions'
+            $_.Name -ne 'versions' -and
+            $_.Name -ne 'dev'
           } | Remove-Item -Recurse -Force
 
           git -C "$WORK_DIR" add -A
@@ -347,9 +350,10 @@ jobs:
             New-Item -ItemType Directory -Force -Path $WORK_DIR | Out-Null
           }
 
-          # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME
+          # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME, dev/
+          # (dev/ holds BenchmarkDotNet charts published by benchmarks.yaml.)
           Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
-            $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions')
+            $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions', 'dev')
           } | Remove-Item -Recurse -Force
 
           # Ensure .nojekyll exists so GitHub Pages does not run Jekyll


### PR DESCRIPTION
**Extracted from #64.** This PR contains only the two protected workflow files so it can ride the maintainer admin-bypass-merge dance on its own. Once it merges, rebasing #64 onto main will make those two files a no-op diff and #64 can take a normal merge.

## Changes
- **`.github/workflows/benchmarks.yaml`** (NEW) — Per-RDBMS BenchmarkDotNet suite publishing to gh-pages at `dev/bench/<rdbms>/`.
  - Triggers: `workflow_dispatch` + `push: tags: ['v*']`. Zero impact on PR runs.
  - Four jobs (sqlite, sqlserver, postgres, mysql), chained via `needs:` so gh-pages pushes are serial (avoids races on the shared metadata commit).
  - `actions/checkout@v6` uses `persist-credentials: false`.
  - `benchmark-action/github-action-benchmark` pinned to SHA `d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7` (v1.20.4) per supply-chain policy.
- **`.github/workflows/docfx.yaml`** (modified) — adds `'dev'` to the keep-list in both gh-pages cleanup steps so a release-time docs redeploy doesn't wipe accumulated benchmark history under `dev/bench/<rdbms>/`.

## Backward compatibility
- `benchmarks.yaml` only runs on tag pushes and manual dispatch — no impact on PR or merge runs.
- `docfx.yaml` change is additive (adds an item to a keep-list); existing docs deployments still preserve `versions/`, `.nojekyll`, etc.

## Why ride bypass alone?
Workflow files always trip the `detect-projects` protected-file guard regardless of how innocuous the change. Same documented dance as #65: maintainer admin-bypass-merge, then the downstream PR can run clean CI against the new tip.

## Test plan
- [ ] After merge, kick off a no-op PR to confirm `pr.yaml` still passes.
- [ ] After merge, run `gh workflow run benchmarks.yaml -r main` once to confirm the four sequential jobs each publish to `dev/bench/<rdbms>/` on `gh-pages` without conflicts.
- [ ] After merge, the next release-time `docfx.yaml` deploy should leave `dev/` intact on gh-pages.
- [ ] Rebase #64 onto the new main → its diff vs main should no longer include either workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)