### PR TITLE
ci: add MariaDB to integration matrix + benchmarks; fix MySQL benchmark auth

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -199,7 +199,9 @@ jobs:
       - name: Run benchmarks
         env:
           ETL_DBCLIENT_BENCHMARK_RDBMS: mysql
-          ETL_DBCLIENT_BENCHMARK_MYSQL: "Server=localhost;Port=3306;Database=bench;User Id=root;Password=mysql;SslMode=None"
+          # AllowPublicKeyRetrieval=True is required for MySQL 8's default
+          # caching_sha2_password auth when not using TLS.
+          ETL_DBCLIENT_BENCHMARK_MYSQL: "Server=localhost;Port=3306;Database=bench;User Id=root;Password=mysql;SslMode=None;AllowPublicKeyRetrieval=True"
         run: |
           dotnet run -c Release \
             --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
@@ -215,6 +217,59 @@ jobs:
           auto-push: true
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench/mysql
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+
+  # ============================================================================
+  # MariaDB (MySQL-compatible wire protocol; same MySqlConnector driver)
+  # ============================================================================
+  benchmark-mariadb:
+    name: "Benchmarks / mariadb"
+    runs-on: ubuntu-latest
+    needs: benchmark-mysql
+    services:
+      mariadb:
+        image: mariadb:11.4.4
+        env:
+          MARIADB_ROOT_PASSWORD: mariadb
+          MARIADB_DATABASE: bench
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: mariadb
+          # Match the MySQL connection-string flags — MariaDB optionally supports
+          # caching_sha2_password since 10.6 and shares the MySqlConnector driver.
+          ETL_DBCLIENT_BENCHMARK_MARIADB: "Server=localhost;Port=3306;Database=bench;User Id=root;Password=mariadb;SslMode=None;AllowPublicKeyRetrieval=True"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        with:
+          name: "ExtractorBenchmarks (mariadb)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/mariadb
           alert-threshold: '150%'
           comment-on-alert: true
           fail-on-alert: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -697,7 +697,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rdbms: [sqlserver, postgres, mysql, sqlite]
+        rdbms: [sqlserver, postgres, mysql, mariadb, sqlite]
         tfm: [net8.0, net10.0]
 
     steps:


### PR DESCRIPTION
**Companion to #71. Merge order: #71 first, this PR second.** (Originally planned the other way, but that ordering would activate the `mariadb` matrix entry before the MariaDB tests exist on main — `dotnet test --filter Category=mariadb` exits non-zero on zero-match.)

## pr.yaml
- `test-integration` matrix: added `mariadb` to the `rdbms` list (cell will be `Integration / mariadb (net8.0|net10.0)`).

## benchmarks.yaml
- New `benchmark-mariadb` job: `mariadb:11.4.4` container, chained after `benchmark-mysql` so the gh-pages pushes stay serial (as designed for the rest of the chain).
- **Real bug fix**: MySQL benchmark connection string was missing `AllowPublicKeyRetrieval=True`. MySQL 8's default `caching_sha2_password` auth requires it for non-SSL connections. This caused the first scheduled `benchmarks.yaml` run (`workflow_dispatch` on 2026-05-17, run 25979490308) to fail at the MySQL job with `MySqlException: Authentication method 'caching_sha2_password' failed`. Mirrored on the new MariaDB connection string for safety (MariaDB 10.6+ optionally supports the same plugin).

## How this lands
1. **Normal-merge #71 first** — its diff has no protected files, CI greenlights the fixture + tests + non-workflow content.
2. Once #71 is on main, the MariaDB tests exist in the integration project but the matrix doesn't reference `mariadb` yet, so existing CI still passes (`Category=mariadb` filter would match but isn't yet invoked).
3. **Bypass-merge this PR second** — activates the `mariadb` matrix cell, MariaDB tests start running in CI.

⚠️ Touches `.github/workflows/*.yaml` → trips the `detect-projects` protected-files guard → requires maintainer admin-bypass-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)