### PR TITLE
feat: DbProviderFactory + connection-string ctor overload (#28)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -50,7 +50,12 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     // Fields
     // ------------------------------------------------------------------
 
+    // _connection is not `readonly` because the DbProviderFactory ctor overload
+    // creates the connection itself; the caller-supplied-DbConnection ctors set
+    // it once and never re-assign. _ownsConnection tracks whether ExtractWorkerAsync
+    // is responsible for OpenAsync + Dispose.
     private readonly DbConnection _connection;
+    private readonly bool _ownsConnection;
     private readonly string _commandText;
 
     // Defensive snapshot of the caller's parameter dictionary. Copying at
@@ -179,6 +184,53 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
         _commandText = DbCommandBuilder.BuildSelect<TRecord>();
         _transaction = transaction;
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="DbExtractor{TRecord}"/> that owns the
+    /// connection's lifetime. The connection is created from the supplied
+    /// <see cref="DbProviderFactory"/>, opened lazily before extraction begins,
+    /// and disposed when extraction completes (or throws).
+    /// </summary>
+    /// <param name="factory">
+    /// The provider-specific factory (e.g. <c>Microsoft.Data.SqlClient
+    /// .SqlClientFactory.Instance</c>, <c>Npgsql.NpgsqlFactory.Instance</c>).
+    /// </param>
+    /// <param name="connectionString">The provider-specific connection string.</param>
+    /// <param name="commandText">The SQL query to execute.</param>
+    /// <param name="logger">An optional logger for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/>, <paramref name="connectionString"/>, or
+    /// <paramref name="commandText"/> is null.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="factory"/> returned a null connection from
+    /// <see cref="DbProviderFactory.CreateConnection"/>.
+    /// </exception>
+    public DbExtractor
+    (
+        DbProviderFactory factory,
+        string connectionString,
+        string commandText,
+        ILogger<DbExtractor<TRecord>>? logger = null
+    )
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
+        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+
+        var conn = factory.CreateConnection()
+            ?? throw new InvalidOperationException
+            (
+                $"{factory.GetType().FullName}.CreateConnection() returned null. " +
+                "The provider factory does not produce DbConnection instances."
+            );
+        conn.ConnectionString = connectionString;
+        _connection = conn;
+        _ownsConnection = true;
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
@@ -348,40 +400,62 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         _totalItemCount = null;
         LogExtractionStarted();
 
-        var param = _dynamicParameters;
-
-        if (TotalCountQuery != null)
+        // Owned-connection ctor path: open before the first query, dispose after.
+        // try/finally in an async iterator is OK in C# 8+; the iterator runtime
+        // routes break/exception through the finally on Dispose.
+        if (_ownsConnection && _connection.State != ConnectionState.Open)
         {
-            _totalItemCount = await TotalCountQuery(token).ConfigureAwait(false);
+            await _connection.OpenAsync(token).ConfigureAwait(false);
         }
 
-        long rowIndex = 0;
-
-        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
+        try
         {
-            token.ThrowIfCancellationRequested();
-            rowIndex++;
+            var param = _dynamicParameters;
 
-            if (rowIndex <= SkipItemCount)
+            if (TotalCountQuery != null)
             {
-                IncrementCurrentSkippedItemCount();
-                LogDebugRowSkipped(rowIndex);
-                continue;
+                _totalItemCount = await TotalCountQuery(token).ConfigureAwait(false);
             }
 
-            if (CurrentItemCount >= MaximumItemCount)
+            long rowIndex = 0;
+
+            await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
             {
-                LogDebugMaxReached();
-                LogExtractionCompleted();
-                yield break;
+                token.ThrowIfCancellationRequested();
+                rowIndex++;
+
+                if (rowIndex <= SkipItemCount)
+                {
+                    IncrementCurrentSkippedItemCount();
+                    LogDebugRowSkipped(rowIndex);
+                    continue;
+                }
+
+                if (CurrentItemCount >= MaximumItemCount)
+                {
+                    LogDebugMaxReached();
+                    LogExtractionCompleted();
+                    yield break;
+                }
+
+                LogDebugRowExtracted(rowIndex);
+                IncrementCurrentItemCount();
+                yield return record;
             }
 
-            LogDebugRowExtracted(rowIndex);
-            IncrementCurrentItemCount();
-            yield return record;
+            LogExtractionCompleted();
         }
-
-        LogExtractionCompleted();
+        finally
+        {
+            if (_ownsConnection)
+            {
+#if NET5_0_OR_GREATER
+                await _connection.DisposeAsync().ConfigureAwait(false);
+#else
+                _connection.Dispose();
+#endif
+            }
+        }
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -54,7 +54,11 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
     // Fields
     // ------------------------------------------------------------------
 
+    // _ownsConnection tracks whether LoadWorkerAsync is responsible for the
+    // connection's OpenAsync + Dispose. True for the DbProviderFactory ctor
+    // overloads; false when the caller passes a pre-opened DbConnection.
     private readonly DbConnection _connection;
+    private readonly bool _ownsConnection;
     private readonly string _commandText;
     private readonly DbTransaction? _callerTransaction;
     private readonly bool _ownsTransaction;
@@ -132,6 +136,54 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
             : DbCommandBuilder.BuildInsert<TRecord>();
         _callerTransaction = transaction;
         _ownsTransaction = transaction == null;
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="DbLoader{TRecord}"/> that owns the
+    /// connection's lifetime. The connection is created from the supplied
+    /// <see cref="DbProviderFactory"/>, opened lazily before loading begins,
+    /// and disposed when loading completes (or throws).
+    /// </summary>
+    /// <param name="factory">
+    /// The provider-specific factory (e.g. <c>Microsoft.Data.SqlClient
+    /// .SqlClientFactory.Instance</c>, <c>Npgsql.NpgsqlFactory.Instance</c>).
+    /// </param>
+    /// <param name="connectionString">The provider-specific connection string.</param>
+    /// <param name="commandText">The SQL INSERT or UPDATE command to execute per record.</param>
+    /// <param name="logger">An optional logger for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/>, <paramref name="connectionString"/>, or
+    /// <paramref name="commandText"/> is null.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="factory"/> returned a null connection from
+    /// <see cref="DbProviderFactory.CreateConnection"/>.
+    /// </exception>
+    public DbLoader
+    (
+        DbProviderFactory factory,
+        string connectionString,
+        string commandText,
+        ILogger<DbLoader<TRecord>>? logger = null
+    )
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
+        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+
+        var conn = factory.CreateConnection()
+            ?? throw new InvalidOperationException
+            (
+                $"{factory.GetType().FullName}.CreateConnection() returned null. " +
+                "The provider factory does not produce DbConnection instances."
+            );
+        conn.ConnectionString = connectionString;
+        _connection = conn;
+        _ownsConnection = true;
+        _ownsTransaction = true;  // auto-managed transaction inside the owned connection
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
@@ -317,16 +369,38 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
         _stopwatch.Restart();
         LogLoadingStarted();
 
-        if (_ownsTransaction)
+        // Owned-connection ctor path: open before the first execute, dispose at
+        // the end. Wrapped in try/finally so the connection is released even
+        // when LoadWith*Async throws (the caller's exception still propagates).
+        if (_ownsConnection && _connection.State != ConnectionState.Open)
         {
-            await LoadWithAutoTransactionAsync(items, token).ConfigureAwait(false);
-        }
-        else
-        {
-            await LoadWithCallerTransactionAsync(items, token).ConfigureAwait(false);
+            await _connection.OpenAsync(token).ConfigureAwait(false);
         }
 
-        LogLoadingCompleted();
+        try
+        {
+            if (_ownsTransaction)
+            {
+                await LoadWithAutoTransactionAsync(items, token).ConfigureAwait(false);
+            }
+            else
+            {
+                await LoadWithCallerTransactionAsync(items, token).ConfigureAwait(false);
+            }
+
+            LogLoadingCompleted();
+        }
+        finally
+        {
+            if (_ownsConnection)
+            {
+#if NET5_0_OR_GREATER
+                await _connection.DisposeAsync().ConfigureAwait(false);
+#else
+                _connection.Dispose();
+#endif
+            }
+        }
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -3,7 +3,9 @@ Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.get -> System.TimeSpan
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.set -> void
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.get -> System.Data.CommandType
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.set -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.get -> System.TimeSpan?
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.get -> System.Data.CommandType
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -487,6 +487,64 @@ public class DbExtractorTests
 
 
 
+    // ------------------------------------------------------------------
+    // DbProviderFactory ctor (#28)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_factory_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbExtractor<PersonRecord>((System.Data.Common.DbProviderFactory)null!, "Data Source=:memory:", "SELECT 1")
+        );
+    }
+
+
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_connectionString_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbExtractor<PersonRecord>(Microsoft.Data.Sqlite.SqliteFactory.Instance, null!, "SELECT 1")
+        );
+    }
+
+
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_commandText_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbExtractor<PersonRecord>(Microsoft.Data.Sqlite.SqliteFactory.Instance, "Data Source=:memory:", null!)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DbProviderFactory_ctor_extractor_opens_and_disposes_connection()
+    {
+        // Owned-connection path: connection is created from SqliteFactory, opened
+        // on first use inside ExtractWorkerAsync, and disposed when the iterator
+        // completes. Smoke-test that the round-trip succeeds for an empty query
+        // (in-memory SQLite, fresh schema, returns 0 rows).
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            Microsoft.Data.Sqlite.SqliteFactory.Instance,
+            "Data Source=:memory:",
+            "SELECT 1 AS id, 'x' AS first_name, 'y' AS last_name, 30 AS age WHERE 0=1"
+        );
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Empty(results);
+    }
+
+
+
     [Fact]
     public async Task CommandTimeout_does_not_break_extraction_against_in_memory_db()
     {

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -639,4 +639,41 @@ public class DbLoaderTests
 
         Assert.Equal(System.Data.CommandType.StoredProcedure, loader.CommandType);
     }
