### PR TITLE
ci(pr.yaml): path-gate Stage 1 / 2 / 3 via stub jobs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1673,8 +1673,11 @@ jobs:
   # the real Stage 1 / 2 / 3 jobs above skip via their `if:` predicates. The
   # branch ruleset still requires those check names to report success, though,
   # so we fire a stub job with the SAME `name:` whose `if:` is the complement
-  # of the real job's path-gate. Exactly one of (real, stub) runs per stage on
-  # any given PR.
+  # of the real job's path-gate. On a docs-only PR exactly one of (real, stub)
+  # runs per stage. On a code/workflow PR the real job runs; if an upstream
+  # Stage 1 fails, Stage 2/3 real jobs skip via `needs` and the stub stays
+  # off (its predicate excludes code PRs), so neither member runs — that is
+  # the intended "previous stage failed" cascade, not a path-gate condition.
   #
   # GitHub treats multiple jobs sharing a `name:` as separate jobs at runtime
   # but the required-check matching for the ruleset is by name. Either passing

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -270,11 +270,15 @@ jobs:
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
-  test-linux-core: 
+  test-linux-core:
     name: "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate"
     runs-on:  ubuntu-latest
-    needs: detect-projects
-    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    needs: [detect-projects, detect-changes]
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template' &&
+      needs.detect-projects.outputs.has-projects == 'true' &&
+      (needs.detect-changes.outputs.code == 'true' ||
+       needs.detect-changes.outputs.workflows == 'true')
     
     steps:
       - name: Checkout code
@@ -811,8 +815,12 @@ jobs:
   test-windows:
     name: "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
     runs-on: windows-latest
-    needs: [detect-projects, test-linux-core]
-    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    needs: [detect-projects, detect-changes, test-linux-core]
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template' &&
+      needs.detect-projects.outputs.has-projects == 'true' &&
+      (needs.detect-changes.outputs.code == 'true' ||
+       needs.detect-changes.outputs.workflows == 'true')
     
     steps:
       - name: Checkout code
@@ -1113,8 +1121,12 @@ jobs:
   test-macos-core:
     name: "Stage 3: macOS Tests (.NET 6.0-10.0)"
     runs-on: macos-latest
-    needs: [detect-projects, test-windows]
-    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    needs: [detect-projects, detect-changes, test-windows]
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template' &&
+      needs.detect-projects.outputs.has-projects == 'true' &&
+      (needs.detect-changes.outputs.code == 'true' ||
+       needs.detect-changes.outputs.workflows == 'true')
     
     steps:
       - name: Checkout code
@@ -1653,3 +1665,59 @@ jobs:
           name: devskim-results
           path: devskim-results.txt
           if-no-files-found: warn
+
+  # ============================================================================
+  # PATH-GATE STUBS for Stages 1 / 2 / 3
+  # ----------------------------------------------------------------------------
+  # When detect-changes reports neither code nor workflow changes (docs-only PR),
+  # the real Stage 1 / 2 / 3 jobs above skip via their `if:` predicates. The
+  # branch ruleset still requires those check names to report success, though,
+  # so we fire a stub job with the SAME `name:` whose `if:` is the complement
+  # of the real job's path-gate. Exactly one of (real, stub) runs per stage on
+  # any given PR.
+  #
+  # GitHub treats multiple jobs sharing a `name:` as separate jobs at runtime
+  # but the required-check matching for the ruleset is by name. Either passing
+  # satisfies the required check.
+  # ============================================================================
+  test-linux-core-skipped:
+    name: "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate"
+    runs-on: ubuntu-latest
+    needs: [detect-projects, detect-changes]
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template' &&
+      needs.detect-projects.outputs.has-projects == 'true' &&
+      needs.detect-changes.outputs.code != 'true' &&
+      needs.detect-changes.outputs.workflows != 'true'
+    steps:
+      - name: Stage 1 skipped via path-gate
+        run: |
+          echo "::notice::Skipped Stage 1 — this PR changes neither code nor workflows."
+
+  test-windows-skipped:
+    name: "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
+    runs-on: ubuntu-latest
+    needs: [detect-projects, detect-changes]
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template' &&
+      needs.detect-projects.outputs.has-projects == 'true' &&
+      needs.detect-changes.outputs.code != 'true' &&
+      needs.detect-changes.outputs.workflows != 'true'
+    steps:
+      - name: Stage 2 skipped via path-gate
+        run: |
+          echo "::notice::Skipped Stage 2 — this PR changes neither code nor workflows."
+
+  test-macos-core-skipped:
+    name: "Stage 3: macOS Tests (.NET 6.0-10.0)"
+    runs-on: ubuntu-latest
+    needs: [detect-projects, detect-changes]
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template' &&
+      needs.detect-projects.outputs.has-projects == 'true' &&
+      needs.detect-changes.outputs.code != 'true' &&
+      needs.detect-changes.outputs.workflows != 'true'
+    steps:
+      - name: Stage 3 skipped via path-gate
+        run: |
+          echo "::notice::Skipped Stage 3 — this PR changes neither code nor workflows."


### PR DESCRIPTION
Extends the path-gating from the integration matrix (already in place via the `Integration (all)` aggregator) to the Stage 1 / 2 / 3 unit-test pipeline. Docs-only PRs now skip ~25 min of multi-TFM Linux + Windows + macOS testing they couldn't possibly affect.

## Pattern: paired stub jobs (dotnet/runtime style)
Stage 1 / 2 / 3 names are encoded verbatim in the branch ruleset as required checks. Path-gating them with `if:` alone would mark them "skipped", and GitHub's treatment of `skipped` for required-checks resolution varies — safer to **guarantee** one of (real, stub) runs and reports success on every PR.

```
test-linux-core           ← real Stage 1, fires when code/workflows changed
test-linux-core-skipped   ← stub with SAME `name:`, fires when neither changed
                            (the negation of the real job's path-gate)
```

GitHub matches required checks by **name**; either passing satisfies the rule. Exactly one of (real, stub) runs per PR — their `if:` predicates are complementary.

## Changes to real jobs
- `test-linux-core` / `test-windows` / `test-macos-core`: `if:` predicates now also require `code || workflows`. `needs:` extended to include `detect-changes`.
- The Stage 2 / Stage 3 sequential chain to the previous stage's real job is **preserved** — they still only run when the previous Stage's real job passed AND a code/workflow change happened.

## New stub jobs
| Stub job ID | `name:` (must match real job) |
|---|---|
| `test-linux-core-skipped` | `Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate` |
| `test-windows-skipped` | `Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)` |
| `test-macos-core-skipped` | `Stage 3: macOS Tests (.NET 6.0-10.0)` |

All three: `ubuntu-latest`, `needs: [detect-projects, detect-changes]`, `if: detect-projects passed AND neither code nor workflows changed`. Single step echoes a `::notice::` and exits 0.

## CI-time saving
For a docs-only PR (e.g. README typo): instead of running Stage 1 (~4 min) + Stage 2 (~12 min) + Stage 3 (~6 min) = ~22 min on three runners, you get three ~3s stub jobs on shared Linux runners.

## Test plan
- [ ] Open a docs-only PR after this lands — all three Stage rows on the PR view should show ~5s `Stage N skipped via path-gate` annotations, all three required checks pass.
- [ ] Open a code-touching PR — real Stage 1 / 2 / 3 run as before, stubs don't fire.
- [ ] Confirm the branch ruleset's required checks still resolve (no name drift).

⚠️ Touches `.github/workflows/pr.yaml` → trips the `detect-projects` protected-files guard → requires maintainer admin-bypass-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)