### PR TITLE
refactor: thread-safety hardening + helpful errors (review #2/#3/#5)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/ColumnAttributeTypeMapper.cs
+++ b/src/Wolfgang.Etl.DbClient/ColumnAttributeTypeMapper.cs
@@ -66,7 +66,21 @@ internal static class ColumnAttributeTypeMapper
                 prop ??= props.FirstOrDefault(p =>
                     string.Equals(p.Name, columnName, StringComparison.OrdinalIgnoreCase));
 
-                return prop!;
+                if (prop == null)
+                {
+                    // Dapper's default behaviour on unmappable columns throws a
+                    // generic NullReferenceException downstream. Replace with a
+                    // self-describing error so the user sees the offending column
+                    // name and the target type immediately.
+                    throw new InvalidOperationException
+                    (
+                        $"Result-set column '{columnName}' does not map to any property on '{t.FullName}'. " +
+                        "Either add a property of that name, decorate an existing property with " +
+                        $"[Column(\"{columnName}\")], or alias the column in your SELECT statement."
+                    );
+                }
+
+                return prop;
             }
         );
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -33,6 +33,12 @@ namespace Wolfgang.Etl.DbClient;
 /// The extractor never commits or rolls back the transaction.
 /// </para>
 /// <para>
+/// <b>Thread safety.</b> A <see cref="DbExtractor{TRecord}"/> instance is not safe for
+/// concurrent <c>ExtractAsync</c> calls. Internal state (stopwatch, total-count snapshot,
+/// progress-counter increments) assumes a single extraction in flight. Build a separate
+/// instance per concurrent extraction.
+/// </para>
+/// <para>
 /// Command timeout uses the Dapper/ADO.NET default (typically 30 seconds).
 /// A dedicated <c>CommandTimeout</c> property is planned (see GitHub issue #25).
 /// </para>

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -38,6 +38,11 @@ namespace Wolfgang.Etl.DbClient;
 /// <c>LoadAsync</c>.
 /// </para>
 /// <para>
+/// <b>Thread safety.</b> A <see cref="DbLoader{TRecord}"/> instance is not safe for
+/// concurrent <c>LoadAsync</c> calls. Internal state (stopwatch, progress counters)
+/// assumes a single load in flight. Build a separate instance per concurrent load.
+/// </para>
+/// <para>
 /// Command timeout uses the Dapper/ADO.NET default (typically 30 seconds).
 /// A dedicated <c>CommandTimeout</c> property is planned (see GitHub issue #25).
 /// </para>
@@ -56,7 +61,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
     private readonly ILogger _logger;
     private readonly IProgressTimer? _progressTimer;
     private readonly Stopwatch _stopwatch = new();
-    private bool _progressTimerWired;
+    private int _progressTimerWired;
 
 
 
@@ -188,9 +193,10 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
     {
         if (_progressTimer != null)
         {
-            if (!_progressTimerWired)
+            // Atomic 0 → 1 transition. Matches DbExtractor's pattern and prevents
+            // double-subscription if CreateProgressTimer is ever called concurrently.
+            if (Interlocked.CompareExchange(ref _progressTimerWired, 1, 0) == 0)
             {
-                _progressTimerWired = true;
                 _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
             }
 


### PR DESCRIPTION
**PR-B of 9 stacked from the v0.3.0 code review. Depends on #77 (PR-A).**

## What changes
- **`DbLoader._progressTimerWired` (review #2)** — was a plain `bool`; converted to `int` + `Interlocked.CompareExchange(ref _progressTimerWired, 1, 0) == 0` for a thread-safe 0→1 transition. Matches the pattern already in `DbExtractor`. Prevents double-subscription of the `Elapsed` event if `CreateProgressTimer` is ever called concurrently.
- **XML doc: single-use contract (review #3)** — added a "Thread safety" remarks paragraph to both `DbExtractor<T>` and `DbLoader<T>` documenting that instances are not safe for concurrent `ExtractAsync`/`LoadAsync` calls. The implementation already assumed this — this just makes the assumption explicit for library users.
- **`ColumnAttributeTypeMapper` (review #5)** — the custom type-map callback returned `null!` when a result-set column didn't match any property. Dapper then crashed downstream with a generic `NullReferenceException` hiding the actual column name. Now throws an `InvalidOperationException` naming the unmappable column + target type with three remediation suggestions.

## Verification
- `dotnet build -c Release`: 0 warnings, 0 errors
- Unit tests: **141 / 141 ✅**

PR-C will add a regression test that exercises the new exception path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)