### PR TITLE
fix(ci): suppress S3267 in benchmarks (Stage 2 Windows)

### DIFF
--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -46,3 +46,10 @@ dotnet_diagnostic.S3881.severity = none
 dotnet_diagnostic.RS0016.severity = none
 dotnet_diagnostic.RS0017.severity = none
 dotnet_diagnostic.RS0037.severity = none
+
+# S3267 — Loops should be simplified using LINQ "Where". Benchmark hot
+# loops measure their inner call cost; rewriting `foreach` + `if` as
+# `.Count(predicate)` introduces enumerator-allocation + lambda-dispatch
+# noise that pollutes the signal we're trying to measure. Keep loops
+# raw inside [Benchmark] methods.
+dotnet_diagnostic.S3267.severity = none


### PR DESCRIPTION
## Summary

Sonar **S3267** ("Loops should be simplified using the 'Where' LINQ method") fires on `ColumnAttributeTypeMapperBenchmarks.LookupAllColumnsOnce`:

```csharp
[Benchmark]
public int LookupAllColumnsOnce()
{
    var hits = 0;
    foreach (var name in ColumnNames)
    {
        if (_typeMap.GetMember(name) != null)
        {
            hits++;
        }
    }
    return hits;
}
```

**Suppressing on its merits.** This is a `[Benchmark]` hot loop; the whole point is to measure `GetMember`'s cost. Rewriting as `.Count(predicate)` would add enumerator-allocation + lambda-dispatch noise that pollutes the signal we're trying to measure.

## Change

`benchmarks/.editorconfig` — added `dotnet_diagnostic.S3267.severity = none` with a paragraph rationale next to the existing BDN-conflict suppressions.

## Why this didn't show locally

S3267 didn't fire on my Linux Release build (Sonar's ruleset varies a bit between SDK + platform), only on Stage 2 Windows. After this fix, my reproduction of Stage 2's exact command — `dotnet build benchmarks/.../*.csproj -c Release -p:TreatWarningsAsErrors=true` — returns clean.

## Stack history

This is the 4th iteration on the same Stage 2 failure:

| PR | Fix |
|---|---|
| #181 | RS0016 / RS0017 + NU1903 in **tests/** |
| #182 | RS0037 in tests/ |
| #183 | RS00* + NU1903 in **benchmarks/** + **examples/** |
| **#184 (this)** | **S3267 in benchmarks/** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)