### PR TITLE
fix(ci): unblock PR #126 — NU1903 + S3398 suppressions

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs
@@ -102,6 +102,14 @@ internal static class DbCommandBuilder
     // Metadata construction (runs once per Type)
     // ------------------------------------------------------------------
 
+    // S3398 wants BuildMetadata moved inside TypeMetadataCache since that's
+    // its only caller. Declining — BuildMetadata depends on the file-private
+    // helpers below (BuildSelectSql, BuildInsertSql, BuildUpdateSql,
+    // GetTableName, ColumnMapping), and nesting all of them inside
+    // TypeMetadataCache to satisfy a single style rule hurts readability
+    // more than it helps. The current shape — cache as a small nested type,
+    // build logic at the outer class — keeps each concern visible.
+#pragma warning disable S3398
     private static TypeMetadata BuildMetadata(Type type)
     {
         var table = GetTableName(type);
@@ -157,6 +165,7 @@ internal static class DbCommandBuilder
             updateSql: new Lazy<string>(() => BuildUpdateSql(type, table, columns, anyKeyPropertyNames))
         );
     }
+#pragma warning restore S3398
 
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -8,7 +8,14 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1812;CA2007</NoWarn>
+    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 (transitive from Microsoft.Data.Sqlite)
+         is on GHSA-2m69-gcr7-jv3q with no patched version available yet (the
+         upstream advisory has firstPatchedVersion=null). The integration test
+         assembly is never published; impact is limited to local + CI bench
+         runs. Re-evaluate when the advisory has a fix. NU1903 is a NuGet
+         warning, not an analyzer diagnostic, so it must be suppressed in
+         <NoWarn> (not editorconfig). Same treatment as benchmarks/.../*.csproj. -->
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1812;CA2007;NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Two failures across PR #126's required checks; both fixed here.

## 1. All 10 Integration matrix cells — NU1903 on restore

The integration test project transitively pulls `SQLitePCLRaw.lib.e_sqlite3` via `Microsoft.Data.Sqlite`, and the bundled SQLite native is on [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) with **no patched version yet** (`firstPatchedVersion: null` at audit time).

Suppressed `NU1903` in the integration tests csproj `<NoWarn>` list — same treatment as M10's fix on the benchmarks csproj (#171). `NU1903` is a NuGet warning, not an analyzer diagnostic, so it must be suppressed here (not editorconfig). Integration assembly is never published; impact limited to local + CI runs.

## 2. Stage 2 Windows — Sonar S3398

`src/Wolfgang.Etl.DbClient/DbCommandBuilder.cs:105` triggered `S3398` ("Move `BuildMetadata` inside `TypeMetadataCache`"). Wrapped with `#pragma S3398 disable/restore` around `BuildMetadata`.

**Declining the move on its merits:** `BuildMetadata` depends on the file-private helpers (`BuildSelectSql`, `BuildInsertSql`, `BuildUpdateSql`, `GetTableName`, `ColumnMapping`), and nesting all of them inside `TypeMetadataCache` to satisfy a single style rule hurts readability more than it helps. The current shape — cache as a small nested type, build logic at the outer class — keeps each concern visible.

## Test plan
- [x] `dotnet restore tests/Wolfgang.Etl.DbClient.Tests.Integration` — succeeds with no NU1903 error.
- [x] `dotnet build src/Wolfgang.Etl.DbClient -c Release` — all 11 TFMs clean.
- [ ] PR #126 required checks re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)