### PR TITLE
feat: CommandTimeout on DbExtractor + DbLoader (#25)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -215,6 +215,49 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// How long each command (the extraction query and the
+    /// <see cref="TotalCountQuery"/>) may execute before timing out. <c>null</c>
+    /// (the default) means "use the ADO.NET provider's default", which is
+    /// typically 30 seconds.
+    /// </summary>
+    /// <remarks>
+    /// Maps onto Dapper's <c>commandTimeout</c> parameter (an <c>int?</c> count
+    /// of seconds). Fractional seconds in the supplied <see cref="TimeSpan"/>
+    /// are truncated. A negative <see cref="TimeSpan"/> is rejected.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The assigned value is negative.
+    /// </exception>
+    public TimeSpan? CommandTimeout
+    {
+        get => _commandTimeout;
+        set
+        {
+            if (value.HasValue && value.Value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException
+                (
+                    nameof(value),
+                    value,
+                    "CommandTimeout cannot be negative. Use null to fall back to the ADO.NET default."
+                );
+            }
+            _commandTimeout = value;
+        }
+    }
+
+    private TimeSpan? _commandTimeout;
+
+    // Dapper's commandTimeout parameter is `int?` seconds. Centralized here so
+    // every call site uses the same conversion (and so future "0 = infinite"
+    // semantics, if needed, only have to flip in one place).
+    private int? CommandTimeoutSeconds => _commandTimeout.HasValue
+        ? (int)_commandTimeout.Value.TotalSeconds
+        : (int?)null;
+
+
+
+    /// <summary>
     /// When non-null, this function is invoked before extraction begins to determine
     /// the total record count, which is then reported via <see cref="DbReport.TotalItemCount"/>.
     /// Assign <see cref="DefaultTotalCountQuery"/> to use the library's built-in
@@ -298,7 +341,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
         long rowIndex = 0;
 
-        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction).ConfigureAwait(false))
+        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds).ConfigureAwait(false))
         {
             token.ThrowIfCancellationRequested();
             rowIndex++;
@@ -337,7 +380,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         var countSql = $"SELECT COUNT(*) FROM ({sanitized}) AS _count";
         var param = _dynamicParameters;
         return _connection.ExecuteScalarAsync<int>(
-            new CommandDefinition(countSql, param, _transaction, cancellationToken: token));
+            new CommandDefinition(countSql, param, _transaction, CommandTimeoutSeconds, cancellationToken: token));
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -169,6 +169,46 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// How long each <c>ExecuteAsync</c> call may run before timing out.
+    /// <c>null</c> (the default) means "use the ADO.NET provider's default",
+    /// typically 30 seconds.
+    /// </summary>
+    /// <remarks>
+    /// Maps onto Dapper's <c>commandTimeout</c> parameter (an <c>int?</c> count
+    /// of seconds). Fractional seconds are truncated. Applies to every batch,
+    /// not the whole load — so a batched insert of 10 batches each gets the
+    /// full timeout independently.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The assigned value is negative.
+    /// </exception>
+    public TimeSpan? CommandTimeout
+    {
+        get => _commandTimeout;
+        set
+        {
+            if (value.HasValue && value.Value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException
+                (
+                    nameof(value),
+                    value,
+                    "CommandTimeout cannot be negative. Use null to fall back to the ADO.NET default."
+                );
+            }
+            _commandTimeout = value;
+        }
+    }
+
+    private TimeSpan? _commandTimeout;
+
+    private int? CommandTimeoutSeconds => _commandTimeout.HasValue
+        ? (int)_commandTimeout.Value.TotalSeconds
+        : (int?)null;
+
+
+
+    /// <summary>
     /// Number of records sent per <c>ExecuteAsync</c> call. Defaults to <c>1</c>
     /// (one round-trip per record). Larger values pass an <c>IEnumerable&lt;TRecord&gt;</c>
     /// to Dapper, which amortizes per-call overhead (parameter parsing, command setup)
@@ -371,6 +411,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
                     _commandText,
                     item,
                     transaction,
+                    CommandTimeoutSeconds,
                     cancellationToken: token
                 )
             ).ConfigureAwait(false);
@@ -446,6 +487,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
                 _commandText,
                 batch,
                 transaction,
+                CommandTimeoutSeconds,
                 cancellationToken: token
             )
         ).ConfigureAwait(false);

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.set -> void

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -393,4 +393,69 @@ public class DbExtractorTests
             async () => await extractor.ExtractAsync().ToListAsync()
         );
     }
+
+
+
+    // ------------------------------------------------------------------
+    // CommandTimeout (#25)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CommandTimeout_defaults_to_null()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT 1");
+
+        Assert.Null(extractor.CommandTimeout);
+    }
+
+
+
+    [Fact]
+    public void CommandTimeout_set_and_get_roundtrips()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT 1");
+
+        extractor.CommandTimeout = TimeSpan.FromMinutes(5);
+
+        Assert.Equal(TimeSpan.FromMinutes(5), extractor.CommandTimeout);
+    }
+
+
+
+    [Fact]
+    public void CommandTimeout_when_set_to_negative_throws_ArgumentOutOfRangeException()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT 1");
+
+        Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => extractor.CommandTimeout = TimeSpan.FromSeconds(-1)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task CommandTimeout_does_not_break_extraction_against_in_memory_db()
+    {
+        // SQLite in-memory ignores commandTimeout but the call path must still
+        // succeed when a non-null timeout is supplied. Guards against accidentally
+        // routing through a code path that doesn't pass the timeout cleanly.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(3);
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT id, first_name, last_name, age FROM People ORDER BY id"
+        )
+        {
+            CommandTimeout = TimeSpan.FromMinutes(2)
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(3, results.Count);
+    }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -569,4 +569,46 @@ public class DbLoaderTests
         await Task.CompletedTask;
         throw new InvalidOperationException("Simulated failure");
     }
+
+
+
+    // ------------------------------------------------------------------
+    // CommandTimeout (#25)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CommandTimeout_defaults_to_null()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Null(loader.CommandTimeout);
+    }
+
+
+
+    [Fact]
+    public void CommandTimeout_set_and_get_roundtrips()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        loader.CommandTimeout = TimeSpan.FromMinutes(10);
+
+        Assert.Equal(TimeSpan.FromMinutes(10), loader.CommandTimeout);
+    }
+
+
+
+    [Fact]
+    public void CommandTimeout_when_set_to_negative_throws_ArgumentOutOfRangeException()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => loader.CommandTimeout = TimeSpan.FromMilliseconds(-1)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

New public surface:

```csharp
DbExtractor<TRecord>.CommandTimeout { get; set; } // TimeSpan?
DbLoader<TRecord>.CommandTimeout    { get; set; } // TimeSpan?
```

`null` (the default) means "use the ADO.NET provider default" (~30 s on most providers). A non-null value is wired to Dapper's `commandTimeout` parameter (int? seconds) on **every** command:

- DbExtractor — main `QueryUnbufferedAsync` + the default count query
- DbLoader    — the per-record `ExecuteAsync` + the batched `ExecuteAsync`

Negative values throw `ArgumentOutOfRangeException`. Fractional seconds truncate.

## Closes
- **#25** — Add CommandTimeout property

## Test plan
- [x] 7 new unit tests cover null default, set/get round-trip, negative-value rejection, and end-to-end with a non-null timeout against in-memory SQLite.
- [x] `dotnet test tests/Wolfgang.Etl.DbClient.Tests.Unit` — **168 pass** (was 161).
- [x] `PublicAPI.Unshipped.txt` updated.

## Stack
First PR of the v0.4.0 stack. Base: `vNext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)