### PR TITLE
docs: repo settings & branch-protection audit (#114)

### DIFF
--- a/docs/REPO-SETTINGS-AUDIT.md
+++ b/docs/REPO-SETTINGS-AUDIT.md
@@ -1,0 +1,61 @@
+# Repo Settings & Branch-Protection Audit
+
+Snapshot of the canonical settings and the audit result for this repo.
+This document is **descriptive** — the source of truth lives in:
+
+- the **GitHub Ruleset** (`Protect main branch`) — ruleset id `14462276`
+- the **repo settings** (Settings → General → Pull Requests + Settings → Branches)
+
+To re-apply the canonical settings programmatically, see
+`scripts/Setup-BranchRuleset.ps1` and `scripts/Setup-GitHubPages.ps1` in the
+canonical `repo-template`.
+
+## Branch-protection ruleset — `Protect main branch`
+
+| Rule | Configured |
+|---|---|
+| `pull_request` (require PR) | ✅ |
+| `required_status_checks` | ✅ (8 checks, see below) |
+| `code_scanning` (CodeQL must succeed) | ✅ |
+| `copilot_code_review` (Copilot review required) | ✅ |
+| `non_fast_forward` (no force-push) | ✅ |
+| `deletion` (no branch delete) | ✅ |
+| `code_quality` | ✅ |
+
+### Required status checks
+
+| Check name | Workflow |
+|---|---|
+| `Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate` | `pr.yaml` |
+| `Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)` | `pr.yaml` |
+| `Stage 3: macOS Tests (.NET 6.0-10.0)` | `pr.yaml` |
+| `Security Scan (DevSkim)` | `pr.yaml` |
+| `Security Scan (CodeQL) (csharp)` | `codeql.yaml` |
+| `Secrets Scan (gitleaks)` | `pr.yaml` |
+| `Detect .NET Projects` | `pr.yaml` |
+| `Integration (all)` | `pr.yaml` (aggregator over the per-RDBMS matrix) |
+
+## Repo-level settings
+
+| Setting | Value |
+|---|---|
+| `deleteBranchOnMerge` | ✅ true |
+| `squashMergeAllowed` | ✅ true |
+| `mergeCommitAllowed` | ✅ true |
+| `rebaseMergeAllowed` | ✅ true |
+| `viewerDefaultMergeMethod` | `MERGE` (used for the stacked-PR workflow) |
+| `hasIssuesEnabled` | ✅ true |
+| `hasProjectsEnabled` | ✅ true |
+| `hasWikiEnabled` | ✅ true |
+
+## Audit result
+
+**No drift.** Ruleset rule set, required status checks, and repo merge settings all match the canonical pattern. The `MERGE` default merge method is intentional — the maintainer's stacked-PR workflow relies on merge commits so the stack's history stays visible after each merge (squash would flatten it).
+
+## Re-audit cadence
+
+This document captures the state at the time of [issue #114](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/114). Re-run the audit:
+
+- when a new required check is added to `pr.yaml` (update the table above + the ruleset).
+- when the canonical ruleset changes in `repo-template`.
+- before each release that adds or removes a CI stage.


### PR DESCRIPTION
## Summary

Audit per #114 acceptance criteria: "Repo settings and branch ruleset match the canonical standard."

**Result: no drift.** Captured the findings in [`docs/REPO-SETTINGS-AUDIT.md`](docs/REPO-SETTINGS-AUDIT.md) so the snapshot is discoverable and future re-audits have a baseline to compare against.

## Findings

| Area | Status |
|---|---|
| Ruleset (`Protect main branch`, id `14462276`) | ✅ 7 rules active (pull_request, required_status_checks, code_scanning, copilot_code_review, non_fast_forward, deletion, code_quality) |
| Required status checks | ✅ all 8 expected checks present (Stage 1/2/3, DevSkim, CodeQL, gitleaks, Detect .NET Projects, Integration (all)) |
| `deleteBranchOnMerge` | ✅ true |
| Merge methods | ✅ all 3 enabled, default `MERGE` (intentional — stacked-PR workflow relies on merge commits) |

## Closes
- **#114** — `[Maintenance] CI/CD: Repo settings and branch-protection consistency audit`

## Stack
M08 of the Tier-1 maintenance stack. Base: `ci/gha-hardening` (M06 → #167). M07 (#108 CodeQL security-extended) was a no-op — already done; closed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)