### PR TITLE
docs: CHANGELOG v0.3.0 + README/Markdown accuracy audit (#101 #103 #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] — code-review pass + integration-test surface
+
 ### Added
+- `DbClientOptions.StrictColumnMapping` (default `false`) — opt-in flag that converts unmapped result-set columns from Dapper's silent-drop default into a descriptive `InvalidOperationException` naming the column and target type. Preserves out-of-the-box Dapper behavior by default. Useful for catching `[Column]` typos during development.
+- `DbLoader<TRecord>.BatchSize` — new batched-execution knob. Defaults to `1` (one round-trip per record, unchanged behavior); raise it to amortize per-call overhead on networked databases. `SkipItemCount` / `MaximumItemCount` are still honored at per-record granularity.
+- Integration-test surface (Testcontainers): SQL Server, PostgreSQL, MySQL, MariaDB, CockroachDB, SQLite across net8.0 and net10.0, gated by the `Integration (all)` aggregator on every PR.
+- Per-RDBMS dynamic shields.io status badges + per-RDBMS BenchmarkDotNet charts published to `gh-pages`.
 
 ### Changed
-
-### Deprecated
-
-### Removed
+- **Major perf win** in `DbCommandBuilder`: per-`Type` cache of reflection results + pre-built SQL strings. BuildSelect / BuildInsert / BuildUpdate went from ~7–8 µs to ~5 ns each (~1500× faster, zero allocations on cache hits).
+- **Major perf win** in `ColumnAttributeTypeMapper`: replaced per-column reflection + LINQ scan with a single-pass `Dictionary<string, PropertyInfo>` built once at `Register<T>()`. 6-column lookup went from 15.69 µs to 202 ns (~77× faster).
+- `DbExtractor` now takes a defensive copy of the caller's parameter dictionary at construction; cached `DynamicParameters` wrapper for reuse across the data query and the default total-count query.
+- `DbLoader.LoadWorkerAsync` split into named caller-managed vs auto-managed transaction helpers for readability.
+- Thread-safety hardening across extractor + loader (`Interlocked.CompareExchange` for the progress-timer wiring one-shot; documented single-use contract).
+- CI Stage 1 / 2 / 3 path-gated via stub jobs (docs-only PRs skip the multi-TFM matrix while keeping ruleset-required check names green).
 
 ### Fixed
+- `DbReport` restored the 4-arg constructor as a `[EditorBrowsable(Never)]` binary-compat shim so already-compiled consumers don't hit `MissingMethodException`.
 
-### Security
+## [0.2.x] and earlier
+
+See git history.
+
+[Unreleased]: https://github.com/Chris-Wolfgang/Etl-DbClient/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Chris-Wolfgang/Etl-DbClient/releases/tag/v0.3.0


### PR DESCRIPTION
## Summary

Combines M17 / M18 / M19 — three docs audits all touching Markdown.

## #101 — CHANGELOG

`CHANGELOG.md` already existed but was an empty Keep-a-Changelog skeleton. Filled in the v0.3.0 entry sourced from PR #126's description:

- **Added** — `DbClientOptions.StrictColumnMapping`, `DbLoader<T>.BatchSize`, full integration-test surface, per-RDBMS dynamic badges, per-RDBMS benchmark charts.
- **Changed** — DbCommandBuilder cache (~1500×), ColumnAttributeTypeMapper cache (~77×), defensive parameter copy, LoadWorkerAsync split, thread-safety hardening, Stage 1/2/3 path-gating.
- **Fixed** — DbReport 4-arg binary-compat shim.

Added `[Unreleased]` and `[0.3.0]` comparison links at the bottom.

## #103 — README accuracy

Audit findings: **zero inaccuracies**. The Target Frameworks table matches the csproj exactly; the Tested Databases table versions match the integration fixtures; badge URLs all resolve.

## #104 — Other Markdown files

Audit findings: **zero inaccuracies**. CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md, REPO-INSTRUCTIONS.md are canonical-template content. `docs/README-FORMATTING.md`, `RELEASE-WORKFLOW-SETUP.md`, `WORKFLOW_SECURITY.md`, and `REPO-SETTINGS-AUDIT.md` (added in M08) describe current state.

## Closes
- **#101** — `[Maintenance] docs: Create a CHANGELOG if missing`
- **#103** — `[Maintenance] docs: Audit README for accuracy`
- **#104** — `[Maintenance] docs: Audit other Markdown files for accuracy`

## Stack
M17 + M18 + M19 combined, of the Tier-1 maintenance stack. Base: `test/add-stryker` (M14 → #173). M15 (#120 test quality audit) and M16 (#100 standardize README) were no-ops — already met; closed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)