### PR TITLE
Release v0.4.0 — production-readiness knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] — production-readiness knobs
+
+### Added
+- `DbExtractor<TRecord>.CommandTimeout` / `DbLoader<TRecord>.CommandTimeout` (`TimeSpan?`) — controls how long each underlying command can run before timing out. `null` (the default) falls back to the ADO.NET provider default (~30 s). Negative values throw `ArgumentOutOfRangeException`. Wired through every Dapper call site (extractor's main query + default count query; loader's per-record and batched `ExecuteAsync`).
+- `DbExtractor<TRecord>.CommandType` / `DbLoader<TRecord>.CommandType` (`System.Data.CommandType`) — enables stored-procedure invocation. Default `CommandType.Text` preserves prior behavior. Set to `CommandType.StoredProcedure` and `CommandText` becomes the sproc name; Dapper binds parameters from the POCO properties as usual. Not wired to `DefaultTotalCountQuery` (that path wraps `CommandText` in `SELECT COUNT(*) FROM (...)` which is incompatible with sprocs by construction; supply a custom `TotalCountQuery` instead).
+- `DbExtractor<TRecord>(DbProviderFactory, string connectionString, string commandText, ILogger?)` — owned-connection ctor overload. The extractor creates the connection via the supplied `DbProviderFactory`, opens it lazily before the first command, and disposes it when extraction completes (or throws). Saves callers the `using var conn = …; await conn.OpenAsync();` boilerplate for one-off scenarios.
+- `DbLoader<TRecord>(DbProviderFactory, string connectionString, string commandText, ILogger?)` — owned-connection ctor overload with the same semantics (open lazily, dispose at end). Defaults to auto-managed transaction.
+
+[Unreleased]: https://github.com/Chris-Wolfgang/Etl-DbClient/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Chris-Wolfgang/Etl-DbClient/releases/tag/v0.4.0
+
 ## [0.3.0] — code-review pass + integration-test surface
 
 ### Added
@@ -30,5 +41,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See git history.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/Etl-DbClient/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/Chris-Wolfgang/Etl-DbClient/releases/tag/v0.3.0

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -50,7 +50,12 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     // Fields
     // ------------------------------------------------------------------
 
+    // _connection is not `readonly` because the DbProviderFactory ctor overload
+    // creates the connection itself; the caller-supplied-DbConnection ctors set
+    // it once and never re-assign. _ownsConnection tracks whether ExtractWorkerAsync
+    // is responsible for OpenAsync + Dispose.
     private readonly DbConnection _connection;
+    private readonly bool _ownsConnection;
     private readonly string _commandText;
 
     // Defensive snapshot of the caller's parameter dictionary. Copying at
@@ -179,6 +184,53 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
         _commandText = DbCommandBuilder.BuildSelect<TRecord>();
         _transaction = transaction;
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="DbExtractor{TRecord}"/> that owns the
+    /// connection's lifetime. The connection is created from the supplied
+    /// <see cref="DbProviderFactory"/>, opened lazily before extraction begins,
+    /// and disposed when extraction completes (or throws).
+    /// </summary>
+    /// <param name="factory">
+    /// The provider-specific factory (e.g. <c>Microsoft.Data.SqlClient
+    /// .SqlClientFactory.Instance</c>, <c>Npgsql.NpgsqlFactory.Instance</c>).
+    /// </param>
+    /// <param name="connectionString">The provider-specific connection string.</param>
+    /// <param name="commandText">The SQL query to execute.</param>
+    /// <param name="logger">An optional logger for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/>, <paramref name="connectionString"/>, or
+    /// <paramref name="commandText"/> is null.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="factory"/> returned a null connection from
+    /// <see cref="DbProviderFactory.CreateConnection"/>.
+    /// </exception>
+    public DbExtractor
+    (
+        DbProviderFactory factory,
+        string connectionString,
+        string commandText,
+        ILogger<DbExtractor<TRecord>>? logger = null
+    )
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
+        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+
+        var conn = factory.CreateConnection()
+            ?? throw new InvalidOperationException
+            (
+                $"{factory.GetType().FullName}.CreateConnection() returned null. " +
+                "The provider factory does not produce DbConnection instances."
+            );
+        conn.ConnectionString = connectionString;
+        _connection = conn;
+        _ownsConnection = true;
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
@@ -348,40 +400,62 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         _totalItemCount = null;
         LogExtractionStarted();
 
