### PR TITLE
ci(pr.yaml): close warnings-as-errors gap on dotnet test

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -504,9 +504,15 @@ jobs:
               [ -z "$fw" ] && continue
               echo "Testing framework: $fw"
               
+              # --no-build / --no-restore: the build step above already produced
+              # binaries for every TFM with -p:TreatWarningsAsErrors=true; the
+              # implicit `dotnet test` build wouldn't carry that flag, so an
+              # analyzer warning introduced during test build could slip through.
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
+                --no-build \
+                --no-restore \
                 --collect:"XPlat Code Coverage" \
                 --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
@@ -660,10 +666,14 @@ jobs:
       - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
         if: steps.locate.outputs.found == 'true'
         run: |
+          # This job has no prior build step, so dotnet test compiles inline.
+          # Pass -p:TreatWarningsAsErrors=true so analyzer warnings introduced
+          # in the integration project still fail CI.
           dotnet test "${{ steps.locate.outputs.project }}" \
             --configuration Release \
             --framework ${{ matrix.tfm }} \
             --filter "Category=${{ matrix.rdbms }}" \
+            -p:TreatWarningsAsErrors=true \
             --logger "console;verbosity=normal" \
             --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
             --results-directory "./TestResults-Integration"
@@ -863,10 +873,15 @@ jobs:
             foreach ($fw in $frameworks) {
               Write-Host "Testing framework: $fw" -ForegroundColor Yellow
 
+              # --no-build / --no-restore: the build step above already produced
+              # binaries for every TFM with -p:TreatWarningsAsErrors=true; the
+              # implicit dotnet test build wouldn't carry that flag.
               if ($fw -match '^net([5-9]|[1-9][0-9]+)\.') {
                 dotnet test $testProj.FullName `
                   --configuration Release `
                   --framework $fw `
+                  --no-build `
+                  --no-restore `
                   --collect:"XPlat Code Coverage" `
                   --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
@@ -875,6 +890,8 @@ jobs:
                 dotnet test $testProj.FullName `
                   --configuration Release `
                   --framework $fw `
+                  --no-build `
+                  --no-restore `
                   --logger "console;verbosity=normal"
               }
 
@@ -1248,9 +1265,14 @@ jobs:
               [ -z "$fw" ] && continue
               echo "Testing framework: $fw"
 
+              # --no-build / --no-restore: the build step above already produced
+              # binaries for every TFM with -p:TreatWarningsAsErrors=true; the
+              # implicit dotnet test build wouldn't carry that flag.
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
+                --no-build \
+                --no-restore \
                 --collect:"XPlat Code Coverage" \
                 --settings coverlet.runsettings \
                 --results-directory "./TestResults" \


### PR DESCRIPTION
Follow-up to #69: the review-cycle fix for Copilot's `dotnet test` feedback wasn't part of #69's merge commit (it landed on the branch *after* the merge clicked). This PR ports just that change.

## What this PR adds
`-p:TreatWarningsAsErrors=true` was added to every `dotnet build` invocation in #69, but `dotnet test` does an implicit rebuild by default — that implicit build wouldn't carry the flag, leaving a gap. Two patterns applied across the five `dotnet test` invocations:

- **Stages 1 / 2 / 3 (4 invocations)** — the prior step in each job already runs `dotnet build` with `-p:TreatWarningsAsErrors=true` for every TFM. Added `--no-build --no-restore` to the test invocation so it just executes, no second build.
- **`test-integration` (1 invocation)** — that job has no prior build step (matrix cells just check out + setup .NET + run `dotnet test`). `--no-build` would fail. Instead passes `-p:TreatWarningsAsErrors=true` directly so the implicit build still gates on warnings.

Net effect: every compilation path in CI now enforces TreatWarningsAsErrors with no gaps.

## Side benefit
`--no-build --no-restore` on Stages 1/2/3 also shaves a chunk off CI time per test run — dotnet test no longer re-evaluates / re-compiles after the dedicated build step already produced the binaries.

⚠️ Touches `.github/workflows/pr.yaml` → trips the `detect-projects` protected-files guard → requires maintainer admin-bypass-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)