### PR TITLE
chore(benchmarks): curated .editorconfig + Sqlite bump (#117)

### DIFF
--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,40 @@
+# Benchmark-specific analyzer policy.
+#
+# Benchmark projects hold themselves to the same TreatWarningsAsErrors gate as
+# src/ (set in Directory.Build.props for the Release configuration). The
+# exceptions below suppress analyzer codes that fight BenchmarkDotNet's
+# required type/method shape — sealing benchmark classes, async naming,
+# `Task<T>` return types where BDN wants `void`, and the abbreviated Dispose
+# pattern BDN documents in its samples. Every suppression has a one-line
+# rationale; remove a rule from this file only when the underlying conflict
+# with BenchmarkDotNet has been resolved.
+
+[*.cs]
+
+# MA0004 — Use Task.ConfigureAwait. BenchmarkDotNet's [Benchmark] methods are
+# run inside a synchronization-context-free harness; ConfigureAwait(false)
+# adds noise without changing observable behaviour.
+dotnet_diagnostic.MA0004.severity = none
+
+# MA0048 — File name must match type name. BDN samples and the benchmark
+# project here use one file per benchmark grouping; the grouping name and
+# the file name can legitimately diverge (e.g. nested classes for
+# parameter sources).
+dotnet_diagnostic.MA0048.severity = none
+
+# VSTHRD200 — Use "Async" suffix in names of methods that return Task.
+# BDN-decorated methods (`[Benchmark] public Task Foo()`) are invoked by
+# the harness, not by user code. The naming convention is BDN's, not ours.
+dotnet_diagnostic.VSTHRD200.severity = none
+
+# CA1063 — Implement IDisposable correctly. BDN benchmark classes can't be
+# sealed (BDN derives a runner type from them at runtime), and BDN's
+# documented lifecycle gives [GlobalCleanup] full ownership of teardown,
+# so the abbreviated `public void Dispose()` is intentional. The
+# `_disposed` guard in DbLoaderBatchSizeBenchmarks.cs makes the call
+# idempotent.
+dotnet_diagnostic.CA1063.severity = none
+
+# S3881 — "IDisposable" should be implemented correctly. Same rationale
+# as CA1063 — BDN's lifecycle owns teardown, not the standard pattern.
+dotnet_diagnostic.S3881.severity = none

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj
@@ -5,10 +5,20 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <!-- CA1063, S3881: BenchmarkDotNet requires non-sealed benchmark types, but the IDisposable
-         pattern analyzers want sealed or full Dispose(bool). BDN's lifecycle is fully controlled
-         by GlobalSetup/GlobalCleanup so the abbreviated Dispose() is intentional. -->
-    <NoWarn>$(NoWarn);MA0004;MA0048;VSTHRD200;CA1063;S3881</NoWarn>
+    <!-- Analyzer-rule suppressions for BenchmarkDotNet compatibility now live
+         in benchmarks/.editorconfig (curated, one-comment-per-rule). The
+         Release-mode TreatWarningsAsErrors gate inherited from
+         Directory.Build.props stays on for every other rule.
+
+         NU1903 (NuGet vulnerability warning) is suppressed for the benchmarks
+         project only — the bundled SQLite native library (SQLitePCLRaw.lib.
+         e_sqlite3) is on GHSA-2m69-gcr7-jv3q and the upstream advisory has no
+         patched version yet (firstPatchedVersion: null at audit time). The
+         benchmark assembly is never published or distributed, so the impact
+         is limited to local + CI bench runs. Re-evaluate when the advisory
+         gets a fix. NU1903 is a NuGet warning, not an analyzer diagnostic,
+         so it must be suppressed here (not in editorconfig). -->
+    <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />


### PR DESCRIPTION
## Summary

Issue #117 asked for a curated `benchmarks/.editorconfig` so the existing wall of `<NoWarn>` codes in the csproj gets a per-rule rationale. Benchmarks already inherited `TreatWarningsAsErrors` from `Directory.Build.props` — the gap was discoverability of why each rule was off.

## Changes

| File | Change |
|---|---|
| **** (new) | Each previously-suppressed analyzer rule (MA0004, MA0048, VSTHRD200, CA1063, S3881) now has its own `dotnet_diagnostic.X.severity = none` entry with a one-paragraph rationale explaining the BenchmarkDotNet conflict that motivated the suppression. |
| **`benchmarks/.../*.csproj`** | Removes the opaque `<NoWarn>MA0004;MA0048;VSTHRD200;CA1063;S3881</NoWarn>`. Leaves a single `NoWarn;NU1903` (see below). |
| **`benchmarks/.../*.csproj`** | Bumps `Microsoft.Data.Sqlite` 9.0.3 → 10.0.9 to align with the .NET 10 surface. |

## NU1903 (security) — left suppressed in csproj

The bundled SQLite native library () is on [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) and the upstream advisory **has no patched version yet** (`firstPatchedVersion: null` at audit time). NU1903 is a NuGet warning, not an analyzer diagnostic, so it can't be turned off via editorconfig — must stay in csproj `NoWarn`. The benchmark assembly is never published; impact limited to local + CI bench runs.

## Closes
- **#117** — `[Maintenance] performance: Hold benchmark projects to TreatWarningsAsErrors (curated benchmarks/.editorconfig)`

## Test plan
- [x] `dotnet build benchmarks/Wolfgang.Etl.DbClient.Benchmarks -c Release` — 0 warnings / 0 errors.

## Stack
M10 of the Tier-1 maintenance stack. Base: `chore/nuget-package-quality` (M09 → #170).

🤖 Generated with [Claude Code](https://claude.com/claude-code)