### PR TITLE
Canonical sync (protected files) ahead of v0.2.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,13 +25,13 @@ indent_size = 2
 [*.{yml,yaml}]
 indent_size = 2
 
-# PowerShell files inherit LF + UTF-8 (no BOM) + 4-space indent from
-# the global [*] section above — no [*.ps1] override needed. The
-# `charset = utf-8` setting is what prevents editors from writing a
-# BOM, which together with the LF requirement keeps the
-# `#!/usr/bin/env pwsh` shebang (where present) on scripts under
-# `scripts/` working on Linux/macOS — CR breaks the kernel's exec
-# lookup, and a leading BOM prevents shebang recognition entirely.
+# PowerShell scripts inherit LF + UTF-8 (no BOM) + 4-space indent from
+# the global [*] section above — no per-language override is needed.
+# LF + no-BOM is required for the `#!/usr/bin/env pwsh` shebang (where
+# present) on scripts under scripts/ to work on Linux/macOS — CR
+# breaks the kernel's exec lookup, and a leading BOM prevents shebang
+# recognition entirely.
+
 # C# files
 [*.cs]
 

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -37,7 +37,7 @@ jobs:
     name: "Benchmarks / sqlite"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: actions/setup-dotnet@v5
@@ -53,7 +53,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: "ExtractorBenchmarks (sqlite)"
           tool: 'benchmarkdotnet'
@@ -87,7 +87,7 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: actions/setup-dotnet@v5
@@ -104,7 +104,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: "ExtractorBenchmarks (sqlserver)"
           tool: 'benchmarkdotnet'
@@ -138,7 +138,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: actions/setup-dotnet@v5
@@ -155,7 +155,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: "ExtractorBenchmarks (postgres)"
           tool: 'benchmarkdotnet'
@@ -189,7 +189,7 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: actions/setup-dotnet@v5
@@ -208,7 +208,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: "ExtractorBenchmarks (mysql)"
           tool: 'benchmarkdotnet'
@@ -242,7 +242,7 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: actions/setup-dotnet@v5
@@ -261,7 +261,7 @@ jobs:
             -- --filter "*ExtractorBenchmarks*" --exporters json --artifacts BDN_OUT
 
       - name: Publish to gh-pages
-        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: "ExtractorBenchmarks (mariadb)"
           tool: 'benchmarkdotnet'

--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository (full history + all tags)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Full history so all tags are reachable
           persist-credentials: false

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         persist-credentials: false
 
@@ -77,7 +77,7 @@ jobs:
 
     - name: Initialize CodeQL
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
@@ -128,7 +128,7 @@ jobs:
     - name: Perform CodeQL Analysis
       id: perform-codeql-analysis
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false

