### PR TITLE
fix(release): skip integration tests in release validation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,8 +98,14 @@ jobs:
       - name: Run multi-framework tests with coverage
         shell: pwsh
         run: |
-          $testProjects = Get-ChildItem -Path './tests' -Recurse -Filter '*Test*.csproj'
-          
+          # Exclude *.Tests.Integration.* — those need Docker / Testcontainers,
+          # which the release runner doesn't provide. The integration matrix is
+          # exercised by pr.yaml's test-integration job (with proper services:
+          # blocks per RDBMS) on every PR, so release-time re-validation isn't
+          # adding signal. Match the per-language SDK extensions (cs / vb / fs).
+          $testProjects = Get-ChildItem -Path './tests' -Recurse -Include '*Test*.csproj', '*Test*.vbproj', '*Test*.fsproj' |
+            Where-Object { $_.Name -notmatch '\.Tests\.Integration\.(cs|vb|fs)proj$' }
+
           if ($testProjects.Count -eq 0) {
             Write-Error "❌ No test projects found - release requires tests to validate quality"
             exit 1


### PR DESCRIPTION
## Why

The v0.3.0 release (run [27965648162](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/runs/27965648162)) failed at **Validate Release Build**. The downstream chain — Documentation, Pack & Validate NuGet, **Publish to NuGet.org**, Attach Artifacts — was all `skipped`, so **v0.3.0 never reached nuget.org**.

## Root cause

`release.yaml` line 101 discovers test projects via:

```pwsh
Get-ChildItem -Path './tests' -Recurse -Filter '*Test*.csproj'
```

That now catches the new `Tests.Integration` project (added in the v0.3.0 stack). Integration tests require Docker / Testcontainers, which the release runner doesn't provide → every MariaDB / SQL Server / PostgreSQL / MySQL / Sqlite test failed.

## Fix

Filter integration tests out at discovery time, and add .vbproj/.fsproj coverage too (template parity):

```pwsh
$testProjects = Get-ChildItem -Path './tests' -Recurse -Include '*Test*.csproj', '*Test*.vbproj', '*Test*.fsproj' |
    Where-Object { $_.Name -notmatch '\.Tests\.Integration\.(cs|vb|fs)proj$' }
```

The integration matrix is already exercised by `pr.yaml`'s `test-integration` job (with proper `services:` blocks per RDBMS) on every PR, so release-time re-validation isn't adding signal — only failure surface.

## After this merges

1. **Delete the v0.3.0 release** (`gh release delete v0.3.0`) — this also deletes the tag.
2. **Re-create it** (`gh release create v0.3.0 --target main ...`) — fires `release.yaml` with the patched workflow definition.

(Re-running the failed run alone uses the old workflow definition, so it wouldn't help.)

## ⚠ Protected file

This touches `.github/workflows/release.yaml` — the protected-files guard in `pr.yaml` will fail CI on this PR. Maintainer admin bypass required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)