### PR TITLE
bench: add DbCommandBuilder microbenchmarks (review #18 part 1)

### DIFF
--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/DbCommandBuilderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/DbCommandBuilderBenchmarks.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Etl.DbClient;
+
+namespace Wolfgang.Etl.DbClient.Benchmarks;
+
+/// <summary>
+/// Microbenchmarks for the SQL command builder. Establishes the reflection-cost
+/// baseline that the upcoming cache (review #7) will compare against. No I/O —
+/// pure reflection + string concat.
+/// </summary>
+[MemoryDiagnoser]
+public class DbCommandBuilderBenchmarks
+{
+    [Table("benchmark_people")]
+    public class BenchmarkPerson
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("first_name")]
+        public string FirstName { get; set; } = string.Empty;
+
+        [Column("last_name")]
+        public string LastName { get; set; } = string.Empty;
+
+        [Column("age")]
+        public int Age { get; set; }
+
+        [Column("email")]
+        public string Email { get; set; } = string.Empty;
+
+        [Column("created_at")]
+        public DateTime CreatedAt { get; set; }
+    }
+
+
+
+    [Benchmark]
+    public string BuildSelect() => DbCommandBuilder.BuildSelect<BenchmarkPerson>();
+
+
+
+    [Benchmark]
+    public string BuildInsert() => DbCommandBuilder.BuildInsert<BenchmarkPerson>();
+
+
+
+    [Benchmark]
+    public string BuildUpdate() => DbCommandBuilder.BuildUpdate<BenchmarkPerson>();
+}

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Unit" />
+    <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Benchmarks" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**PR-D of 9 stacked from the v0.3.0 code review. Depends on #77 → #78 → #79.**

Establishes the reflection-cost baseline for review item #7. The follow-up PR-E introduces a `TypeMetadata` cache and proves the speedup against these numbers.

## What this PR adds
- **`DbCommandBuilderBenchmarks.cs`** — three BDN methods:
  - `BuildSelect` — 6-property POCO with `[Table]`, `[Column]`, `[Key]`
  - `BuildInsert` — excludes the `[Key]+Identity` column
  - `BuildUpdate` — key in WHERE clause, non-key in SET clause
- **`InternalsVisibleTo("Wolfgang.Etl.DbClient.Benchmarks")`** so the benchmarks can invoke the `internal static` builder methods directly. Isolates the measurement from `DbExtractor`/`DbLoader` construction cost.

## Baseline (Windows + net10.0 + Intel i7-14700HX, ShortRun)

| Method      | Mean     | Allocated |
|-------------|---------:|----------:|
| BuildSelect | 8.41 µs  | 3.57 KB   |
| BuildInsert | 8.49 µs  | 5.05 KB   |
| BuildUpdate | 7.22 µs  | 4.88 KB   |

Per call. Each Build* invocation does multiple `Type.GetProperties()` calls plus per-property `GetCustomAttribute<...>()` lookups — that's where the time and allocations come from. PR-E will cache that work per Type.

## Verification
- `dotnet build benchmarks/ -c Release`: 0 warnings, 0 errors
- Benchmarks executed cleanly via `--filter "*DbCommandBuilderBenchmarks*" --job short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)