--- a/.github/workflows/integration-status.yaml
+++ b/.github/workflows/integration-status.yaml
@@ -1,0 +1,228 @@
+name: Integration Status (per-RDBMS badges → gh-pages)
+
+# Runs the integration matrix on main and publishes one shields.io
+# endpoint-format JSON per RDBMS to gh-pages at dev/status/<rdbms>.json.
+# README badges read those JSONs via https://img.shields.io/endpoint?url=...
+#
+# Why a dedicated workflow (rather than reusing pr.yaml's test-integration)?
+# pr.yaml uses `pull_request_target` and only runs on PR events. To keep the
+# per-RDBMS badges in sync with what's actually on main, we re-run the
+# matrix on every push to main and write fresh status JSONs.
+#
+# Why aggregate per-RDBMS instead of per-cell (rdbms × tfm)? The "Tested
+# Databases" matrix in README has one row per RDBMS; users care whether
+# the DB works, not which TFM ran the test. An RDBMS is "passing" only
+# when every TFM cell for it passed.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write    # write per-RDBMS status JSONs to gh-pages
+  pull-requests: read
+
+concurrency:
+  # Serialize against ourselves so two pushes to main never race the
+  # gh-pages write. The publish-status job below also does a
+  # fetch+rebase+retry loop before pushing so it stays correct when
+  # benchmarks.yaml / docfx.yaml are pushing to gh-pages at the same
+  # time (each writes a distinct sub-directory, so the rebase is
+  # always conflict-free).
+  group: integration-status
+  cancel-in-progress: false
+
+jobs:
+  # ============================================================================
+  # MATRIX: run the integration tests, capture pass/fail per (rdbms, tfm)
+  # ============================================================================
+  test-matrix:
+    name: "Status / ${{ matrix.rdbms }} (${{ matrix.tfm }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    strategy:
+      fail-fast: false
+      matrix:
+        rdbms: [sqlserver, postgres, mysql, mariadb, cockroachdb, sqlite]
+        tfm: [net8.0, net10.0]
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Locate integration project
+        id: locate
+        shell: bash
+        run: |
+          proj=$(find ./tests -type f \
+            \( -name "*.Tests.Integration.csproj" \
+            -o -name "*.Tests.Integration.vbproj" \
+            -o -name "*.Tests.Integration.fsproj" \) \
+            | head -n1)
+          if [ -z "$proj" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "project=$proj" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ${{ matrix.rdbms }} (${{ matrix.tfm }})
+        id: run-tests
+        if: steps.locate.outputs.found == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          # Capture dotnet test's output so we can distinguish a real failure
+          # from "no tests matched the filter" — the latter exits non-zero on
+          # newer SDKs but is not an actual regression (it happens transiently
+          # while a new RDBMS Category trait is rolling out across stacked PRs).
+          set +e
+          out=$(dotnet test "${{ steps.locate.outputs.project }}" \
+            --configuration Release \
+            --framework ${{ matrix.tfm }} \
+            --filter "Category=${{ matrix.rdbms }}" \
+            -p:TreatWarningsAsErrors=true \
+            --logger "console;verbosity=normal" 2>&1)
+          rc=$?
+          echo "$out"
+
+          if [ $rc -ne 0 ] && echo "$out" | grep -qE "No test (is available|matches the given test|s were found)"; then
+            echo "no_tests=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          exit $rc
+
+      - name: Record cell outcome
+        if: always()
+        run: |
+          mkdir -p _status
+          # outcome is "success", "failure", "skipped", or — when the filter
+          # matched zero tests — we override to "skipped" so the aggregator
+          # doesn't treat a missing trait as a failing badge.
+          if [ "${{ steps.run-tests.outputs.no_tests }}" = "true" ]; then
+            outcome="skipped"
+          else
+            outcome="${{ steps.run-tests.outcome || 'skipped' }}"
+          fi
+          echo "$outcome" > "_status/${{ matrix.rdbms }}__${{ matrix.tfm }}.txt"
+
+      - name: Upload cell outcome
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: status-${{ matrix.rdbms }}-${{ matrix.tfm }}
+          # Upload the specific file (not the directory) so the artifact's
+          # internal layout is a flat <rdbms>__<tfm>.txt. download-artifact
+          # extracts into `_status/`, giving `_status/<rdbms>__<tfm>.txt` —
+          # the layout the aggregator glob below expects.
+          path: _status/${{ matrix.rdbms }}__${{ matrix.tfm }}.txt
+
+  # ============================================================================
+  # PUBLISH: aggregate cell outcomes per-RDBMS, write JSONs to gh-pages
+  # ============================================================================
+  publish-status:
+    name: "Publish per-RDBMS status to gh-pages"
+    runs-on: ubuntu-latest
+    needs: test-matrix
+    # Run even when some cells failed — we still want fresh badge state.
+    if: always() && github.repository != 'Chris-Wolfgang/repo-template'
+
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: gh-pages
+          # Don't persist the token in local git config. The push step below
+          # sets the remote URL explicitly with $GITHUB_TOKEN when needed —
+          # same pattern as docfx.yaml.
+          persist-credentials: false
+
+      - name: Download all cell outcomes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: _status
+          merge-multiple: true
+
+      - name: Aggregate per-RDBMS and write JSONs
+        shell: bash
+        run: |
+          mkdir -p dev/status
+
+          # An RDBMS is "passing" iff EVERY (rdbms, tfm) cell succeeded.
+          # Any failure → "failing". Any skip (with no failures) → "unknown".
+          for rdbms in sqlserver postgres mysql mariadb cockroachdb sqlite; do
+            aggregate="passing"
+            color="brightgreen"
+            for file in _status/${rdbms}__*.txt; do
+              [ -f "$file" ] || continue
+              outcome=$(cat "$file" | tr -d '[:space:]')
+              echo "  ${rdbms} → $(basename "$file" .txt): $outcome"
+              case "$outcome" in
+                success)   ;;
+                failure)   aggregate="failing"; color="red"; break ;;
+                *)         aggregate="unknown"; color="lightgrey" ;;
+              esac
+            done
+
+            # Pretty label per RDBMS (keep parity with README copy).
+            case "$rdbms" in
+              sqlserver)   label="SQL Server" ;;
+              postgres)    label="PostgreSQL" ;;
+              mysql)       label="MySQL" ;;
+              mariadb)     label="MariaDB" ;;
+              cockroachdb) label="CockroachDB" ;;
+              sqlite)      label="SQLite" ;;
+            esac
+
+            cat > "dev/status/${rdbms}.json" <<EOF
+          {
+            "schemaVersion": 1,
+            "label": "${label}",
+            "message": "${aggregate}",
+            "color": "${color}"
+          }
+          EOF
+            echo "✓ wrote dev/status/${rdbms}.json (${aggregate})"
+          done
+
+      - name: Commit + push status JSONs
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git add dev/status/
+          if git diff --cached --quiet; then
+            echo "No status changes to commit"
+            exit 0
+          fi
+          git commit -m "chore(status): update per-RDBMS integration status for ${GITHUB_SHA::7}"
+
+          # Retry on non-fast-forward — benchmarks.yaml / docfx.yaml may have
+          # pushed to gh-pages while we were building the status JSONs. Each
+          # writer touches a distinct subdir (dev/status vs dev/bench/<rdbms>
+          # vs the docs root), so rebase is always conflict-free.
+          for attempt in 1 2 3 4 5; do
+            if git push origin gh-pages; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed on attempt $attempt — fetching + rebasing"
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+          done
+
+          echo "::error::Failed to push to gh-pages after 5 attempts"
+          exit 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,7 +44,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -85,7 +85,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -231,7 +231,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -240,7 +240,7 @@ jobs:
           fetch-depth: 0
 
       - name: Filter changed paths
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           # Compare against the PR's base branch so we see the full PR diff,
@@ -282,7 +282,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -706,7 +706,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -824,7 +824,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1130,7 +1130,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1523,7 +1523,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -347,7 +347,7 @@ jobs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -669,7 +669,7 @@ jobs:
         run: zip -r release-coverage.zip ./release-coverage
 
       - name: Attach artifacts to release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -1,0 +1,107 @@