+
+
+
+    // ------------------------------------------------------------------
+    // DbProviderFactory ctor (#28)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_factory_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbLoader<PersonRecord>((System.Data.Common.DbProviderFactory)null!, "Data Source=:memory:", "INSERT INTO People (first_name) VALUES (@FirstName)")
+        );
+    }
+
+
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_connectionString_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbLoader<PersonRecord>(Microsoft.Data.Sqlite.SqliteFactory.Instance, null!, "INSERT INTO People (first_name) VALUES (@FirstName)")
+        );
+    }
+
+
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_commandText_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbLoader<PersonRecord>(Microsoft.Data.Sqlite.SqliteFactory.Instance, "Data Source=:memory:", (string)null!)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds an owned-connection ctor overload to both `DbExtractor` and `DbLoader`. The extractor/loader creates the connection via `DbProviderFactory`, opens it lazily before the first command, and disposes it when the worker completes (or throws). Saves callers a `using var conn = …; await conn.OpenAsync();` boilerplate for one-off scenarios.

## New public surface

```csharp
new DbExtractor<MyRecord>(
    SqlClientFactory.Instance,
    "Server=.;Database=…;Trusted_Connection=true",
    "SELECT * FROM Customers");

new DbLoader<MyRecord>(
    SqlClientFactory.Instance,
    "Server=.;Database=…;Trusted_Connection=true",
    "INSERT INTO Customers (...) VALUES (...)");
```

