### PR TITLE
chore(nuget): wire PackageIcon (#112)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -34,6 +34,7 @@
     <Description>Extractor and Loader implementations for ADO.NET databases (DbConnection/DbCommand), built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/Wolfgang.Etl.DbClient</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
     <RepositoryUrl>https://github.com/Chris-Wolfgang/Wolfgang.Etl.DbClient</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -53,6 +54,14 @@
     <None Include="..\..\README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
+    </None>
+    <!-- NuGet PackageIcon: 180×180 PNG, sourced from the canonical favicon set
+         that ships under docfx_project/. Pinned to a single asset so the
+         package icon and the docs site favicon stay in lockstep. -->
+    <None Include="..\..\docfx_project\apple-touch-icon.png">
+      <Pack>True</Pack>
+      <PackagePath>\icon.png</PackagePath>
+      <Visible>False</Visible>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Audit per #112. Everything else was already done — only gap was PackageIcon.

| Quality item | Status |
|---|---|
| SourceLink | ✅ `Microsoft.SourceLink.GitHub` in `Directory.Build.props` |
| Deterministic build | ✅ `ContinuousIntegrationBuild=true` when `CI` |
| Symbol packages (`.snupkg`) | ✅ `IncludeSymbols=true` + `SymbolPackageFormat=snupkg` |
| Source embedding | ✅ `EmbedUntrackedSources=true` + `PublishRepositoryUrl=true` |
| Metadata | ✅ Description, PackageTags, License (MIT), PackageReadmeFile, Authors, Copyright, RepositoryUrl |
| **PackageIcon** | ❌ → **✅ this PR** |

Points `PackageIcon` at `docfx_project/apple-touch-icon.png` — the 180×180 PNG that ships with the canonical favicon set (added to vNext in M02). Keeps the NuGet package icon and the docs site favicon in lockstep.

## Verified

```
$ dotnet pack src/Wolfgang.Etl.DbClient -c Release
Successfully created package 'Wolfgang.Etl.DbClient.0.3.0.nupkg'
Successfully created package 'Wolfgang.Etl.DbClient.0.3.0.snupkg'

$ unzip -l ...0.3.0.nupkg | grep -E 'icon|README'
11220  README.md
 4308  icon.png   ← new
```

## Closes
- **#112** — `[Maintenance] CI/CD: NuGet package quality`

## Stack
M09 of the Tier-1 maintenance stack. Base: `ci/branch-protection-audit` (M08 → #169).

🤖 Generated with [Claude Code](https://claude.com/claude-code)