### PR TITLE
fix(examples): clear MA0004 / VSTHRD200 warnings + enforce TreatWarningsAsErrors in CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -428,14 +428,14 @@ jobs:
             if [ "$framework_count" -eq 1 ]; then
               # Single target framework - build normally
               echo "  Target framework: $frameworks"
-              dotnet build "$proj" --no-restore --configuration Release || exit 1
+              dotnet build "$proj" --no-restore --configuration Release -p:TreatWarningsAsErrors=true || exit 1
             else
               # Multi-targeting project - build each compatible framework separately
               echo "  Target frameworks (multi-targeting): $(echo "$frameworks" | tr '\n' ' ')"
               while IFS= read -r fw; do
                 [ -z "$fw" ] && continue
                 echo "  Building framework: $fw"
-                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" || exit 1
+                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" -p:TreatWarningsAsErrors=true || exit 1
               done <<< "$frameworks"
             fi
           done
@@ -797,7 +797,7 @@ jobs:
         run: dotnet restore
 
       - name: Build solution
-        run: dotnet build --no-restore --configuration Release
+        run: dotnet build --no-restore --configuration Release -p:TreatWarningsAsErrors=true
 
       - name: Run all .NET tests (.NET 5.0-10.0 and Framework 4.6.2-4.8.1)
         shell: pwsh
@@ -1171,14 +1171,14 @@ jobs:
             if [ "$framework_count" -eq 1 ]; then
               # Single target framework - build normally
               echo "  Target framework: $frameworks"
-              dotnet build "$proj" --no-restore --configuration Release || exit 1
+              dotnet build "$proj" --no-restore --configuration Release -p:TreatWarningsAsErrors=true || exit 1
             else
               # Multi-targeting project - build each compatible framework separately
               echo "  Target frameworks (multi-targeting): $(echo "$frameworks" | tr '\n' ' ')"
               while IFS= read -r fw; do
                 [ -z "$fw" ] && continue
                 echo "  Building framework: $fw"
-                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" || exit 1
+                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" -p:TreatWarningsAsErrors=true || exit 1
               done <<< "$frameworks"
             fi
           done

--- a/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Program.cs
@@ -12,7 +12,7 @@ using Wolfgang.Etl.DbClient.Example.AutoSql;
 // automatically from data annotation attributes on the record type.
 
 using var connection = new SqliteConnection("Data Source=:memory:");
-await connection.OpenAsync();
+await connection.OpenAsync().ConfigureAwait(false);
 
 // Create the Products table
 using (var cmd = connection.CreateCommand())
@@ -24,7 +24,7 @@ using (var cmd = connection.CreateCommand())
             category TEXT NOT NULL,
             price REAL NOT NULL
         );";
-    await cmd.ExecuteNonQueryAsync();
+    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 }
 
 Console.WriteLine("=== Auto-SQL Example: Extract and Load with attribute-based SQL ===");
@@ -36,9 +36,9 @@ var loader = new DbLoader<ProductRecord>(connection, WriteMode.Insert);
 Console.WriteLine($"Loader SQL: {loader.CommandText}");
 Console.WriteLine();
 
-await loader.LoadAsync(SeedProducts());
+await loader.LoadAsync(SeedProductsAsync()).ConfigureAwait(false);
 
-static async IAsyncEnumerable<ProductRecord> SeedProducts()
+static async IAsyncEnumerable<ProductRecord> SeedProductsAsync()
 {
     var products = new[]
     {
@@ -52,7 +52,7 @@ static async IAsyncEnumerable<ProductRecord> SeedProducts()
     foreach (var p in products)
     {
         Console.WriteLine($"  Inserting: {p.Name} ({p.Category}) ${p.Price}");
-        await Task.CompletedTask;
+        await Task.CompletedTask.ConfigureAwait(false);
         yield return p;
     }
 }
@@ -65,7 +65,7 @@ Console.WriteLine($"Extractor SQL: {extractor.CommandText}");
 Console.WriteLine();
 
 Console.WriteLine("All products:");
-await foreach (var product in extractor.ExtractAsync())
+await foreach (var product in extractor.ExtractAsync().ConfigureAwait(false))
 {
     Console.WriteLine($"  [{product.Id}] {product.Name} ({product.Category}): ${product.Price}");
 }

--- a/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Program.cs
@@ -14,7 +14,7 @@ using Wolfgang.Etl.DbClient.Example.UpdateWithTransaction;
 // 3. Progress reporting during loading
 
 using var connection = new SqliteConnection("Data Source=:memory:");
-await connection.OpenAsync();
+await connection.OpenAsync().ConfigureAwait(false);
 
 // Create and seed the Inventory table
 using (var cmd = connection.CreateCommand())
@@ -31,7 +31,7 @@ using (var cmd = connection.CreateCommand())
         INSERT INTO Inventory VALUES ('SKU-003', 'Gadget X',  75, '2026-01-01');
         INSERT INTO Inventory VALUES ('SKU-004', 'Gadget Y',  25, '2026-01-01');
         INSERT INTO Inventory VALUES ('SKU-005', 'Doohickey', 200, '2026-01-01');";
-    await cmd.ExecuteNonQueryAsync();
+    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 }
 
 Console.WriteLine("=== Update with Transaction Example ===");