After the worker yields its last row / executes its last batch, the connection is disposed automatically.

## Internal changes

- `_ownsConnection` bool on both types — `true` when the factory ctor is used, `false` when a pre-opened `DbConnection` is supplied. The existing transaction-ownership flag handles the second axis (so owned-conn + auto-tx is the default for the new ctor).
- `ExtractWorkerAsync` wraps its body in `try { … } finally { dispose }` — opens the connection on entry (if not already open) and disposes on exit. `try/finally` inside an async iterator is OK in C# 8+; the runtime routes break/exception/Dispose through the finally.
- `LoadWorkerAsync` gets the same open/finally-dispose envelope.
- `DbProviderFactory.CreateConnection()` can legally return null (per the framework contract); we wrap that as an `InvalidOperationException` naming the factory type.

## Closes
- **#28** — Add connection string constructor overload

## Test plan
- [x] 7 new unit tests cover null-arg rejection on all three positional params + an end-to-end smoke test that an owned in-memory SQLite connection opens, runs an empty query, and disposes cleanly.
- [x] **180 tests pass** (was 173).
- [x] All 11 TFMs build clean.
- [x] PublicAPI.Unshipped.txt updated.

## Stack
Third PR of the v0.4.0 stack. Base: `feat/command-type` (N02 → #188).

🤖 Generated with [Claude Code](https://claude.com/claude-code)