### PR TITLE
test: add Stryker mutation testing config (#99)

### DIFF
--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/stryker-config.json
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/stryker-config.json
@@ -1,0 +1,25 @@
+{
+    "stryker-config": {
+        "project": "../../src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj",
+        "test-projects": [
+            "Wolfgang.Etl.DbClient.Tests.Unit.csproj"
+        ],
+        "target-framework": "net10.0",
+        "reporters": [
+            "html",
+            "progress",
+            "cleartext"
+        ],
+        "mutation-level": "Standard",
+        "concurrency": 0,
+        "thresholds": {
+            "high": 80,
+            "low": 60,
+            "break": 0
+        },
+        "ignore-mutations": [
+            "string"
+        ],
+        "comment": "thresholds.break=0 keeps the run non-gating per #99 (scheduled + workflow_dispatch only, not a PR gate). Raise to a real score (50, 60, ...) when the mutation baseline is established and you want a gate."
+    }
+}


### PR DESCRIPTION
## Summary

The Stryker workflow (`.github/workflows/stryker.yaml`) was already canonical infrastructure; it just no-op'd because no `stryker-config.json` was present. This PR adds the per-suite config that turns it on.

## Config

`tests/Wolfgang.Etl.DbClient.Tests.Unit/stryker-config.json`:

| Setting | Value |
|---|---|
| `project` | `../../src/Wolfgang.Etl.DbClient/.csproj` |
| `test-projects` | `[Wolfgang.Etl.DbClient.Tests.Unit.csproj]` |
| `target-framework` | `net10.0` |
| `mutation-level` | Standard |
| `reporters` | html + progress + cleartext |
| `thresholds.high` | 80 |
| `thresholds.low` | 60 |
| `thresholds.break` | **0** (non-gating per #99) |
| `ignore-mutations` | `["string"]` |

`break=0` keeps the workflow non-gating: it runs, reports a score, never fails CI. Raise to a real number once there's a stable baseline.

## How it runs

`.github/workflows/stryker.yaml` already wired:
- `workflow_dispatch` (manual)
- Weekly cron (`0 6 * * 0`)
- Auto-detects `stryker-config.json` at repo root or under `tests/**/` (this PR ships the second shape)

## Closes
- **#99** — `[Maintenance] testing: Add Stryker mutation testing`

## Stack
M14 of the Tier-1 maintenance stack. Base: `cleanup/dead-code-tests-benchmarks` (M12 → #172). M11 + M13 were no-ops (#102 already met, #97 already met).

🤖 Generated with [Claude Code](https://claude.com/claude-code)