### PR TITLE
perf: cache DbCommandBuilder reflection per Type (review #7/#12)

### DIFF
--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/DbCommandBuilderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/DbCommandBuilderBenchmarks.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Etl.DbClient;
+
+namespace Wolfgang.Etl.DbClient.Benchmarks;
+
+/// <summary>
+/// Microbenchmarks for the SQL command builder. Establishes the reflection-cost
+/// baseline that the upcoming cache (review #7) will compare against. No I/O —
+/// pure reflection + string concat.
+/// </summary>
+[MemoryDiagnoser]
+public class DbCommandBuilderBenchmarks
+{
+    [Table("benchmark_people")]
+    public class BenchmarkPerson
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("first_name")]
+        public string FirstName { get; set; } = string.Empty;
+
+        [Column("last_name")]
+        public string LastName { get; set; } = string.Empty;
+
+        [Column("age")]
+        public int Age { get; set; }
+
+        [Column("email")]
+        public string Email { get; set; } = string.Empty;
+
+        [Column("created_at")]
+        public DateTime CreatedAt { get; set; }
+    }
+
+
+
+    [Benchmark]
+    public string BuildSelect() => DbCommandBuilder.BuildSelect<BenchmarkPerson>();
+
+
+
+    [Benchmark]
+    public string BuildInsert() => DbCommandBuilder.BuildInsert<BenchmarkPerson>();
+
+
+
+    [Benchmark]
+    public string BuildUpdate() => DbCommandBuilder.BuildUpdate<BenchmarkPerson>();
+}

--- a/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -11,6 +12,12 @@ namespace Wolfgang.Etl.DbClient;
 /// Generates SQL commands from <see cref="TableAttribute"/>, <see cref="ColumnAttribute"/>,
 /// and <see cref="KeyAttribute"/> annotations on a POCO type.
 /// </summary>
