### PR TITLE
feat(integration): add CockroachDB (#62) — non-workflow part

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ an in-memory connection instead of a container.
 | **PostgreSQL** | 16 | `Npgsql` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/postgres/) |
 | **MySQL** | 8.0 | `MySqlConnector` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mysql/) |
 | **MariaDB** | 11.4 | `MySqlConnector` | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/mariadb/) |
+| **CockroachDB** | v24.3 | `Npgsql` (Postgres-wire-compatible) | [![CI](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/workflows/pr.yaml?query=branch%3Amain) | [📊 chart](https://chris-wolfgang.github.io/Etl-DbClient/dev/bench/cockroachdb/) |
 
 > **About these badges.** GitHub doesn't natively render a different status per matrix
 > job, so each row currently shows the *overall* `pr.yaml` status. If any of the four

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/BenchmarkContext.cs
@@ -31,13 +31,15 @@ public static class BenchmarkContext
     {
         DbConnection conn = Rdbms switch
         {
-            "sqlserver" => new SqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MSSQL")),
-            "postgres"  => new NpgsqlConnection(Require("ETL_DBCLIENT_BENCHMARK_PG")),
-            "mysql"     => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MYSQL")),
+            "sqlserver"   => new SqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MSSQL")),
+            "postgres"    => new NpgsqlConnection(Require("ETL_DBCLIENT_BENCHMARK_PG")),
+            "mysql"       => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MYSQL")),
             // MariaDB shares the MySQL wire protocol — same MySqlConnector driver.
-            "mariadb"   => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MARIADB")),
-            "sqlite"    => new SqliteConnection("Data Source=:memory:"),
-            _           => throw new InvalidOperationException($"Unknown ETL_DBCLIENT_BENCHMARK_RDBMS value '{Rdbms}'. Expected one of: sqlite, sqlserver, postgres, mysql, mariadb."),
+            "mariadb"     => new MySqlConnection(Require("ETL_DBCLIENT_BENCHMARK_MARIADB")),
+            // CockroachDB speaks the Postgres wire protocol — same Npgsql driver.
+            "cockroachdb" => new NpgsqlConnection(Require("ETL_DBCLIENT_BENCHMARK_COCKROACHDB")),
+            "sqlite"      => new SqliteConnection("Data Source=:memory:"),
+            _             => throw new InvalidOperationException($"Unknown ETL_DBCLIENT_BENCHMARK_RDBMS value '{Rdbms}'. Expected one of: sqlite, sqlserver, postgres, mysql, mariadb, cockroachdb."),
         };
 
         conn.Open();
@@ -60,6 +62,8 @@ public static class BenchmarkContext
                             "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);"),
             "mariadb"   => ("DROP TABLE IF EXISTS contract_items;",
                             "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);"),
+            "cockroachdb" => ("DROP TABLE IF EXISTS contract_items;",
+                              "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);"),
             _           => ("DROP TABLE IF EXISTS contract_items;",
                             "CREATE TABLE contract_items (name TEXT NOT NULL, value INTEGER NOT NULL);"),
         };

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -244,7 +244,7 @@ if (-not $SkipIntegration -and -not $SkipTests -and $failed.Count -eq 0) {
         # SQLite needs no Docker; the other providers do. Build the list accordingly.
         $rdbmsList = @('sqlite')
         if ($dockerOk) {
-            $rdbmsList += @('sqlserver', 'postgres', 'mysql', 'mariadb')
+            $rdbmsList += @('sqlserver', 'postgres', 'mysql', 'mariadb', 'cockroachdb')
         }
         else {
             Write-Host "⚠️  Docker daemon is not reachable — running only the SQLite slice." -ForegroundColor Yellow

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/CockroachDbTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/CockroachDbTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration;
+
+[CollectionDefinition("CockroachDb")]
+public class CockroachDbCollection : ICollectionFixture<CockroachDbFixture> { }
+
+
+
+[Collection("CockroachDb")]
+[Trait("Category", "cockroachdb")]
+[ExcludeFromCodeCoverage]
+public sealed class CockroachDbExtractorTests : DbExtractorIntegrationTestsBase
+{
+    private readonly CockroachDbFixture _fixture;
+    public CockroachDbExtractorTests(CockroachDbFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}
+
+
+
+[Collection("CockroachDb")]
+[Trait("Category", "cockroachdb")]
+[ExcludeFromCodeCoverage]
+public sealed class CockroachDbLoaderTests : DbLoaderIntegrationTestsBase
+{
+    private readonly CockroachDbFixture _fixture;
+    public CockroachDbLoaderTests(CockroachDbFixture fixture) => _fixture = fixture;
+    protected override IDbProviderFixture Fixture => _fixture;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/CockroachDbFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/CockroachDbFixture.cs
@@ -1,0 +1,93 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Npgsql;
+
+namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
+
+/// <summary>
+/// CockroachDB fixture. Speaks the PostgreSQL wire protocol so the existing
+/// <c>Npgsql</c> driver works unchanged — only the container image differs.
+/// Testcontainers does not ship a dedicated <c>Testcontainers.CockroachDb</c>
+/// module, so this fixture uses the generic <see cref="ContainerBuilder"/>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class CockroachDbFixture : DbProviderFixtureBase
+{
+    private const int CockroachSqlPort = 26257;
+    private const int CockroachHttpPort = 8080;
+
+    private IContainer? _container;
+
+    public override string ProviderName => "cockroachdb";
+
+
+
+    protected override async Task StartAsync()
+    {
+        // Pinned patch tag for reproducible CI. Bump deliberately when
+        // moving to a new minor.
+        _container = new ContainerBuilder()
+            .WithImage("cockroachdb/cockroach:v24.3.5")
+            .WithCommand("start-single-node", "--insecure")
+            .WithPortBinding(CockroachSqlPort, true)
+            .WithPortBinding(CockroachHttpPort, true)
+            // Wait by actually executing a SQL probe inside the container —
+            // the SQL port opens a few seconds before the engine is accepting
+            // queries, and the HTTP /health endpoint's behaviour varies across
+            // versions. A successful `SELECT 1` is the unambiguous signal.
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilCommandIsCompleted("./cockroach", "sql", "--insecure", "-e", "SELECT 1"))
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+    }
+
+
+
+    protected override async Task StopAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+
+
+    public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var port = _container!.GetMappedPublicPort(CockroachSqlPort);
+        // Insecure single-node defaults: user 'root', no password, database 'defaultdb'.
+        var connectionString = $"Host=localhost;Port={port};Database=defaultdb;Username=root;";
+        var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return conn;
+    }
+
+
+
+    public override async Task ResetSchemaAsync(DbConnection connection, CancellationToken cancellationToken = default)
+    {
+        await ExecuteAsync(connection, "DROP TABLE IF EXISTS contract_items;", cancellationToken).ConfigureAwait(false);
+        await ExecuteAsync(connection, "CREATE TABLE contract_items (name VARCHAR(100) NOT NULL, value INT NOT NULL);", cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+    public override async Task SeedAsync(DbConnection connection, int rowCount, CancellationToken cancellationToken = default)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO contract_items (name, value) VALUES (@name, @value);";
+            var p1 = cmd.CreateParameter(); p1.ParameterName = "name"; p1.Value = string.Format(CultureInfo.InvariantCulture, "Item{0}", i);
+            var p2 = cmd.CreateParameter(); p2.ParameterName = "value"; p2.Value = i * 10;
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/CockroachDbFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/CockroachDbFixture.cs
@@ -17,7 +17,6 @@ namespace Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
 public sealed class CockroachDbFixture : DbProviderFixtureBase
 {
     private const int CockroachSqlPort = 26257;
-    private const int CockroachHttpPort = 8080;
 
     private IContainer? _container;
 
@@ -33,13 +32,14 @@ public sealed class CockroachDbFixture : DbProviderFixtureBase
             .WithImage("cockroachdb/cockroach:v24.3.5")
             .WithCommand("start-single-node", "--insecure")
             .WithPortBinding(CockroachSqlPort, true)
-            .WithPortBinding(CockroachHttpPort, true)
             // Wait by actually executing a SQL probe inside the container —
             // the SQL port opens a few seconds before the engine is accepting
             // queries, and the HTTP /health endpoint's behaviour varies across
             // versions. A successful `SELECT 1` is the unambiguous signal.
+            // Invoke via absolute path so a future image WORKDIR change won't
+            // silently break the probe.
             .WithWaitStrategy(Wait.ForUnixContainer()
-                .UntilCommandIsCompleted("./cockroach", "sql", "--insecure", "-e", "SELECT 1"))
+                .UntilCommandIsCompleted("/cockroach/cockroach", "sql", "--insecure", "-e", "SELECT 1"))
             .Build();
 
         await _container.StartAsync().ConfigureAwait(false);
@@ -59,9 +59,13 @@ public sealed class CockroachDbFixture : DbProviderFixtureBase
 
     public override async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
     {
-        var port = _container!.GetMappedPublicPort(CockroachSqlPort);
+        var host = _container!.Hostname;
+        var port = _container.GetMappedPublicPort(CockroachSqlPort);
         // Insecure single-node defaults: user 'root', no password, database 'defaultdb'.
-        var connectionString = $"Host=localhost;Port={port};Database=defaultdb;Username=root;";
+        // Use the container's reported Hostname (not literal "localhost") so the fixture
+        // works under Docker-in-Docker, remote DOCKER_HOST, rootless setups, and
+        // Testcontainers Cloud.
+        var connectionString = $"Host={host};Port={port};Database=defaultdb;Username=root;";
         var conn = new NpgsqlConnection(connectionString);
         await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
         return conn;

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -43,6 +43,10 @@
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
+    <!-- Explicit Testcontainers base — CockroachDbFixture uses the generic
+         ContainerBuilder directly (no dedicated Testcontainers.CockroachDb
+         module exists at this version). -->
+    <PackageReference Include="Testcontainers" Version="4.4.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.4.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
     <PackageReference Include="Testcontainers.MySql" Version="4.4.0" />


### PR DESCRIPTION
**Companion to #73.** Merge order: **this PR first** (normal merge — zero protected files), then **#73** (bypass-merge — adds matrix entry + benchmark job). Same MariaDB-style ordering: tests must exist on main before the matrix entry activates, otherwise `dotnet test --filter Category=cockroachdb` exits non-zero on zero matches.

## Why CockroachDB
PostgreSQL wire-compatible. Proves the library's claim that any Postgres-compatible engine works with the existing `Npgsql` driver — same code path, same correctness guarantees. Also a credible enterprise target (Netflix, Shopify, DoorDash, Bose).

## Changes
- **New `CockroachDbFixture`** — uses the generic `ContainerBuilder` from `Testcontainers` (no dedicated `Testcontainers.CockroachDb` module exists at this version). Image pinned to `cockroachdb/cockroach:v24.3.5`. CMD overridden to `start-single-node --insecure`. Readiness via `UntilCommandIsCompleted` running `cockroach sql -e "SELECT 1"` — the most reliable signal (SQL port opens before engine readiness; HTTP `/health` semantics vary across versions).
- **New `CockroachDbTests`** — `[Trait("Category", "cockroachdb")]` + collection definition.
- **`Tests.Integration.csproj`** — added explicit `Testcontainers` 4.4.0 base PackageReference (used directly via `ContainerBuilder`).
- **`BenchmarkContext`** — new `cockroachdb` arm using Npgsql; env var `ETL_DBCLIENT_BENCHMARK_COCKROACHDB`.
- **`scripts/build-pr.ps1`** — `cockroachdb` added to `rdbmsList`.
- **`README.md`** — new CockroachDB row in the "Tested Databases" matrix.

## Verification
Local on net10.0: **7/7 pass in ~8s** with warm image cache. Cold pull adds ~30s.

## Follow-up
`#62` remaining: YugabyteDB (same Postgres-wire-compatible pattern as CockroachDB — easy follow-up), Oracle XE (medium, ~2 GB image, license-aware), DB2 (high effort), Firebird (niche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)