### PR TITLE
chore: sync .gitignore from canonical (#87)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -427,20 +427,13 @@ CoverageReport/
 package-smoke-test/
 nuget-packages/
 
-# DocFX generated files
-docfx_project/_site/
+# DocFX generated files (any depth)
+_site/
 docfx_project/obj/
+# Auto-generated API metadata: `docfx metadata` writes <Type>.yml and toc.yml
+# under docfx_project/api/ for every public type extracted from src/. Keep
+# these out of the repo so a careless `git add -A` after running docfx
+# metadata locally doesn't commit generated files. The hand-written
+# index.md and README.md in api/ are intentionally tracked.
+docfx_project/api/*.yml
 
-# Generated documentation (built by CI/CD)
-docs/*
-!docs/.gitkeep
-!docs/LICENSE-SELECTION.md
-!docs/README-FORMATTING.md
-!docs/RELEASE-WORKFLOW-SETUP.md
-!docs/TEMPLATE-PLACEHOLDERS.md
-!docs/WORKFLOW_SECURITY.md
-.nuget/nuget.exe
-
-
-# ReSharper inspection output
-resharper-results.xml


### PR DESCRIPTION
## Summary

Resolves repo-template drift. After auditing every commonly-tracked config file, **only `.gitignore` has real semantic drift**. The other "diff'd" files are placeholder substitutions baked into the template (project name, owner) — intentional, not drift.

## Audit results

| File | Status |
|---|---|
| `.gitignore` | **REAL drift** (this PR) |
| `BannedSymbols.txt` | placeholder substitution only — `{{PROJECT_NAME}}` → `Wolfgang.Etl.DbClient` |
| `CONTRIBUTING.md` | placeholder substitution + one repo-specific SDK version note (kept) |
| `.github/CODEOWNERS` | placeholder substitution only — `{{GITHUB_USERNAME}}` → `@Chris-Wolfgang` |

## What the canonical `.gitignore` changes

| Net effect | Detail |
|---|---|
| Adds | comment block explaining the `docfx_project/api/*.yml` auto-generation exclusion |
| Drops | the dead `docs/*` allow-list block — files in `docs/` are already tracked so the ignore is a no-op for them |
| Drops | `.nuget/nuget.exe` and `resharper-results.xml` rules — neither path exists in this repo |

## Out of scope (covered by other M-stack PRs)

- Missing `docs/DOCFX-VERSION-PICKER.md`, `docfx_project/public/version-picker.js`, `docfx_project/versions.json` — all on `main`, will flow in via PR #126 or be added by M22 (#107).
- Missing favicon assets — covered by M02 (#163).
- Missing `scripts/Setup-*.ps1` and `LICENSE-*.txt` files — these are template scaffolding intentionally absent from downstream consumers.

## Closes
- **#87** — `[Maintenance] cleanup: Resolve template drift`

## Test plan
- [x] `git diff origin/repo-template/main:.gitignore HEAD:.gitignore` is empty.
- [x] `docs/*.md` files still tracked (gitignore doesn't affect tracked files).

## Stack
M03 of the Tier-1 maintenance stack. Base: `docs/verify-favicon-canonical` (M02 → #163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)