-        var param = _dynamicParameters;
-
-        if (TotalCountQuery != null)
+        // Owned-connection ctor path: open before the first query, dispose after.
+        // try/finally in an async iterator is OK in C# 8+; the iterator runtime
+        // routes break/exception through the finally on Dispose.
+        if (_ownsConnection && _connection.State != ConnectionState.Open)
         {
-            _totalItemCount = await TotalCountQuery(token).ConfigureAwait(false);
+            await _connection.OpenAsync(token).ConfigureAwait(false);
         }
 
-        long rowIndex = 0;
-
-        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
+        try
         {
-            token.ThrowIfCancellationRequested();
-            rowIndex++;
+            var param = _dynamicParameters;
 
-            if (rowIndex <= SkipItemCount)
+            if (TotalCountQuery != null)
             {
-                IncrementCurrentSkippedItemCount();
-                LogDebugRowSkipped(rowIndex);
-                continue;
+                _totalItemCount = await TotalCountQuery(token).ConfigureAwait(false);
             }
 
-            if (CurrentItemCount >= MaximumItemCount)
+            long rowIndex = 0;
+
+            await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
             {
-                LogDebugMaxReached();
-                LogExtractionCompleted();
-                yield break;
+                token.ThrowIfCancellationRequested();
+                rowIndex++;
+
+                if (rowIndex <= SkipItemCount)
+                {
+                    IncrementCurrentSkippedItemCount();
+                    LogDebugRowSkipped(rowIndex);
+                    continue;
+                }
+
+                if (CurrentItemCount >= MaximumItemCount)
+                {
+                    LogDebugMaxReached();
+                    LogExtractionCompleted();
+                    yield break;
+                }
+
+                LogDebugRowExtracted(rowIndex);
+                IncrementCurrentItemCount();
+                yield return record;
             }
 
-            LogDebugRowExtracted(rowIndex);
-            IncrementCurrentItemCount();
-            yield return record;
+            LogExtractionCompleted();
         }
-
-        LogExtractionCompleted();
+        finally
+        {
+            if (_ownsConnection)
+            {
+#if NET5_0_OR_GREATER
+                await _connection.DisposeAsync().ConfigureAwait(false);
+#else
+                _connection.Dispose();
+#endif
+            }
+        }
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -258,6 +258,22 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// How <see cref="CommandText"/> is interpreted by the ADO.NET provider.
+    /// Defaults to <see cref="CommandType.Text"/> (a SQL statement). Set to
+    /// <see cref="CommandType.StoredProcedure"/> to invoke a stored procedure
+    /// by name; <see cref="CommandText"/> then holds the procedure name.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CommandType.TableDirect"/> is supported by very few providers
+    /// (notably OleDb). It's accepted on this property — Dapper passes it
+    /// through — but most consumers should stick to <c>Text</c> or
+    /// <c>StoredProcedure</c>.
+    /// </remarks>
+    public CommandType CommandType { get; set; } = CommandType.Text;
+
+
+
+    /// <summary>
     /// When non-null, this function is invoked before extraction begins to determine
     /// the total record count, which is then reported via <see cref="DbReport.TotalItemCount"/>.
     /// Assign <see cref="DefaultTotalCountQuery"/> to use the library's built-in
@@ -341,7 +357,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
         long rowIndex = 0;
 