@@ -39,10 +39,10 @@ Console.WriteLine();
 
 // Show current state
 Console.WriteLine("Before update:");
-await PrintInventory(connection);
+await PrintInventoryAsync(connection).ConfigureAwait(false);
 
 // Create a caller-managed transaction
-using var transaction = await connection.BeginTransactionAsync();
+using var transaction = await connection.BeginTransactionAsync().ConfigureAwait(false);
 
 // Auto-generates:
 // UPDATE Inventory SET product_name = @ProductName, quantity = @Quantity, last_updated = @LastUpdated
@@ -57,16 +57,16 @@ Console.WriteLine($"Update SQL: {loader.CommandText}");
 Console.WriteLine();
 
 // Apply inventory adjustments within the caller's transaction
-await loader.LoadAsync(GetAdjustments());
+await loader.LoadAsync(GetAdjustmentsAsync()).ConfigureAwait(false);
 
 // Commit the transaction (caller controls the lifetime)
-await transaction.CommitAsync();
+await transaction.CommitAsync().ConfigureAwait(false);
 
 Console.WriteLine();
 Console.WriteLine("After update:");
-await PrintInventory(connection);
+await PrintInventoryAsync(connection).ConfigureAwait(false);
 
-static async IAsyncEnumerable<InventoryRecord> GetAdjustments()
+static async IAsyncEnumerable<InventoryRecord> GetAdjustmentsAsync()
 {
     var adjustments = new[]
     {
@@ -78,17 +78,17 @@ static async IAsyncEnumerable<InventoryRecord> GetAdjustments()
     foreach (var adj in adjustments)
     {
         Console.WriteLine($"  Updating {adj.Sku}: quantity {adj.Quantity}");
-        await Task.CompletedTask;
+        await Task.CompletedTask.ConfigureAwait(false);
         yield return adj;
     }
 }
 
-static async Task PrintInventory(SqliteConnection conn)
+static async Task PrintInventoryAsync(SqliteConnection conn)
 {
     using var cmd = conn.CreateCommand();
     cmd.CommandText = "SELECT sku, product_name, quantity, last_updated FROM Inventory ORDER BY sku";
-    using var reader = await cmd.ExecuteReaderAsync();
-    while (await reader.ReadAsync())
+    using var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
+    while (await reader.ReadAsync().ConfigureAwait(false))
     {
         Console.WriteLine($"  {reader.GetString(0)}: {reader.GetString(1)} — qty {reader.GetInt32(2)} (updated {reader.GetString(3)})");
     }


### PR DESCRIPTION
Two-part fix for the analyzer warnings that surfaced in PR #64's Stage 2 (Windows) build output but did not fail CI:

## 1. Example code cleanup
`examples/Wolfgang.Etl.DbClient.Example.AutoSql/Program.cs` and `examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Program.cs` were missing the same warning hygiene the third example project (`Example`) had via its `NoWarn` list. Instead of suppressing the warnings, fixed them:

- **MA0004** — added `.ConfigureAwait(false)` to every awaited call in both Program.cs files (top-level statements, helper methods, and iterator bodies).
- **VSTHRD200** — renamed helpers and iterators to follow the Async convention:
  - `SeedProducts` → `SeedProductsAsync`
  - `GetAdjustments` → `GetAdjustmentsAsync`
  - `PrintInventory` → `PrintInventoryAsync`

The third example project (`Wolfgang.Etl.DbClient.Example`) was already silenced via its own `NoWarn` list and is intentionally left untouched.

## 2. Server-side enforcement
Every `dotnet build` invocation in `.github/workflows/pr.yaml` now passes `-p:TreatWarningsAsErrors=true` (5 locations). `Directory.Build.props` already enables this for Release builds, but project-level overrides and analyzer severity quirks can let warnings slip through silently — explicitly forcing it on the CLI eliminates that drift.

## Local verification
- `dotnet build -c Release` of the full solution: **0 warnings, 0 errors** (was previously emitting MA0004/VSTHRD200 in CI Stage 2 even though local was clean — clear inconsistency now removed).
- Both example apps still run end-to-end against in-memory SQLite.

⚠️ This PR touches `.github/workflows/pr.yaml` → trips the `detect-projects` protected-files guard → requires maintainer admin-bypass-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)