+# Stryker mutation testing
+#
+# Runs the Stryker.NET mutation tester against the repo's test projects to
+# measure mutation score. Mutation runs are slow — triggered manually
+# (workflow_dispatch) and on a weekly schedule, not on every PR.
+#
+# The workflow looks for a stryker-config.json at the repo root or under
+# tests/**/. If none is present the run is a no-op (Stryker setup is a
+# per-repo follow-up; this file is the canonical infrastructure).
+name: Stryker (mutation testing)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 0' # weekly Sunday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  stryker:
+    name: Run Stryker
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Detect stryker-config.json
+        id: check
+        shell: bash
+        run: |
+          # Explicit existence checks rather than globbing — `nullglob` only
+          # drops words that look like patterns (contain *, ?, [). The bare
+          # literal `stryker-config.json` has no glob characters, so it would
+          # be preserved as a literal even when the file doesn't exist, and
+          # the workflow would mistakenly think a config was present.
+          shopt -s globstar nullglob
+          configs=()
+          [ -f stryker-config.json ] && configs+=(stryker-config.json)
+          for cfg in tests/**/stryker-config.json; do
+            [ -f "$cfg" ] && configs+=("$cfg")
+          done
+          if (( ${#configs[@]} )); then
+            printf 'found=true\n' >> "$GITHUB_OUTPUT"
+            # NOTE: previously also wrote a configs<<EOF multi-line output here,
+            # but (a) the downstream Run Stryker step re-globs from scratch and
+            # didn't consume it, and (b) ${configs[*]} joins with spaces so the
+            # value was effectively a single space-separated line — not actually
+            # multi-line. Dropped the dead/broken output.
+          else
+            echo "::notice::No stryker-config.json found — skipping Stryker run. Add one at repo root or under tests/<project>/ to enable mutation testing."
+            printf 'found=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Install dotnet-stryker
+        if: steps.check.outputs.found == 'true'
+        run: dotnet tool update -g dotnet-stryker || dotnet tool install -g dotnet-stryker
+
+      - name: Run Stryker
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          set -e
+          shopt -s globstar nullglob
+          # Run BOTH a root stryker-config.json (if present) AND any
+          # tests/**/stryker-config.json suites. The Detect step collects
+          # both shapes; running only one leaves per-test suites unscanned
+          # in repos that have both an umbrella and per-suite configs.
+          ran=0
+          if [ -f stryker-config.json ]; then
+            echo "::group::Stryker with root stryker-config.json"
+            dotnet stryker --config-file stryker-config.json
+            echo "::endgroup::"
+            ran=1
+          fi
+          for cfg in tests/**/stryker-config.json; do
+            dir=$(dirname "$cfg")
+            echo "::group::Stryker in $dir"
+            (cd "$dir" && dotnet stryker)
+            echo "::endgroup::"
+            ran=1
+          done
+          if [ "$ran" -eq 0 ]; then
+            echo "::error::Detect step said stryker-config.json was present, but Run found neither root nor tests/**/stryker-config.json. Bailing."
+            exit 1
+          fi
+
+      - name: Upload Stryker report
+        if: always() && steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: stryker-report-${{ github.run_id }}
+          path: |
+            **/StrykerOutput/**
+          if-no-files-found: ignore
+          retention-days: 30

--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -79,4 +79,3 @@ M:System.Console.ReadLine(); Blocking - avoid in async code paths
 M:System.Console.Read(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(System.Boolean); Blocking - avoid in async code paths
-

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,14 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+    <!-- Enable nullable reference types for every SDK-style C# project.
+         The condition excludes:
+           - F# (.fsproj) and VB (.vbproj) — by the .csproj check
+           - Legacy non-SDK csproj (no Microsoft.NET.Sdk import) — by the
+             $(UsingMicrosoftNETSdk) check
+         SDK-style C# projects that need to opt out can set
+         <Nullable>disable</Nullable> in their own csproj. -->
+    <Nullable Condition="'$(MSBuildProjectExtension)' == '.csproj' and '$(UsingMicrosoftNETSdk)' == 'true'">enable</Nullable>
 
     <!-- Enable .NET analyzers -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -56,4 +64,51 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
+         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
+         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
+         project directory and the analyzer activates for that project only.
+         Library projects under src/ should opt in; test / example /
+         benchmark projects should not. Per-repo enablement is tracked as a
+         follow-up maintenance issue. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!--
+    PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt are auto-added as
+    AdditionalFiles by the Microsoft.CodeAnalysis.PublicApiAnalyzers package's
+    .targets when present in the project directory. Adding them again here
+    would double-register every declaration and cause spurious RS0017 errors.
+  -->
+
+
+  <PropertyGroup>
+    <!-- CI3: NuGet package metadata canonical defaults. Per-repo fields
+         (Description, PackageTags, PackageProjectUrl, RepositoryUrl,
+         PackageLicenseExpression, PackageReadmeFile) stay in each src
+         csproj where they are repo-specific. -->
+    <Authors>Chris Wolfgang</Authors>
+    <Company>Chris Wolfgang</Company>
+    <Copyright>Copyright (c) Chris Wolfgang</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- SourceLink: embed source provenance into PDBs so debuggers can step
+         into NuGet package code from GitHub. -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Why this PR exists

The Release v0.2.1 PR ([#126](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/126)) has 59 files in its diff, **11 of which are "protected"** under `pr.yaml`'s `Detect .NET Projects` guard. Merging #126 as-is would require admin-bypass on the whole 59-file diff — and the bypass waives every ruleset rule at once, including `required_review_thread_resolution` on the 48 *non-protected* files.

This split-out PR carries only the 11 protected files so the bypass surface is small and easy to eyeball. #126 then merges through the standard ruleset with full review-thread enforcement.

## What's in here

| File | Why it's protected |
|------|--------------------|
| `.editorconfig` | Root `.editorconfig` is exact-match protected — controls analyzer rules and code style |
| `BannedSymbols.txt` | Banned API list — protected so a malicious PR can't allow `Process.Start("rm")` past CI |
| `Directory.Build.props` | MSBuild defaults — protected so analyzer/SDK pins can't be silently disabled |
| `.github/workflows/benchmarks.yaml` | Workflow files glob-protected (P2 BenchmarkDotNet → chart) |
| `.github/workflows/build-all-versions.yaml` | Same |
| `.github/workflows/codeql.yaml` | Same |
| `.github/workflows/docfx.yaml` | Same |
| `.github/workflows/integration-status.yaml` | Same (per-DB integration status badges) |
| `.github/workflows/pr.yaml` | Same — this is the file that *defines* the guard |
| `.github/workflows/release.yaml` | Same |
| `.github/workflows/stryker.yaml` | Same (new in this release — T3 mutation-testing workflow) |

These are **verbatim copies** of vNext's content. No edits applied during extraction — `git diff origin/main` shows exactly the deltas already on vNext.

## Expected CI behaviour

- `Detect .NET Projects` → ❌ FAIL (expected — that's why we're splitting)
- Stages 1/2/3 → SKIPPED (gated on `detect-projects.outputs.has-projects`)
- Secrets Scan (gitleaks), Security Scan (DevSkim), Security Scan (CodeQL) → ✅ should pass

## Merge plan

1. Maintainer admin-bypass-merges this PR (one click, 11-file diff, easy to review).
2. I merge `origin/main` back into `vNext` — the protected-file delta on [#126](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/126) vanishes.
3. [#126](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/126) flips from "needs admin bypass" to `MERGEABLE` with full ruleset enforcement.
4. [#126](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/126) merges via the normal merge button.

## Same shape as

This is the standard split done today for Try-Pattern #166 ([#202](https://github.com/Chris-Wolfgang/Try-Pattern/pull/202)) and System.Mail-Extensions #119 ([#162](https://github.com/Chris-Wolfgang/System.Mail-Extensions/pull/162)). Same recipe.