-        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds).ConfigureAwait(false))
+        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
         {
             token.ThrowIfCancellationRequested();
             rowIndex++;

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -215,6 +215,49 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// How long each command (the extraction query and the
+    /// <see cref="TotalCountQuery"/>) may execute before timing out. <c>null</c>
+    /// (the default) means "use the ADO.NET provider's default", which is
+    /// typically 30 seconds.
+    /// </summary>
+    /// <remarks>
+    /// Maps onto Dapper's <c>commandTimeout</c> parameter (an <c>int?</c> count
+    /// of seconds). Fractional seconds in the supplied <see cref="TimeSpan"/>
+    /// are truncated. A negative <see cref="TimeSpan"/> is rejected.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The assigned value is negative.
+    /// </exception>
+    public TimeSpan? CommandTimeout
+    {
+        get => _commandTimeout;
+        set
+        {
+            if (value.HasValue && value.Value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException
+                (
+                    nameof(value),
+                    value,
+                    "CommandTimeout cannot be negative. Use null to fall back to the ADO.NET default."
+                );
+            }
+            _commandTimeout = value;
+        }
+    }
+
+    private TimeSpan? _commandTimeout;
+
+    // Dapper's commandTimeout parameter is `int?` seconds. Centralized here so
+    // every call site uses the same conversion (and so future "0 = infinite"
+    // semantics, if needed, only have to flip in one place).
+    private int? CommandTimeoutSeconds => _commandTimeout.HasValue
+        ? (int)_commandTimeout.Value.TotalSeconds
+        : (int?)null;
+
+
+
+    /// <summary>
     /// When non-null, this function is invoked before extraction begins to determine
     /// the total record count, which is then reported via <see cref="DbReport.TotalItemCount"/>.
     /// Assign <see cref="DefaultTotalCountQuery"/> to use the library's built-in
@@ -298,7 +341,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
         long rowIndex = 0;
 
-        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction).ConfigureAwait(false))
+        await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds).ConfigureAwait(false))
         {
             token.ThrowIfCancellationRequested();
             rowIndex++;
@@ -337,7 +380,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         var countSql = $"SELECT COUNT(*) FROM ({sanitized}) AS _count";
         var param = _dynamicParameters;
         return _connection.ExecuteScalarAsync<int>(
-            new CommandDefinition(countSql, param, _transaction, cancellationToken: token));
+            new CommandDefinition(countSql, param, _transaction, CommandTimeoutSeconds, cancellationToken: token));
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -54,7 +54,11 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
     // Fields
     // ------------------------------------------------------------------
 
+    // _ownsConnection tracks whether LoadWorkerAsync is responsible for the
+    // connection's OpenAsync + Dispose. True for the DbProviderFactory ctor
+    // overloads; false when the caller passes a pre-opened DbConnection.
     private readonly DbConnection _connection;
+    private readonly bool _ownsConnection;
     private readonly string _commandText;
     private readonly DbTransaction? _callerTransaction;
     private readonly bool _ownsTransaction;
@@ -132,6 +136,54 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
             : DbCommandBuilder.BuildInsert<TRecord>();
         _callerTransaction = transaction;
         _ownsTransaction = transaction == null;
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="DbLoader{TRecord}"/> that owns the
+    /// connection's lifetime. The connection is created from the supplied
+    /// <see cref="DbProviderFactory"/>, opened lazily before loading begins,
+    /// and disposed when loading completes (or throws).
+    /// </summary>
+    /// <param name="factory">
+    /// The provider-specific factory (e.g. <c>Microsoft.Data.SqlClient
+    /// .SqlClientFactory.Instance</c>, <c>Npgsql.NpgsqlFactory.Instance</c>).
+    /// </param>
+    /// <param name="connectionString">The provider-specific connection string.</param>
+    /// <param name="commandText">The SQL INSERT or UPDATE command to execute per record.</param>
+    /// <param name="logger">An optional logger for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/>, <paramref name="connectionString"/>, or
+    /// <paramref name="commandText"/> is null.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="factory"/> returned a null connection from
+    /// <see cref="DbProviderFactory.CreateConnection"/>.
+    /// </exception>
+    public DbLoader
+    (
+        DbProviderFactory factory,
+        string connectionString,
+        string commandText,
+        ILogger<DbLoader<TRecord>>? logger = null
+    )
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
+        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+
+        var conn = factory.CreateConnection()
+            ?? throw new InvalidOperationException
+            (
+                $"{factory.GetType().FullName}.CreateConnection() returned null. " +
+                "The provider factory does not produce DbConnection instances."
+            );
+        conn.ConnectionString = connectionString;
+        _connection = conn;
+        _ownsConnection = true;
+        _ownsTransaction = true;  // auto-managed transaction inside the owned connection
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
@@ -317,16 +369,38 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
         _stopwatch.Restart();
         LogLoadingStarted();
 
