### PR TITLE
ci(pr.yaml): add 'Integration (all)' aggregator job for stable required check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -686,6 +686,35 @@ jobs:
           path: TestResults-Integration/
 
   # ============================================================================
+  # INTEGRATION AGGREGATOR
+  # A single stable-named job whose only purpose is to roll up every cell of
+  # the test-integration matrix into one pass/fail signal. Mark THIS one
+  # required on the branch ruleset — the matrix can grow (MariaDB, Oracle,
+  # CockroachDB, …) or change TFMs without breaking the required-check name.
+  # ============================================================================
+  test-integration-all:
+    name: "Integration (all)"
+    runs-on: ubuntu-latest
+    needs: [detect-projects, test-integration]
+    # Run even when a matrix cell failed/cancelled so this job can report the
+    # rollup result instead of silently being marked "skipped". The if: predicate
+    # mirrors test-integration's so this aggregator is genuinely skipped (not
+    # failed) on the repo-template repo or on repos without .NET projects.
+    if: >-
+      always() &&
+      github.repository != 'Chris-Wolfgang/repo-template' &&
+      needs.detect-projects.outputs.has-projects == 'true'
+    steps:
+      - name: Check matrix result
+        run: |
+          result="${{ needs.test-integration.result }}"
+          echo "Aggregated test-integration result: $result"
+          if [ "$result" != "success" ]; then
+            echo "::error::At least one integration matrix cell did not succeed (result=$result)"
+            exit 1
+          fi
+
+  # ============================================================================
   # STAGE 2: Windows - All .NET Tests (Gated by Stage 1)
   # ============================================================================
   test-windows:


### PR DESCRIPTION
Adds a single rollup job to `pr.yaml` so the branch ruleset can mark **one** stable check as required for all integration matrix cells, instead of having to list each `Integration / <rdbms> (<tfm>)` cell individually.

## What it does
- New job `test-integration-all` (name shown in CI: **`Integration (all)`**).
- `needs: [detect-projects, test-integration]`.
- `if: always()` — runs even when a matrix cell fails so the rollup can report failure instead of being marked "skipped" (which the ruleset would treat as missing).
- Exits 1 unless every matrix cell succeeded.

## Why
Each matrix cell name (`Integration / sqlserver (net8.0)`, etc.) is stored **verbatim** in the ruleset. Any change to the matrix — adding MariaDB / Oracle (follow-up #62), dropping a TFM, renaming a provider — would silently invalidate those names and block every PR with "missing required status check" until a maintainer updates the ruleset by hand.

With this aggregator, the matrix can grow or shrink freely; only the single **`Integration (all)`** check stays required.

## Follow-up after merge
Flip the branch ruleset's required-checks list to include `Integration (all)` (and **remove** the individual `Integration / *` entries if you'd added them previously). The eight matrix cells still run on every PR — they're just no longer individually required.

## Test plan
- [ ] CI on this PR shows nine new Integration entries: 8 cells + 1 `Integration (all)` rollup, all green.
- [ ] After merge, deliberately break one matrix cell in a test PR (e.g. change the SqlServer image tag to a non-existent one) and confirm `Integration (all)` fails red.
- [ ] Confirm `Integration (all)` is "skipped" — not "failed" — when `detect-projects.outputs.has-projects` is false (template repos without csprojs).

⚠️ This PR touches `.github/workflows/pr.yaml` → trips the `detect-projects` protected-files guard → requires maintainer admin-bypass-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)