### PR TITLE
fix(ci): blanket RS00* + NU1903 suppression for non-shipping projects

### DIFF
--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -38,3 +38,11 @@ dotnet_diagnostic.CA1063.severity = none
 # S3881 — "IDisposable" should be implemented correctly. Same rationale
 # as CA1063 — BDN's lifecycle owns teardown, not the standard pattern.
 dotnet_diagnostic.S3881.severity = none
+
+# RS0016/RS0017/RS0037 — PublicApiAnalyzers is loaded fleet-wide via
+# Directory.Build.props but only meaningful for src/. Benchmark projects
+# don't ship and shouldn't be tracked. Same suppression that lives in
+# tests/.editorconfig — kept in parity for the whole non-shipping fleet.
+dotnet_diagnostic.RS0016.severity = none
+dotnet_diagnostic.RS0017.severity = none
+dotnet_diagnostic.RS0037.severity = none

--- a/examples/.editorconfig
+++ b/examples/.editorconfig
@@ -1,0 +1,15 @@
+# Example projects don't ship as NuGet packages and shouldn't be held to
+# the same public-API tracking + vulnerability-warning gate as src/.
+
+[*.cs]
+
+# RS0016/RS0017/RS0037 — PublicApiAnalyzers is loaded fleet-wide via
+# Directory.Build.props but only meaningful for src/. Example projects
+# don't ship and shouldn't be tracked. Same suppression that lives in
+# tests/.editorconfig and benchmarks/.editorconfig.
+#   RS0016 — symbol not in PublicAPI
+#   RS0017 — declared in PublicAPI but not found
+#   RS0037 — PublicAPI.txt missing #nullable enable
+dotnet_diagnostic.RS0016.severity = none
+dotnet_diagnostic.RS0017.severity = none
+dotnet_diagnostic.RS0037.severity = none

--- a/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Wolfgang.Etl.DbClient.Example.AutoSql.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Wolfgang.Etl.DbClient.Example.AutoSql.csproj
@@ -6,6 +6,11 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 (transitive from Microsoft.Data.Sqlite)
+         is on GHSA-2m69-gcr7-jv3q with no patched version available yet. Same
+         treatment as the test + benchmark projects. Example assembly is never
+         published; impact limited to local + CI runs. -->
+    <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction.csproj
@@ -6,6 +6,8 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <!-- NU1903: see sister-csproj note in Example.AutoSql. -->
+    <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Wolfgang.Etl.DbClient.Example/Wolfgang.Etl.DbClient.Example.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example/Wolfgang.Etl.DbClient.Example.csproj
@@ -6,7 +6,8 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);MA0002;MA0004;MA0048;VSTHRD200;S3903</NoWarn>
+    <!-- NU1903: see sister-csproj note in Example.AutoSql. -->
+    <NoWarn>$(NoWarn);MA0002;MA0004;MA0048;VSTHRD200;S3903;NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Reproduced Stage 2's exact build locally and fixed every analyzer/restore failure it surfaced:

```
dotnet restore
dotnet build --no-restore --configuration Release -p:TreatWarningsAsErrors=true
```

Previous patch PRs (#181, #182) covered `tests/` but the `benchmarks/` and `examples/` projects were still exposed:

| Project | Previously failing on |
|---|---|
| `benchmarks/` | `RS0016` (`BenchmarkContext`, `BenchmarkPerson`, `BatchSize`, `BuildSelect/Insert/Update`) — PublicApiAnalyzers fires fleet-wide; no PublicAPI baseline → every public symbol flagged. |
| `examples/Example.AutoSql/` | `NU1903` — `SQLitePCLRaw.lib.e_sqlite3` on GHSA-2m69-gcr7-jv3q, no patched version. |
| `examples/Example.UpdateWithTransaction/` | `NU1903` |
| `examples/Example/` | `NU1903` |

## Changes

| File | Change |
|---|---|
| `benchmarks/.editorconfig` | + `dotnet_diagnostic.RS0016 / RS0017 / RS0037 = none` (was already disabling BDN-conflict rules) |
| `examples/.editorconfig` | new file — same `RS00*` family disabled |
| 3× `examples/*/*.csproj` | + `NU1903` in NoWarn list with reference to the sister-csproj NU1903 note |

## Local verification

```
$ dotnet restore
$ dotnet build --no-restore --configuration Release -p:TreatWarningsAsErrors=true
Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet test tests/Wolfgang.Etl.DbClient.Tests.Unit --no-build --configuration Release
Passed!  - Failed: 0, Passed: 161 — across all 13 TFMs
```

## Closes
- Stage 2 Windows failure on PR #126 (final iteration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)