-        if (_ownsTransaction)
+        // Owned-connection ctor path: open before the first execute, dispose at
+        // the end. Wrapped in try/finally so the connection is released even
+        // when LoadWith*Async throws (the caller's exception still propagates).
+        if (_ownsConnection && _connection.State != ConnectionState.Open)
         {
-            await LoadWithAutoTransactionAsync(items, token).ConfigureAwait(false);
-        }
-        else
-        {
-            await LoadWithCallerTransactionAsync(items, token).ConfigureAwait(false);
+            await _connection.OpenAsync(token).ConfigureAwait(false);
         }
 
-        LogLoadingCompleted();
+        try
+        {
+            if (_ownsTransaction)
+            {
+                await LoadWithAutoTransactionAsync(items, token).ConfigureAwait(false);
+            }
+            else
+            {
+                await LoadWithCallerTransactionAsync(items, token).ConfigureAwait(false);
+            }
+
+            LogLoadingCompleted();
+        }
+        finally
+        {
+            if (_ownsConnection)
+            {
+#if NET5_0_OR_GREATER
+                await _connection.DisposeAsync().ConfigureAwait(false);
+#else
+                _connection.Dispose();
+#endif
+            }
+        }
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -169,6 +169,46 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// How long each <c>ExecuteAsync</c> call may run before timing out.
+    /// <c>null</c> (the default) means "use the ADO.NET provider's default",
+    /// typically 30 seconds.
+    /// </summary>
+    /// <remarks>
+    /// Maps onto Dapper's <c>commandTimeout</c> parameter (an <c>int?</c> count
+    /// of seconds). Fractional seconds are truncated. Applies to every batch,
+    /// not the whole load — so a batched insert of 10 batches each gets the
+    /// full timeout independently.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The assigned value is negative.
+    /// </exception>
+    public TimeSpan? CommandTimeout
+    {
+        get => _commandTimeout;
+        set
+        {
+            if (value.HasValue && value.Value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException
+                (
+                    nameof(value),
+                    value,
+                    "CommandTimeout cannot be negative. Use null to fall back to the ADO.NET default."
+                );
+            }
+            _commandTimeout = value;
+        }
+    }
+
+    private TimeSpan? _commandTimeout;
+
+    private int? CommandTimeoutSeconds => _commandTimeout.HasValue
+        ? (int)_commandTimeout.Value.TotalSeconds
+        : (int?)null;
+
+
+
+    /// <summary>
     /// Number of records sent per <c>ExecuteAsync</c> call. Defaults to <c>1</c>
     /// (one round-trip per record). Larger values pass an <c>IEnumerable&lt;TRecord&gt;</c>
     /// to Dapper, which amortizes per-call overhead (parameter parsing, command setup)
@@ -371,6 +411,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
                     _commandText,
                     item,
                     transaction,
+                    CommandTimeoutSeconds,
                     cancellationToken: token
                 )
             ).ConfigureAwait(false);
@@ -446,6 +487,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
                 _commandText,
                 batch,
                 transaction,
