### PR TITLE
chore: version metadata consistency (#90)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -4,14 +4,31 @@
     <TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
+    <!-- ===== Version metadata strategy =====================================
+         Three numbers, three different roles:
+
+           <Version>            — the package / NuGet version. Source of truth;
+                                  every other version below derives from it.
+                                  Update at release time.
+
+           <AssemblyVersion>    — the binding identity that the CLR matches on.
+                                  Pinned to 1.0.0.0 so consumers don't need
+                                  binding redirects on every minor/patch bump.
+                                  ONLY bump on a deliberate breaking API change.
+
+           <FileVersion>        — the Windows file-properties version. Derived
+                                  from <Version> via regex (prerelease tag
+                                  stripped, ".0" appended to make 4 parts).
+
+           <InformationalVersion> — the human-readable version (with prerelease
+                                  / build metadata if any). Defaults to
+                                  <Version>; set explicitly here so it's
+                                  discoverable in a metadata dump.
+         ===================================================================== -->
     <Version>0.3.0</Version>
-    <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
-         do not need to recompile / add binding redirects on every minor/patch
-         bump. Bump only on a deliberate breaking API change. FileVersion +
-         InformationalVersion (the latter auto-derived from <Version>) carry
-         the actual release version. -->
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
+    <InformationalVersion>$(Version)</InformationalVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Extractor and Loader implementations for ADO.NET databases (DbConnection/DbCommand), built on Wolfgang.Etl.Abstractions.</Description>


### PR DESCRIPTION
## Summary

Audit per #90. The existing setup was already mostly correct — `<AssemblyVersion>1.0.0.0</AssemblyVersion>` is intentionally pinned for binding stability, with a clear comment explaining the design. This PR tightens it up:

- **Adds explicit `<InformationalVersion>$(Version)</InformationalVersion>`** — was implicit (defaults to `$(Version)`); making it explicit so it's visible in metadata dumps and to anyone reading the csproj.
- **Expands the comment block** into a table-shaped breakdown of each version's role, so a future maintainer doesn't have to re-derive the rationale from git blame.

## Net effect on consumers

**Zero.** The CLR's binding identity stays at `1.0.0.0`, NuGet's package version stays at `0.3.0`, and `<FileVersion>` still derives the 4-part Windows value via the existing regex. The change is purely about auditability.

## Strategy at a glance

| Property | Value | Role |
|---|---|---|
| `<Version>` | `0.3.0` | release version (source of truth); update at release time |
| `<AssemblyVersion>` | `1.0.0.0` | CLR binding identity; pinned so consumers don't need binding redirects per minor/patch bump — **only bump on a deliberate breaking change** |
| `<FileVersion>` | regex-derived from `$(Version)` | 4-part Windows file-properties value |
| `<InformationalVersion>` | `$(Version)` | human-readable version (now explicit) |

## Closes
- **#90** — `[Maintenance] cleanup: Version metadata consistency`

## Test plan
- [x] `dotnet build src/Wolfgang.Etl.DbClient -c Release` — clean.
- [ ] Inspect resulting assembly's `AssemblyInformationalVersionAttribute` shows `0.3.0`.

## Stack
M04 of the Tier-1 maintenance stack. Base: `chore/template-drift-resolve` (M03 → #164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)