+/// <remarks>
+/// Reflection results are cached per <see cref="Type"/> via <see cref="TypeMetadataCache"/>;
+/// the cached entry contains the table name, column mappings, key set, and the
+/// already-built SELECT / INSERT / UPDATE strings. The first Build* call for a given
+/// type pays the reflection cost; subsequent calls return cached strings.
+/// </remarks>
 internal static class DbCommandBuilder
 {
     /// <summary>
@@ -20,12 +27,141 @@ internal static class DbCommandBuilder
     /// <exception cref="InvalidOperationException">
     /// Thrown when the type does not have a <see cref="TableAttribute"/>.
     /// </exception>
-    internal static string BuildSelect<T>()
-    {
-        var type = typeof(T);
-        var table = GetTableName(type);
-        var columns = GetColumnMappings(type);
+    internal static string BuildSelect<T>() => TypeMetadataCache.For(typeof(T)).SelectSql;
 
+
+
+    /// <summary>
+    /// Generates an INSERT statement for all mapped non-key columns.
+    /// If no <see cref="KeyAttribute"/> columns exist, all columns are included.
+    /// Requires <see cref="TableAttribute"/> on the type.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the type does not have a <see cref="TableAttribute"/> or has no
+    /// mapped columns for INSERT.
+    /// </exception>
+    internal static string BuildInsert<T>() => TypeMetadataCache.For(typeof(T)).InsertSql;
+
+
+
+    /// <summary>
+    /// Generates an UPDATE statement using <see cref="KeyAttribute"/> columns in the WHERE clause.
+    /// Requires <see cref="TableAttribute"/> and at least one <see cref="KeyAttribute"/> property.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the type does not have a <see cref="TableAttribute"/>, no <see cref="KeyAttribute"/>
+    /// properties, or no non-key columns for the SET clause.
+    /// </exception>
+    internal static string BuildUpdate<T>() => TypeMetadataCache.For(typeof(T)).UpdateSql;
+
+
+
+    // ------------------------------------------------------------------
+    // Internal cache: one entry per Type. Reflection runs once.
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Per-type cache of reflection metadata and pre-built SQL strings.
+    /// Thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd(TKey, Func{TKey, TValue})"/>.
+    /// </summary>
+    private static class TypeMetadataCache
+    {
+        private static readonly ConcurrentDictionary<Type, TypeMetadata> Cache = new();
+
+        internal static TypeMetadata For(Type type) => Cache.GetOrAdd(type, BuildMetadata);
+    }
+
+
+
+    private sealed class TypeMetadata
+    {
+        public TypeMetadata(string selectSql, Lazy<string> insertSql, Lazy<string> updateSql)
+        {
+            SelectSql = selectSql;
+            _insertSql = insertSql;
+            _updateSql = updateSql;
+        }
+
+        // SELECT can never throw on a type with at least one mapped property (or
+        // returns "SELECT *" if there are none) so it's safe to build eagerly.
+        public string SelectSql { get; }
+
+        // INSERT / UPDATE may throw on validation failures (no non-key columns,
+        // [Key]-but-[NotMapped], etc). Defer until first request so a type that
+        // only ever calls BuildSelect doesn't surface those errors at cache time.
+        private readonly Lazy<string> _insertSql;
+        public string InsertSql => _insertSql.Value;
+
+        private readonly Lazy<string> _updateSql;
+        public string UpdateSql => _updateSql.Value;
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Metadata construction (runs once per Type)
+    // ------------------------------------------------------------------
+
+    private static TypeMetadata BuildMetadata(Type type)
+    {
+        var table = GetTableName(type);
+        var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        // Single pass: read [NotMapped], [Column], [Key], [DatabaseGenerated]
+        // off each property and bucket the results.
+        // - `columns`           — mapped columns (excludes [NotMapped]).
+        // - `anyKeyPropertyNames` — every property with [Key], including those
+        //   that also have [NotMapped]. BuildUpdate needs this to distinguish
+        //   "no [Key] anywhere" from "[Key] exists but all are [NotMapped]".
+        // - `autoIdentityKeyPropertyNames` — subset that is BOTH [Key] AND
+        //   [DatabaseGenerated(Identity)]; excluded from INSERT.
+        var columns = new List<ColumnMapping>(capacity: props.Length);
+        var anyKeyPropertyNames = new HashSet<string>(StringComparer.Ordinal);
+        var autoIdentityKeyPropertyNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var prop in props)
+        {
+            var isNotMapped = prop.GetCustomAttribute<NotMappedAttribute>() != null;
+            var isKey = prop.GetCustomAttribute<KeyAttribute>() != null;
+
+            if (isKey)
+            {
+                anyKeyPropertyNames.Add(prop.Name);
+            }
+
+            if (isNotMapped)
+            {
+                continue;
+            }
+
+            var columnName = prop.GetCustomAttribute<ColumnAttribute>()?.Name ?? prop.Name;
+            columns.Add(new ColumnMapping(columnName, prop.Name));
+
+            if (isKey)
+            {
+                var dbGenerated = prop.GetCustomAttribute<DatabaseGeneratedAttribute>();
+                if (dbGenerated?.DatabaseGeneratedOption == DatabaseGeneratedOption.Identity)
+                {
+                    autoIdentityKeyPropertyNames.Add(prop.Name);
+                }
+            }
+        }
+
+        return new TypeMetadata
+        (
+            selectSql: BuildSelectSql(table, columns),
+            // BuildInsert / BuildUpdate validate column counts and may throw. Wrap in
+            // Lazy so a type that only ever calls BuildSelect (e.g. one with all
+            // [NotMapped] properties) doesn't surface the INSERT failure at cache time.
+            insertSql: new Lazy<string>(() => BuildInsertSql(type, table, columns, autoIdentityKeyPropertyNames)),
+            updateSql: new Lazy<string>(() => BuildUpdateSql(type, table, columns, anyKeyPropertyNames))
+        );
+    }
+
+
+
+    private static string BuildSelectSql(string table, List<ColumnMapping> columns)
+    {
         if (columns.Count == 0)
         {
             return $"SELECT * FROM {table}";
@@ -44,26 +180,19 @@ internal static class DbCommandBuilder
 
 
 
-    /// <summary>
-    /// Generates an INSERT statement for all mapped non-key columns.
-    /// If no <see cref="KeyAttribute"/> columns exist, all columns are included.
-    /// Requires <see cref="TableAttribute"/> on the type.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when the type does not have a <see cref="TableAttribute"/>.
-    /// </exception>
-    internal static string BuildInsert<T>()
+    private static string BuildInsertSql
+    (
+        Type type,
+        string table,
+        List<ColumnMapping> columns,
+        HashSet<string> autoIdentityKeyPropertyNames
+    )
     {
-        var type = typeof(T);
-        var table = GetTableName(type);
-        var columns = GetColumnMappings(type);
-        var keys = GetKeyProperties(type);
-
         // Exclude [Key] + [DatabaseGenerated(Identity)] columns from INSERT.
         // Non-identity keys (e.g., composite keys) are included since they're
         // user-assigned values.
-        var insertColumns = keys.Count > 0
-            ? columns.Where(c => !IsAutoGeneratedKey(c.Property, keys)).ToList()
+        List<ColumnMapping> insertColumns = autoIdentityKeyPropertyNames.Count > 0
+            ? columns.Where(c => !autoIdentityKeyPropertyNames.Contains(c.PropertyName)).ToList()
             : columns;
 
         if (insertColumns.Count == 0)
@@ -88,49 +217,15 @@ internal static class DbCommandBuilder
 
 
 
-    /// <summary>
-    /// Generates an UPDATE statement using <see cref="KeyAttribute"/> columns in the WHERE clause.
-    /// Requires <see cref="TableAttribute"/> and at least one <see cref="KeyAttribute"/> property.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when the type does not have a <see cref="TableAttribute"/> or
-    /// no properties are decorated with <see cref="KeyAttribute"/>.
-    /// </exception>
-    internal static string BuildUpdate<T>()
-    {
-        var type = typeof(T);
-        var table = GetTableName(type);
-        var columns = GetColumnMappings(type);
-        var keys = GetKeyProperties(type);
-
-        ValidateUpdateInputs(type, columns, keys);
-
-        var keyNames = new HashSet<string>(keys.Select(k => k.Name), StringComparer.Ordinal);
-        var whereColumns = columns.Where(c => keyNames.Contains(c.PropertyName)).ToList();
-        var setColumns = columns.Where(c => !keyNames.Contains(c.PropertyName)).ToList();
-
-        ValidateUpdateColumns(type, whereColumns, setColumns);
-
-        var setClause = string.Join(", ", setColumns.Select(c => $"{c.ColumnName} = @{c.PropertyName}"));
-        var whereClause = string.Join(" AND ", whereColumns.Select(c => $"{c.ColumnName} = @{c.PropertyName}"));
-
-        return $"UPDATE {table} SET {setClause} WHERE {whereClause}";
-    }
-
-
-
-    // ------------------------------------------------------------------
-    // Private helpers
-    // ------------------------------------------------------------------
-
-    private static void ValidateUpdateInputs
+    private static string BuildUpdateSql
     (
         Type type,
+        string table,
         List<ColumnMapping> columns,
-        List<PropertyInfo> keys
+        HashSet<string> keyPropertyNames
     )
     {
-        if (keys.Count == 0)
+        if (keyPropertyNames.Count == 0)
         {
             throw new InvalidOperationException
             (
@@ -147,17 +242,10 @@ internal static class DbCommandBuilder
                 "UPDATE requires at least one mapped property that is not decorated with [NotMapped]."
             );
         }
-    }
 
+        var whereColumns = columns.Where(c => keyPropertyNames.Contains(c.PropertyName)).ToList();
+        var setColumns = columns.Where(c => !keyPropertyNames.Contains(c.PropertyName)).ToList();
 
-
-    private static void ValidateUpdateColumns
-    (
-        Type type,
-        List<ColumnMapping> whereColumns,
-        List<ColumnMapping> setColumns
-    )
-    {
         if (whereColumns.Count == 0)
         {
             throw new InvalidOperationException
@@ -175,9 +263,18 @@ internal static class DbCommandBuilder
                 "UPDATE requires at least one property that is not decorated with [Key]."
             );
         }
+
+        var setClause = string.Join(", ", setColumns.Select(c => $"{c.ColumnName} = @{c.PropertyName}"));
+        var whereClause = string.Join(" AND ", whereColumns.Select(c => $"{c.ColumnName} = @{c.PropertyName}"));
+
+        return $"UPDATE {table} SET {setClause} WHERE {whereClause}";
     }
 
 
+
+    // ------------------------------------------------------------------
+    // Small helpers
+    // ------------------------------------------------------------------
 
     private static string GetTableName(Type type)
     {
@@ -197,61 +294,5 @@ internal static class DbCommandBuilder
 
 
 
-    private static List<ColumnMapping> GetColumnMappings(Type type)
-    {
-        var mappings = new List<ColumnMapping>();
-
-        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-        {
-            if (prop.GetCustomAttribute<NotMappedAttribute>() != null)
-            {
-                continue;
-            }
-
-            var columnAttr = prop.GetCustomAttribute<ColumnAttribute>();
-            var columnName = columnAttr?.Name ?? prop.Name;
-
-            mappings.Add(new ColumnMapping(prop, columnName, prop.Name));
-        }
-
-        return mappings;
-    }
-
-
-
-    private static List<PropertyInfo> GetKeyProperties(Type type)
-    {
-        return type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(p => p.GetCustomAttribute<KeyAttribute>() != null)
-            .ToList();
-    }
-
-
-
-    private static bool IsAutoGeneratedKey(PropertyInfo property, List<PropertyInfo> keys)
-    {
-        if (!keys.Any(k => string.Equals(k.Name, property.Name, StringComparison.Ordinal)))
-        {
-            return false;
-        }
-
-        var dbGenerated = property.GetCustomAttribute<DatabaseGeneratedAttribute>();
-        return dbGenerated?.DatabaseGeneratedOption == DatabaseGeneratedOption.Identity;
-    }
-
-
-
-    private sealed class ColumnMapping
-    {
-        public ColumnMapping(PropertyInfo property, string columnName, string propertyName)
-        {
-            Property = property;
-            ColumnName = columnName;
-            PropertyName = propertyName;
-        }
-
-        public PropertyInfo Property { get; }
-        public string ColumnName { get; }
-        public string PropertyName { get; }
-    }
+    private readonly record struct ColumnMapping(string ColumnName, string PropertyName);
 }

--- a/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
@@ -13,10 +13,13 @@ namespace Wolfgang.Etl.DbClient;
 /// and <see cref="KeyAttribute"/> annotations on a POCO type.
 /// </summary>
 /// <remarks>
-/// Reflection results are cached per <see cref="Type"/> via <see cref="TypeMetadataCache"/>;
-/// the cached entry contains the table name, column mappings, key set, and the
-/// already-built SELECT / INSERT / UPDATE strings. The first Build* call for a given
-/// type pays the reflection cost; subsequent calls return cached strings.
+/// Reflection results are cached per <see cref="Type"/> via <see cref="TypeMetadataCache"/>.
+/// The cached entry holds the eagerly-built SELECT string plus <see cref="Lazy{T}"/>
+/// wrappers around the INSERT and UPDATE strings — those two paths can throw on
+/// invalid annotations, so they're deferred to the first <see cref="BuildInsert{T}"/>
+/// / <see cref="BuildUpdate{T}"/> call rather than at cache-population time.
+/// The first Build* call for a given type pays the reflection cost; subsequent calls
+/// return the cached strings without further reflection or allocation.
 /// </remarks>
 internal static class DbCommandBuilder
 {
@@ -64,6 +67,14 @@ internal static class DbCommandBuilder
     /// Per-type cache of reflection metadata and pre-built SQL strings.
     /// Thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd(TKey, Func{TKey, TValue})"/>.
     /// </summary>
+    /// <remarks>
+    /// Note: <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd(TKey, Func{TKey, TValue})"/>
+    /// may invoke the value factory more than once for the same key under concurrent
+    /// cold-cache calls — only the winning result is stored. Building <see cref="TypeMetadata"/>
+    /// is idempotent and side-effect-free, so a rare duplicate reflection pass is wasted work
+    /// but never incorrect. If exactly-once reflection ever becomes a requirement, swap the
+    /// value type to <see cref="Lazy{T}"/> of <see cref="TypeMetadata"/>.
+    /// </remarks>
     private static class TypeMetadataCache
     {
         private static readonly ConcurrentDictionary<Type, TypeMetadata> Cache = new();

--- a/src/Wolfgang.Etl.DbClient/IsExternalInit.cs
+++ b/src/Wolfgang.Etl.DbClient/IsExternalInit.cs
@@ -1,0 +1,15 @@
+#if NETFRAMEWORK || NETSTANDARD2_0 || NETSTANDARD2_1 || NET5_0 || NET6_0 || NET7_0
+// Polyfill for record struct / init-only setters on TFMs that don't ship this type.
+// The C# compiler requires System.Runtime.CompilerServices.IsExternalInit to lower
+// init / record members; adding it as an internal stub here is the standard fix.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Unit" />
+    <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Benchmarks" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Caches `DbCommandBuilder` reflection + built SQL strings per `Type` using `ConcurrentDictionary<Type, TypeMetadata>`. The first `Build*<T>()` call for a given type pays the reflection cost; subsequent calls return cached strings with zero allocations.

- `BuildSelect<T>()` is built eagerly (cannot fail on a valid `[Table]` type).
- `BuildInsert<T>()` / `BuildUpdate<T>()` are wrapped in `Lazy<string>` so validation errors (e.g. no non-key columns, `[Key]` + `[NotMapped]`) still surface at the first call site rather than at cache time — preserves existing exception behavior for `BuildSelect`-only types.
- Single-pass reflection collects mapped columns, all `[Key]` property names (including `[NotMapped]` keys, so the \"keys exist but none are mapped\" error path keeps working), and the identity-key subset (for INSERT exclusion).
- `ColumnMapping` is now a `readonly record struct` (Sonar S3898 + free `IEquatable<T>`).

## Benchmark (BenchmarkDotNet, --job short)

| Method      | Before (PR-D) | After (PR-E) | Allocations | Speedup |
|-------------|---------------|--------------|-------------|---------|
| BuildSelect | 8.41 us       | 5.57 ns      | 3.57 KB → 0 | ~1510x  |
| BuildInsert | 8.49 us       | 5.13 ns      | 5.05 KB → 0 | ~1655x  |
| BuildUpdate | 7.22 us       | 4.95 ns      | 4.88 KB → 0 | ~1459x  |

## Test plan
- [x] `dotnet test tests/Wolfgang.Etl.DbClient.Tests.Unit -c Release` — all existing builder tests green (including all-`[NotMapped]`, `[Key]`+`[NotMapped]`, and identity-key cases).
- [x] Benchmarks rerun shows zero allocations on warm cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)