+                CommandTimeoutSeconds,
                 cancellationToken: token
             )
         ).ConfigureAwait(false);

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -209,6 +209,17 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// How <see cref="CommandText"/> is interpreted by the ADO.NET provider.
+    /// Defaults to <see cref="CommandType.Text"/> (a SQL INSERT / UPDATE).
+    /// Set to <see cref="CommandType.StoredProcedure"/> to invoke a stored
+    /// procedure by name per record (or per batch when <see cref="BatchSize"/>
+    /// is &gt; 1); <see cref="CommandText"/> then holds the procedure name.
+    /// </summary>
+    public CommandType CommandType { get; set; } = CommandType.Text;
+
+
+
+    /// <summary>
     /// Number of records sent per <c>ExecuteAsync</c> call. Defaults to <c>1</c>
     /// (one round-trip per record). Larger values pass an <c>IEnumerable&lt;TRecord&gt;</c>
     /// to Dapper, which amortizes per-call overhead (parameter parsing, command setup)
@@ -412,6 +423,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
                     item,
                     transaction,
                     CommandTimeoutSeconds,
+                    CommandType,
                     cancellationToken: token
                 )
             ).ConfigureAwait(false);
@@ -488,6 +500,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>
                 batch,
                 transaction,
                 CommandTimeoutSeconds,
+                CommandType,
                 cancellationToken: token
             )
         ).ConfigureAwait(false);

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Shipped.txt
@@ -2,9 +2,14 @@
 Wolfgang.Etl.DbClient.DbClientOptions
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandText.get -> string!
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.set -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.set -> void
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbConnection! connection, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbConnection! connection, string! commandText, System.Collections.Generic.IDictionary<string!, object!>! parameters, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbConnection! connection, string! commandText, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DefaultTotalCountQuery.get -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<int>!>!
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.TotalCountQuery.get -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<int>!>?
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.TotalCountQuery.set -> void
@@ -12,8 +17,13 @@ Wolfgang.Etl.DbClient.DbLoader<TRecord>
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.BatchSize.get -> int
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.BatchSize.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandText.get -> string!
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbConnection! connection, Wolfgang.Etl.DbClient.WriteMode writeMode, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbConnection! connection, string! commandText, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void
 Wolfgang.Etl.DbClient.DbReport
 Wolfgang.Etl.DbClient.DbReport.CommandText.get -> string!
 Wolfgang.Etl.DbClient.DbReport.CurrentSkippedItemCount.get -> int

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -3,7 +3,9 @@ Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.get -> System.TimeSpan
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.set -> void
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.get -> System.Data.CommandType
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.set -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.get -> System.TimeSpan?
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.get -> System.Data.CommandType
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.set -> void

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
 #nullable enable
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.get -> System.TimeSpan?
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.set -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.get -> System.TimeSpan?
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.set -> void

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,11 +1,1 @@
 #nullable enable
-Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.get -> System.TimeSpan?
-Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandTimeout.set -> void
-Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.get -> System.Data.CommandType
-Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CommandType.set -> void
-Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
-Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.get -> System.TimeSpan?
-Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandTimeout.set -> void
-Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.get -> System.Data.CommandType
-Wolfgang.Etl.DbClient.DbLoader<TRecord>.CommandType.set -> void
-Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -25,7 +25,7 @@
                                   <Version>; set explicitly here so it's
                                   discoverable in a metadata dump.
          ===================================================================== -->
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -393,4 +393,69 @@ public class DbExtractorTests
             async () => await extractor.ExtractAsync().ToListAsync()
         );
     }
+
+
+
+    // ------------------------------------------------------------------
+    // CommandTimeout (#25)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CommandTimeout_defaults_to_null()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT 1");
+
+        Assert.Null(extractor.CommandTimeout);
+    }
+
+
+
+    [Fact]
+    public void CommandTimeout_set_and_get_roundtrips()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT 1");
+
+        extractor.CommandTimeout = TimeSpan.FromMinutes(5);
+
+        Assert.Equal(TimeSpan.FromMinutes(5), extractor.CommandTimeout);
+    }
+
+
+
+    [Fact]
+    public void CommandTimeout_when_set_to_negative_throws_ArgumentOutOfRangeException()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT 1");
+
+        Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => extractor.CommandTimeout = TimeSpan.FromSeconds(-1)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task CommandTimeout_does_not_break_extraction_against_in_memory_db()
+    {
+        // SQLite in-memory ignores commandTimeout but the call path must still
+        // succeed when a non-null timeout is supplied. Guards against accidentally
+        // routing through a code path that doesn't pass the timeout cleanly.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(3);
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT id, first_name, last_name, age FROM People ORDER BY id"
+        )
+        {
+            CommandTimeout = TimeSpan.FromMinutes(2)
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(3, results.Count);
+    }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -438,6 +438,55 @@ public class DbExtractorTests
 
 
 
