### PR TITLE
fix(ci): unblock Stage 2 Windows — RS0016/RS0017 + NU1903 in tests

### DIFF
--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -46,3 +46,10 @@ dotnet_diagnostic.S1144.severity = none
 
 # xUnit2013: Use Assert.Single instead of Assert.Equal for collection size
 dotnet_diagnostic.xUnit2013.severity = none
+
+# RS0016/RS0017: PublicApiAnalyzers — only meaningful for src/. Microsoft
+# .CodeAnalysis.PublicApiAnalyzers is loaded fleet-wide via Directory.Build
+# .props but test projects never ship and their public-test-class surface
+# shouldn't be tracked. Disable both rules for everything under tests/.
+dotnet_diagnostic.RS0016.severity = none
+dotnet_diagnostic.RS0017.severity = none

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -8,7 +8,11 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966</NoWarn>
+    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 (transitive from Microsoft.Data.Sqlite)
+         is on GHSA-2m69-gcr7-jv3q with no patched version available yet. Same
+         treatment as benchmarks/.../*.csproj and Tests.Integration. Test
+         assembly is never published; impact limited to local + CI runs. -->
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

After M05 (PR #166) dropped `<NoWarn>RS0017</NoWarn>` from the src csproj, the PublicApiAnalyzers package — loaded fleet-wide via Directory.Build.props — started firing `RS0016` ("Symbol is not part of the declared public API") on every public **test class** across all 12 TFMs.

The package's own `.targets` only auto-adds `PublicAPI.Shipped/Unshipped.txt` when present in the project directory, but the analyzer assemblies are still loaded for every project. Without a baseline to match against, `RS0016` fires for every public symbol — and test projects don't ship and shouldn't be tracked.

## Changes

1. **`tests/.editorconfig`** — added `dotnet_diagnostic.RS0016.severity = none` and `dotnet_diagnostic.RS0017.severity = none` with an explanatory comment.
2. **`tests/Wolfgang.Etl.DbClient.Tests.Unit/*.csproj`** — added `NU1903` to the existing `NoWarn` list (same advisory + rationale as benchmarks and integration tests).

## Test plan
- [x] `dotnet build tests/Wolfgang.Etl.DbClient.Tests.Unit -c Release` — clean across all 12 TFMs.
- [ ] Stage 2 Windows on PR #126 re-runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)