### PR TITLE
ci: add CockroachDB to integration matrix + benchmarks (#62)

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -299,15 +299,25 @@ jobs:
             cockroachdb/cockroach:v24.3.5 \
             start-single-node --insecure --accept-sql-without-tls
           # Wait for /health?ready=1 — SQL port opens a few seconds before
-          # the engine is actually accepting queries.
+          # the engine is actually accepting queries. If it never reports
+          # ready inside the budget, fail the step explicitly (and dump
+          # container logs) so downstream benchmark failures point at the
+          # real cause instead of a misleading connection error.
+          ready=0
           for i in $(seq 1 30); do
             if curl -sf http://localhost:8080/health?ready=1 > /dev/null; then
-              echo "✅ CockroachDB ready after $i attempt(s)"
+              echo "CockroachDB ready after $i attempt(s)"
+              ready=1
               break
             fi
             echo "Waiting for CockroachDB... ($i/30)"
             sleep 2
           done
+          if [ "$ready" != "1" ]; then
+            echo "::error::CockroachDB did not become ready within 60s"
+            docker logs crdb || true
+            exit 1
+          fi
 
       - name: Run benchmarks
         env:

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -273,3 +273,66 @@ jobs:
           alert-threshold: '150%'
           comment-on-alert: true
           fail-on-alert: false
+
+  # ============================================================================
+  # CockroachDB (PostgreSQL wire-compatible; same Npgsql driver)
+  # The cockroachdb/cockroach image's CMD must be 'start-single-node ...', but
+  # GitHub Actions services: blocks can't override CMD, so we launch the
+  # container manually instead.
+  # ============================================================================
+  benchmark-cockroachdb:
+    name: "Benchmarks / cockroachdb"
+    runs-on: ubuntu-latest
+    needs: benchmark-mariadb
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Start CockroachDB
+        run: |
+          docker run -d --name crdb \
+            -p 26257:26257 -p 8080:8080 \
+            cockroachdb/cockroach:v24.3.5 \
+            start-single-node --insecure --accept-sql-without-tls
+          # Wait for /health?ready=1 — SQL port opens a few seconds before
+          # the engine is actually accepting queries.
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health?ready=1 > /dev/null; then
+              echo "✅ CockroachDB ready after $i attempt(s)"
+              break
+            fi
+            echo "Waiting for CockroachDB... ($i/30)"
+            sleep 2
+          done
+
+      - name: Run benchmarks
+        env:
+          ETL_DBCLIENT_BENCHMARK_RDBMS: cockroachdb
+          # Insecure single-node defaults: user 'root', no password, database 'defaultdb'.
+          ETL_DBCLIENT_BENCHMARK_COCKROACHDB: "Host=localhost;Port=26257;Database=defaultdb;Username=root;"
+        run: |
+          dotnet run -c Release \
+            --project benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj \
+            -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
+
+      - name: Stop CockroachDB
+        if: always()
+        run: docker rm -f crdb || true
+
+      - name: Publish to gh-pages
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        with:
+          name: "ExtractorBenchmarks (cockroachdb)"
+          tool: 'benchmarkdotnet'
+          output-file-path: BDN_OUT/results/Wolfgang.Etl.DbClient.Benchmarks.ExtractorBenchmarks-report-full-compressed.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/cockroachdb
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -697,7 +697,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rdbms: [sqlserver, postgres, mysql, mariadb, sqlite]
+        rdbms: [sqlserver, postgres, mysql, mariadb, cockroachdb, sqlite]
         tfm: [net8.0, net10.0]
 
     steps:

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
@@ -31,13 +31,15 @@ public static class BenchmarkContext
     {
         DbConnection conn = Rdbms switch
         {
-            "sqlserver" => new SqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MSSQL")),
-            "postgres"  => new NpgsqlConnection(Require("ETL_DBCLIENT_BENCHMARK_PG")),
-            "mysql"     => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MYSQL")),
+            "sqlserver"   => new SqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MSSQL")),
+            "postgres"    => new NpgsqlConnection(Require("ETL_DBCLIENT_BENCHMARK_PG")),
+            "mysql"       => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MYSQL")),
             // MariaDB shares the MySQL wire protocol — same MySqlConnector driver.
-            "mariadb"   => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MARIADB")),
-            "sqlite"    => new SqliteConnection("Data Source=:memory:"),
-            _           => throw new InvalidOperationException($"Unknown ETL_DBCLIENT_BENCHMARK_RDBMS value '{Rdbms}'. Expected one of: sqlite, sqlserver, postgres, mysql, mariadb."),
+            "mariadb"     => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MARIADB")),
+            // CockroachDB speaks the PostgreSQL wire protocol — Npgsql works unchanged.
+            "cockroachdb" => new NpgsqlConnection(Require("ETL_DBCLIENT_BENCHMARK_COCKROACHDB")),
+            "sqlite"      => new SqliteConnection("Data Source=:memory:"),
+            _             => throw new InvalidOperationException($"Unknown ETL_DBCLIENT_BENCHMARK_RDBMS value '{Rdbms}'. Expected one of: sqlite, sqlserver, postgres, mysql, mariadb, cockroachdb."),
         };
 
         conn.Open();
@@ -60,6 +62,9 @@ public static class BenchmarkContext
                             "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);"),
             "mariadb"   => ("DROP TABLE IF EXISTS contract_items;",
                             "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);"),
+            // CockroachDB is Postgres-compatible for the DDL we need here.
+            "cockroachdb" => ("DROP TABLE IF EXISTS contract_items;",
+                              "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INTEGER NOT NULL);"),
             _           => ("DROP TABLE IF EXISTS contract_items;",
                             "CREATE TABLE contract_items (name TEXT NOT NULL, value INTEGER NOT NULL);"),
         };


### PR DESCRIPTION
**Companion to non-workflow PR. Merge order: non-workflow PR first, then this one** (same MariaDB-style pattern — tests must exist on main before the matrix entry activates, otherwise `dotnet test --filter Category=cockroachdb` exits non-zero on zero matches).

## pr.yaml
- `test-integration` matrix: added `cockroachdb` to the `rdbms` list.

## benchmarks.yaml
- New `benchmark-cockroachdb` job, chained after `benchmark-mariadb` so the gh-pages pushes stay serial.
- **Launches CockroachDB via a manual `docker run` step** rather than a `services:` block — GH Actions `services:` blocks can't override CMD, and the `cockroachdb/cockroach` image's entrypoint expects `start-single-node --insecure` as its run command.
- Waits for `/health?ready=1` on the admin/HTTP port with a 30-attempt × 2s loop before running benchmarks.

⚠️ Touches `.github/workflows/*.yaml` → trips the `detect-projects` protected-files guard → requires maintainer admin-bypass-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)