+    // ------------------------------------------------------------------
+    // CommandType (#26)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CommandType_defaults_to_Text()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT 1");
+
+        Assert.Equal(System.Data.CommandType.Text, extractor.CommandType);
+    }
+
+
+
+    [Fact]
+    public void CommandType_set_and_get_roundtrips()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "usp_GetPeople");
+
+        extractor.CommandType = System.Data.CommandType.StoredProcedure;
+
+        Assert.Equal(System.Data.CommandType.StoredProcedure, extractor.CommandType);
+    }
+
+
+
+    [Fact]
+    public async Task CommandType_Text_still_executes_normal_query()
+    {
+        // Explicitly setting to Text (the default) should be a no-op regression check.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(3);
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT id, first_name, last_name, age FROM People ORDER BY id"
+        )
+        {
+            CommandType = System.Data.CommandType.Text
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(3, results.Count);
+    }
+
+
+
     [Fact]
     public async Task CommandTimeout_does_not_break_extraction_against_in_memory_db()
     {

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -487,6 +487,64 @@ public class DbExtractorTests
 
 
 
+    // ------------------------------------------------------------------
+    // DbProviderFactory ctor (#28)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_factory_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbExtractor<PersonRecord>((System.Data.Common.DbProviderFactory)null!, "Data Source=:memory:", "SELECT 1")
+        );
+    }
+
+
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_connectionString_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbExtractor<PersonRecord>(Microsoft.Data.Sqlite.SqliteFactory.Instance, null!, "SELECT 1")
+        );
+    }
+
+
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_commandText_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbExtractor<PersonRecord>(Microsoft.Data.Sqlite.SqliteFactory.Instance, "Data Source=:memory:", null!)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DbProviderFactory_ctor_extractor_opens_and_disposes_connection()
+    {
+        // Owned-connection path: connection is created from SqliteFactory, opened
+        // on first use inside ExtractWorkerAsync, and disposed when the iterator
+        // completes. Smoke-test that the round-trip succeeds for an empty query
+        // (in-memory SQLite, fresh schema, returns 0 rows).
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            Microsoft.Data.Sqlite.SqliteFactory.Instance,
+            "Data Source=:memory:",
+            "SELECT 1 AS id, 'x' AS first_name, 'y' AS last_name, 30 AS age WHERE 0=1"
+        );
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Empty(results);
+    }
+
+
+
     [Fact]
     public async Task CommandTimeout_does_not_break_extraction_against_in_memory_db()
     {

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -569,4 +569,46 @@ public class DbLoaderTests
         await Task.CompletedTask;
         throw new InvalidOperationException("Simulated failure");
     }
+
+
+
+    // ------------------------------------------------------------------
+    // CommandTimeout (#25)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CommandTimeout_defaults_to_null()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Null(loader.CommandTimeout);
+    }
+
+
+
+    [Fact]
+    public void CommandTimeout_set_and_get_roundtrips()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        loader.CommandTimeout = TimeSpan.FromMinutes(10);
+
+        Assert.Equal(TimeSpan.FromMinutes(10), loader.CommandTimeout);
+    }
+
+
+
+    [Fact]
+    public void CommandTimeout_when_set_to_negative_throws_ArgumentOutOfRangeException()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => loader.CommandTimeout = TimeSpan.FromMilliseconds(-1)
+        );
+    }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -639,4 +639,41 @@ public class DbLoaderTests
 
         Assert.Equal(System.Data.CommandType.StoredProcedure, loader.CommandType);
     }
