### PR TITLE
feat: CommandType property for stored procedure calls (#26)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -258,6 +258,22 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// How <see cref="CommandText"/> is interpreted by the ADO.NET provider.
+    /// Defaults to <see cref="CommandType.Text"/> (a SQL statement). Set to
+    /// <see cref="CommandType.StoredProcedure"/> to invoke a stored procedure
+    /// by name; <see cref="CommandText"/> then holds the procedure name.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CommandType.TableDirect"/> is supported by very few providers
+    /// (notably OleDb). It's accepted on this property — Dapper passes it
+    /// through — but most consumers should stick to <c>Text</c> or
+    /// <c>StoredProcedure</c>.
+    /// </remarks>
+    public CommandType CommandType { get; set; } = CommandType.Text;
+
+
+
+    /// <summary>
     /// When non-null, this function is invoked before extraction begins to determine
     /// the total record count, which is then reported via <see cref="DbReport.TotalItemCount"/>.
     /// Assign <see cref="DefaultTotalCountQuery"/> to use the library's built-in
@@ -341,7 +357,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
         long rowIndex = 0;
 
-        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds).ConfigureAwait(false))
+        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
         {
             token.ThrowIfCancellationRequested();
             rowIndex++;

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -209,6 +209,17 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// How <see cref="CommandText"/> is interpreted by the ADO.NET provider.
+    /// Defaults to <see cref="CommandType.Text"/> (a SQL INSERT / UPDATE).
+    /// Set to <see cref="CommandType.StoredProcedure"/> to invoke a stored
+    /// procedure by name per record (or per batch when <see cref="BatchSize"/>
+    /// is &gt; 1); <see cref="CommandText"/> then holds the procedure name.
+    /// </summary>
+    public CommandType CommandType { get; set; } = CommandType.Text;
+
+
+
+    /// <summary>
     /// Number of records sent per <c>ExecuteAsync</c> call. Defaults to <c>1</c>
     /// (one round-trip per record). Larger values pass an <c>IEnumerable&lt;TRecord&gt;</c>
     /// to Dapper, which amortizes per-call overhead (parameter parsing, command setup)
@@ -412,6 +423,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
                     item,
                     transaction,
                     CommandTimeoutSeconds,
+                    CommandType,
                     cancellationToken: token
                 )
             ).ConfigureAwait(false);
@@ -488,6 +500,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
                 batch,
                 transaction,
                 CommandTimeoutSeconds,
+                CommandType,
                 cancellationToken: token
             )
         ).ConfigureAwait(false);

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
 #nullable enable
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.get -> System.TimeSpan?
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.set -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.get -> System.TimeSpan?
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.set -> void

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -438,6 +438,55 @@ public class DbExtractorTests
 
 
 
+    // ------------------------------------------------------------------
+    // CommandType (#26)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CommandType_defaults_to_Text()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT 1");
+
+        Assert.Equal(System.Data.CommandType.Text, extractor.CommandType);
+    }
+
+
+
+    [Fact]
+    public void CommandType_set_and_get_roundtrips()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "usp_GetPeople");
+
+        extractor.CommandType = System.Data.CommandType.StoredProcedure;
+
+        Assert.Equal(System.Data.CommandType.StoredProcedure, extractor.CommandType);
+    }
+
+
+
+    [Fact]
+    public async Task CommandType_Text_still_executes_normal_query()
+    {
+        // Explicitly setting to Text (the default) should be a no-op regression check.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(3);
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT id, first_name, last_name, age FROM People ORDER BY id"
+        )
+        {
+            CommandType = System.Data.CommandType.Text
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(3, results.Count);
+    }
+
+
+
     [Fact]
     public async Task CommandTimeout_does_not_break_extraction_against_in_memory_db()
     {

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -611,4 +611,32 @@ public class DbLoaderTests
             () => loader.CommandTimeout = TimeSpan.FromMilliseconds(-1)
         );
     }
+
+
+
+    // ------------------------------------------------------------------
+    // CommandType (#26)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CommandType_defaults_to_Text()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Equal(System.Data.CommandType.Text, loader.CommandType);
+    }
+
+
+
+    [Fact]
+    public void CommandType_set_and_get_roundtrips()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "usp_InsertPerson");
+
+        loader.CommandType = System.Data.CommandType.StoredProcedure;
+
+        Assert.Equal(System.Data.CommandType.StoredProcedure, loader.CommandType);
+    }
 }


### PR DESCRIPTION
## Summary

New public surface:

```csharp
DbExtractor<TRecord>.CommandType { get; set; } // default CommandType.Text
DbLoader<TRecord>.CommandType    { get; set; } // default CommandType.Text
```

Setting to `CommandType.StoredProcedure` makes `CommandText` the sproc name; Dapper binds parameters from the POCO properties as usual.

## Wired through to

- **DbExtractor** — `QueryUnbufferedAsync`'s `commandType` parameter
- **DbLoader** — both per-record and batched `ExecuteAsync`'s `CommandDefinition.CommandType`

**NOT wired to the count query.** `DefaultTotalCountQuery` wraps `CommandText` in `SELECT COUNT(*) FROM (...)` which is incompatible with sprocs by construction. If a caller sets both `CommandType=StoredProcedure` AND `TotalCountQuery = extractor.DefaultTotalCountQuery`, they need to supply a custom `TotalCountQuery` instead.

## Closes
- **#26** — Add stored procedure support via CommandType property

## Test plan
- [x] 5 new tests: default value, set/get round-trip, regression check that explicit Text still executes.
- [x] **173 tests pass** (was 168).
- [x] PublicAPI.Unshipped.txt updated.

## Stack
Second PR of the v0.4.0 stack. Base: `feat/command-timeout` (N01 → #187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)