### PR TITLE
feat(integration): add MariaDB to the matrix (#62) — non-workflow part

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ an in-memory connection instead of a container.
 | **SQL Server** | 2022 | `Microsoft.Data.SqlClient` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/sqlserver/) |
 | **PostgreSQL** | 16 | `Npgsql` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
 | **MySQL** | 8.0 | `MySqlConnector` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
+| **MariaDB** | 11.4 | `MySqlConnector` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mariadb/) |
 
 > **About these badges.** GitHub doesn't natively render a different status per matrix
 > job, so each row currently shows the *overall* `pr.yaml` status. If any of the four

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
@@ -34,8 +34,10 @@ public static class BenchmarkContext
             "sqlserver" => new SqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MSSQL")),
             "postgres"  => new NpgsqlConnection(Require("ETL_DBCLIENT_BENCHMARK_PG")),
             "mysql"     => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MYSQL")),
+            // MariaDB shares the MySQL wire protocol — same MySqlConnector driver.
+            "mariadb"   => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MARIADB")),
             "sqlite"    => new SqliteConnection("Data Source=:memory:"),
-            _           => throw new InvalidOperationException($"Unknown ETL_DBCLIENT_BENCHMARK_RDBMS value '{Rdbms}'. Expected one of: sqlite, sqlserver, postgres, mysql."),
+            _           => throw new InvalidOperationException($"Unknown ETL_DBCLIENT_BENCHMARK_RDBMS value '{Rdbms}'. Expected one of: sqlite, sqlserver, postgres, mysql, mariadb."),
         };
 
         conn.Open();
@@ -55,6 +57,8 @@ public static class BenchmarkContext
             "postgres"  => ("DROP TABLE IF EXISTS contract_items;",
                             "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INTEGER NOT NULL);"),
             "mysql"     => ("DROP TABLE IF EXISTS contract_items;",
+                            "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);"),
+            "mariadb"   => ("DROP TABLE IF EXISTS contract_items;",
                             "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);"),
             _           => ("DROP TABLE IF EXISTS contract_items;",
                             "CREATE TABLE contract_items (name TEXT NOT NULL, value INTEGER NOT NULL);"),

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -244,7 +244,7 @@ if (-not $SkipIntegration -and -not $SkipTests -and $failed.Count -eq 0) {
         # SQLite needs no Docker; the other providers do. Build the list accordingly.
         $rdbmsList = @('sqlite')
         if ($dockerOk) {
-            $rdbmsList += @('sqlserver', 'postgres', 'mysql')
+            $rdbmsList += @('sqlserver', 'postgres', 'mysql', 'mariadb')
         }
         else {
             Write-Host "⚠️  Docker daemon is not reachable — running only the SQLite slice." -ForegroundColor Yellow

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MariaDbFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MariaDbFixture.cs
@@ -1,0 +1,76 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using MySqlConnector;
+using Testcontainers.MariaDb;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+/// <summary>
+/// MariaDB fixture. Uses the same <c>MySqlConnector</c> driver as
+/// <see cref="MySqlFixture"/> because MariaDB and MySQL share the same wire
+/// protocol; the only difference here is the container image.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class MariaDbFixture : DbProviderFixtureBase
+{
+    private MariaDbContainer? _container;
+
+    public override string ProviderName => "mariadb";
+
+
+
+    protected override async Task StartAsync()
+    {
+        // Pinned patch tag for reproducible CI. Bump deliberately when
+        // moving to a new minor.
+        _container = new MariaDbBuilder()
+            .WithImage("mariadb:11.4.4")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+    }
+
+
+
+    protected override async Task StopAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var conn = new MySqlConnection(_container!.GetConnectionString());
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "DROP TABLE IF EXISTS contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "@name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "@value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/MariaDbTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/MariaDbTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("MariaDb")]
+public class MariaDbCollection : ICollectionFixture<MariaDbFixture> { }
+
+
+
+[Collection("MariaDb")]
+[Trait("Category", "mariadb")]
+[ExcludeFromCodeCoverage]
+public sealed class MariaDbExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly MariaDbFixture _fixture;
+    public MariaDbExtractorTests(MariaDbFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("MariaDb")]
+[Trait("Category", "mariadb")]
+[ExcludeFromCodeCoverage]
+public sealed class MariaDbLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly MariaDbFixture _fixture;
+    public MariaDbLoaderTests(MariaDbFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Testcontainers.MsSql" Version="4.4.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
     <PackageReference Include="Testcontainers.MySql" Version="4.4.0" />
+    <PackageReference Include="Testcontainers.MariaDb" Version="4.4.0" />
     <!-- Pulled in transitively by Testcontainers but referenced directly from
          DbProviderFixtureBase for the Docker availability probe. Pin explicitly
          so a future Testcontainers update can't silently break compilation. -->


### PR DESCRIPTION
**Companion to #72. Merge order: this PR first, then #72.** (Originally framed the other way, but that ordering would activate the `mariadb` matrix entry in pr.yaml before MariaDB tests exist on main — `dotnet test --filter Category=mariadb` exits non-zero on zero matches. Reversing the order lands the tests as dormant code first; #72 then activates the matrix cell.)

This PR is the non-workflow part of the MariaDB addition (#62). Zero protected files; runs CI normally.

## Changes
- **New `MariaDbFixture`** — clones `MySqlFixture`, swaps to `Testcontainers.MariaDb` (4.4.0). Image pinned to `mariadb:11.4.4` (real patch tag, matching the MySQL convention).
- **New `MariaDbTests`** — `[Trait("Category", "mariadb")]` + collection definition; inherits the standard extractor/loader contract base classes.
- **`Tests.Integration.csproj`** — adds `Testcontainers.MariaDb` 4.4.0.
- **`BenchmarkContext`** — new `mariadb` arm in `OpenConnection` / `ResetSchemaAsync`; env var `ETL_DBCLIENT_BENCHMARK_MARIADB`.
- **`scripts/build-pr.ps1`** — added `mariadb` to the `rdbmsList`.
- **`README.md`** — new MariaDB row in the "Tested Databases" matrix, version 11.4.4.

## Verification
Local on net10.0 against `mariadb:11.4.4` container: **7/7 pass in ~24s** (cold image pull). Same contract test base as the other providers.

Once this lands, the MariaDB tests are on main but inert until #72 adds the matrix cell that runs them.

## Follow-up
Remaining `#62` candidates — Oracle XE, CockroachDB, YugabyteDB, DB2, Firebird — not in this PR. CockroachDB / YugabyteDB are the cheapest next entries (both reuse `Npgsql`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)