+
+
+
+    // ------------------------------------------------------------------
+    // DbProviderFactory ctor (#28)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_factory_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbLoader<PersonRecord>((System.Data.Common.DbProviderFactory)null!, "Data Source=:memory:", "INSERT INTO People (first_name) VALUES (@FirstName)")
+        );
+    }
+
+
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_connectionString_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbLoader<PersonRecord>(Microsoft.Data.Sqlite.SqliteFactory.Instance, null!, "INSERT INTO People (first_name) VALUES (@FirstName)")
+        );
+    }
+
+
+
+    [Fact]
+    public void DbProviderFactory_ctor_when_commandText_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DbLoader<PersonRecord>(Microsoft.Data.Sqlite.SqliteFactory.Instance, "Data Source=:memory:", (string)null!)
+        );
+    }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -611,4 +611,32 @@ public class DbLoaderTests
             () => loader.CommandTimeout = TimeSpan.FromMilliseconds(-1)
         );
     }
+
+
+
+    // ------------------------------------------------------------------
+    // CommandType (#26)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CommandType_defaults_to_Text()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Equal(System.Data.CommandType.Text, loader.CommandType);
+    }
+
+
+
+    [Fact]
+    public void CommandType_set_and_get_roundtrips()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "usp_InsertPerson");
+
+        loader.CommandType = System.Data.CommandType.StoredProcedure;
+
+        Assert.Equal(System.Data.CommandType.StoredProcedure, loader.CommandType);
+    }
 }


### PR DESCRIPTION
## Summary

Promotes `v0.4.0` work from `vNext` to `main` for release.

## What's in v0.4.0

### Added — production-readiness knobs

- **`CommandTimeout`** (`TimeSpan?`) on both `DbExtractor<TRecord>` and `DbLoader<TRecord>`. `null` default → ADO.NET provider default (~30 s). Wired through every Dapper call site (extractor main query + default count query; loader per-record + batched `ExecuteAsync`). Negative values throw `ArgumentOutOfRangeException`.

- **`CommandType`** (`System.Data.CommandType`) on both. Default `CommandType.Text` preserves prior behavior. Set to `CommandType.StoredProcedure` and `CommandText` becomes the sproc name; Dapper binds parameters from POCO properties as usual.

- **`DbProviderFactory` + connection-string constructors** on both — owned-connection ctor overloads. The extractor/loader creates the connection via the supplied factory, opens it lazily before the first command, and disposes it when the worker completes (or throws). Saves callers the `using var conn = …; await conn.OpenAsync();` boilerplate.

  ```csharp
  var extractor = new DbExtractor<MyRecord>(
      SqlClientFactory.Instance,
      "Server=.;Database=…;Trusted_Connection=true",
      "SELECT * FROM Customers");
  await foreach (var row in extractor.ExtractAsync()) { … }
  // connection auto-disposed
  ```

## Stack history

| PR | Closes | Tests |
|---|---|---|
| #187 — `feat/command-timeout` | #25 | +7 |
| #188 — `feat/command-type` | #26 | +5 |
| #189 — `feat/connection-string-ctor` | #28 | +7 |
| #190 — release prep (`Version`, PublicAPI shipped, CHANGELOG) | — | — |

**180 tests pass** (was 161 before the stack).

## Backward compatibility

✅ Existing API surface unchanged — every addition is opt-in via new properties or new ctor overloads. v0.3.0 callers compile and run identically.

## Test plan

- [x] `dotnet build src/Wolfgang.Etl.DbClient -c Release` — 0 warnings / 0 errors across all 11 TFMs (net462, net472, net48, net481, netstandard2.0, net5.0–net10.0).
- [x] `dotnet test tests/Wolfgang.Etl.DbClient.Tests.Unit -c Release` — 180/180 pass.
- [ ] Integration matrix on PR (auto-fires once opened).

## Stack
Release branch for v0.4.0. Base: `main`. Head: `vNext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)