### PR TITLE
fix(ci): drop async/await on Load1000Rows benchmark (AsyncFixer01)

### DIFF
--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/DbLoaderBatchSizeBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/DbLoaderBatchSizeBenchmarks.cs
@@ -108,11 +108,11 @@ public class DbLoaderBatchSizeBenchmarks : IDisposable
 
 
     [Benchmark]
-    public async Task Load1000Rows()
+    public Task Load1000Rows()
     {
         var loader = new DbLoader<BenchmarkPerson>(_conn, WriteMode.Insert);
         loader.BatchSize = BatchSize;
-        await loader.LoadAsync(ToAsyncEnumerable(_records));
+        return loader.LoadAsync(ToAsyncEnumerable(_records));
     }
 
 


### PR DESCRIPTION
## Summary

Stage 2 surfaced **`AsyncFixer01`** ("Method only awaits a single expression") on `DbLoaderBatchSizeBenchmarks.Load1000Rows`. The method had exactly one `await`:

```csharp
public async Task Load1000Rows()
{
    var loader = new DbLoader<BenchmarkPerson>(_conn, WriteMode.Insert);
    loader.BatchSize = BatchSize;
    await loader.LoadAsync(ToAsyncEnumerable(_records));
}
```

Refactored per the analyzer's suggestion (return the Task directly):

```csharp
public Task Load1000Rows()
{
    var loader = new DbLoader<BenchmarkPerson>(_conn, WriteMode.Insert);
    loader.BatchSize = BatchSize;
    return loader.LoadAsync(ToAsyncEnumerable(_records));
}
```

Saves one async state machine allocation per benchmark iteration and is the cleaner shape for a Task-returning `[Benchmark]` method.

`ExtractAsync` uses `await foreach` — counts as multiple awaits, unaffected.

## Local verification matches CI command exactly

```
$ dotnet build --no-restore -c Release -p:TreatWarningsAsErrors=true
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)