### PR TITLE
feat: row-level error handling for DbLoader (#24)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -302,6 +302,82 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
 
     /// <summary>
+    /// How the loader reacts when a single row's <c>ExecuteAsync</c> throws.
+    /// Defaults to <see cref="RowErrorHandling.Abort"/>, which preserves the
+    /// v0.4.0 behavior (first failure rolls back the transaction and
+    /// propagates).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="RowErrorHandling.Skip"/> only takes effect on the
+    /// per-record path (<see cref="BatchSize"/> == 1, the default). A failed
+    /// batch cannot be safely attributed to a single row without per-item
+    /// retry, so the load still aborts even in Skip mode when
+    /// <c>BatchSize &gt; 1</c>. See <see cref="RowErrorHandling.Skip"/>.
+    /// </remarks>
+    public RowErrorHandling ErrorHandling { get; set; } = RowErrorHandling.Abort;
+
+
+
+    /// <summary>
+    /// Maximum number of row-level failures the loader will tolerate before
+    /// aborting the load with an <see cref="InvalidOperationException"/>
+    /// whose <see cref="Exception.InnerException"/> is the last underlying
+    /// row failure. Defaults to <c>0</c>, meaning "unlimited" (every failure
+    /// is reported via <see cref="RowFailed"/> and processing continues).
+    /// </summary>
+    /// <remarks>
+    /// Only consulted when <see cref="ErrorHandling"/> is
+    /// <see cref="RowErrorHandling.Skip"/>.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The assigned value is negative.
+    /// </exception>
+    public int MaxErrorCount
+    {
+        get => _maxErrorCount;
+        set
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException
+                (
+                    nameof(value),
+                    value,
+                    "MaxErrorCount cannot be negative. Use 0 for unlimited."
+                );
+            }
+            _maxErrorCount = value;
+        }
+    }
+
+    private int _maxErrorCount;
+
+
+
+    /// <summary>
+    /// Number of rows that have failed to load so far (incremented for every
+    /// <see cref="RowErrorHandling.Skip"/>-handled exception). Resets to 0
+    /// at the start of each <c>LoadAsync</c> call.
+    /// </summary>
+    public int CurrentErrorCount { get; private set; }
+
+
+
+    /// <summary>
+    /// Raised once per row that fails when <see cref="ErrorHandling"/> is
+    /// <see cref="RowErrorHandling.Skip"/>. The handler receives the failing
+    /// record, the underlying exception, and the row's 1-based item index.
+    /// </summary>
+    /// <remarks>
+    /// Typical use: capture the failing record into a dead-letter store. The
+    /// handler is invoked synchronously inside the load loop, so a slow
+    /// handler will slow the entire load.
+    /// </remarks>
+    public event EventHandler<RowFailedEventArgs<TRecord>>? RowFailed;
+
+
+
+    /// <summary>
     /// Number of records sent per <c>ExecuteAsync</c> call. Defaults to <c>1</c>
     /// (one round-trip per record). Larger values pass an <c>IEnumerable&lt;TRecord&gt;</c>
     /// to Dapper, which amortizes per-call overhead (parameter parsing, command setup)
@@ -397,6 +473,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
     )
     {
         _stopwatch.Restart();
+        CurrentErrorCount = 0;
         LogLoadingStarted();
 
         // Owned-connection ctor path: open before the first execute, dispose at
@@ -519,24 +596,69 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
                 continue;
             }
 
-            if (!IsDryRun)
+            if (!IsDryRun && !await TryExecuteItemAsync(item, transaction, token).ConfigureAwait(false))
             {
-                await _connection.ExecuteAsync
-                (
-                    new CommandDefinition
-                    (
-                        _commandText,
-                        item,
-                        transaction,
-                        CommandTimeoutSeconds,
-                        CommandType,
-                        cancellationToken: token
-                    )
-                ).ConfigureAwait(false);
+                continue;
             }
 
             IncrementCurrentItemCount();
             LogDebugRecordLoaded();
+        }
+    }
+
+
+
+    /// <summary>
+    /// Per-row ExecuteAsync wrapper. Returns <see langword="true"/> when the
+    /// row succeeded (or threw in <see cref="RowErrorHandling.Abort"/> mode —
+    /// then the exception propagates and the return value isn't observed);
+    /// <see langword="false"/> when the row failed and was skipped under
+    /// <see cref="RowErrorHandling.Skip"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="MaxErrorCount"/> was reached after this row's failure in
+    /// <see cref="RowErrorHandling.Skip"/> mode.
+    /// </exception>
+    private async Task<bool> TryExecuteItemAsync(TRecord item, DbTransaction? transaction, CancellationToken token)
+    {
+        try
+        {
+            await _connection.ExecuteAsync
+            (
+                new CommandDefinition
+                (
+                    _commandText,
+                    item,
+                    transaction,
+                    CommandTimeoutSeconds,
+                    CommandType,
+                    cancellationToken: token
+                )
+            ).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex) when
+        (
+            ErrorHandling == RowErrorHandling.Skip
+            && ex is not OperationCanceledException
+        )
+        {
+            CurrentErrorCount++;
+            var itemIndex = CurrentItemCount + CurrentSkippedItemCount + CurrentErrorCount;
+            RowFailed?.Invoke(this, new RowFailedEventArgs<TRecord>(item, ex, itemIndex));
+            LogRowErrorSkipped(ex, itemIndex);
+
+            if (_maxErrorCount > 0 && CurrentErrorCount >= _maxErrorCount)
+            {
+                throw new InvalidOperationException
+                (
+                    $"DbLoader.MaxErrorCount ({_maxErrorCount}) exceeded. " +
+                    $"Last failure on item index {itemIndex}; see inner exception.",
+                    ex
+                );
+            }
+
+            return false;
         }
     }
 
@@ -796,6 +918,24 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
                 "Skipping item ({SkippedCount}/{SkipItemCount})",
                 CurrentSkippedItemCount,
                 SkipItemCount
+            );
+        }
+    }
+
+
+
+    private void LogRowErrorSkipped(Exception ex, long itemIndex)
+    {
+        if (_logger.IsEnabled(LogLevel.Warning))
+        {
+            _logger.LogWarning
+            (
+                ex,
+                "Row {ItemIndex} failed and was skipped ({ErrorCount} errors so far). " +
+                "Configured ErrorHandling=Skip; MaxErrorCount={MaxErrorCount}",
+                itemIndex,
+                CurrentErrorCount,
+                _maxErrorCount
             );
         }
     }

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,3 +1,17 @@
 #nullable enable
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.CurrentErrorCount.get -> int
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.ErrorHandling.get -> Wolfgang.Etl.DbClient.RowErrorHandling
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.ErrorHandling.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.IsDryRun.get -> bool
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.IsDryRun.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.MaxErrorCount.get -> int
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.MaxErrorCount.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.RowFailed -> System.EventHandler<Wolfgang.Etl.DbClient.RowFailedEventArgs<TRecord>!>?
+Wolfgang.Etl.DbClient.RowErrorHandling
+Wolfgang.Etl.DbClient.RowErrorHandling.Abort = 0 -> Wolfgang.Etl.DbClient.RowErrorHandling
+Wolfgang.Etl.DbClient.RowErrorHandling.Skip = 1 -> Wolfgang.Etl.DbClient.RowErrorHandling
+Wolfgang.Etl.DbClient.RowFailedEventArgs<TRecord>
+Wolfgang.Etl.DbClient.RowFailedEventArgs<TRecord>.Exception.get -> System.Exception!
+Wolfgang.Etl.DbClient.RowFailedEventArgs<TRecord>.ItemIndex.get -> long
+Wolfgang.Etl.DbClient.RowFailedEventArgs<TRecord>.Record.get -> TRecord
+Wolfgang.Etl.DbClient.RowFailedEventArgs<TRecord>.RowFailedEventArgs(TRecord record, System.Exception! exception, long itemIndex) -> void

--- a/src/Wolfgang.Etl.DbClient/RowErrorHandling.cs
+++ b/src/Wolfgang.Etl.DbClient/RowErrorHandling.cs
@@ -1,0 +1,32 @@
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Controls how <see cref="DbLoader{TRecord}"/> reacts when a single row's
+/// <c>ExecuteAsync</c> call throws.
+/// </summary>
+public enum RowErrorHandling
+{
+    /// <summary>
+    /// First failure rolls back the auto-managed transaction (if any) and
+    /// propagates the exception out of the load. This is the default and
+    /// matches the v0.4.0 behavior.
+    /// </summary>
+    Abort,
+
+    /// <summary>
+    /// Log/event the failure via <c>DbLoader.RowFailed</c>, advance
+    /// <c>CurrentErrorCount</c>, and continue processing the next row. If
+    /// <c>DbLoader.MaxErrorCount</c> is non-zero and the error count reaches
+    /// it, the load aborts with an <see cref="System.InvalidOperationException"/>
+    /// referencing the threshold and the last underlying exception is included
+    /// as the inner exception.
+    /// </summary>
+    /// <remarks>
+    /// Skip mode only applies on the per-record path (<c>BatchSize == 1</c>,
+    /// the default). When <c>BatchSize &gt; 1</c>, a failed batch can't be
+    /// reliably attributed to a single row without per-item retry, so the
+    /// load aborts even in <see cref="Skip"/> mode. Set <c>BatchSize = 1</c>
+    /// if row-level error handling is required.
+    /// </remarks>
+    Skip,
+}

--- a/src/Wolfgang.Etl.DbClient/RowFailedEventArgs.cs
+++ b/src/Wolfgang.Etl.DbClient/RowFailedEventArgs.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Payload for <c>DbLoader{TRecord}.RowFailed</c>. Fires once per row that
+/// failed to load when <c>ErrorHandling</c> is <see cref="RowErrorHandling.Skip"/>.
+/// </summary>
+public sealed class RowFailedEventArgs<TRecord> : EventArgs
+{
+    /// <summary>
+    /// Initializes a new <see cref="RowFailedEventArgs{TRecord}"/>.
+    /// </summary>
+    /// <param name="record">The record whose insert/update threw.</param>
+    /// <param name="exception">The exception thrown by the underlying provider.</param>
+    /// <param name="itemIndex">
+    /// 1-based index of the row in the source enumerable, counted after
+    /// <c>SkipItemCount</c> rows have been skipped.
+    /// </param>
+    public RowFailedEventArgs(TRecord record, Exception exception, long itemIndex)
+    {
+        Record = record;
+        Exception = exception ?? throw new ArgumentNullException(nameof(exception));
+        ItemIndex = itemIndex;
+    }
+
+    /// <summary>The record whose insert/update threw.</summary>
+    public TRecord Record { get; }
+
+    /// <summary>The exception thrown by the underlying provider.</summary>
+    public Exception Exception { get; }
+
+    /// <summary>
+    /// 1-based index of the row in the source enumerable (after
+    /// <c>SkipItemCount</c> rows have been skipped). Useful for dead-letter
+    /// capture and ordering.
+    /// </summary>
+    public long ItemIndex { get; }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -732,6 +732,124 @@ public class DbLoaderTests
 
 
 
+    // ------------------------------------------------------------------
+    // RowErrorHandling (#24)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ErrorHandling_defaults_to_Abort()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Equal(RowErrorHandling.Abort, loader.ErrorHandling);
+    }
+
+
+
+    [Fact]
+    public void MaxErrorCount_defaults_to_zero()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Equal(0, loader.MaxErrorCount);
+    }
+
+
+
+    [Fact]
+    public void MaxErrorCount_when_negative_throws_ArgumentOutOfRangeException()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => loader.MaxErrorCount = -1);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_in_Skip_mode_continues_past_failing_rows()
+    {
+        using var conn = TestDb.CreateConnection();
+        await TestDb.CreateEmptyTableAsync(conn);
+
+        // 5 valid records; constraint-violation SQL targets the `age` column
+        // with a fixed non-existent column to force per-row failures.
+        // Use a SQL that ALWAYS fails to verify Skip semantics cleanly.
+        var loader = new DbLoader<PersonRecord>
+        (
+            conn,
+            "INSERT INTO People (first_name, no_such_column) VALUES (@FirstName, @Age)"
+        )
+        {
+            ErrorHandling = RowErrorHandling.Skip
+        };
+
+        var failures = new List<long>();
+        loader.RowFailed += (_, args) => failures.Add(args.ItemIndex);
+
+        await loader.LoadAsync(CreateTestRecords(5).ToAsyncEnumerable());
+
+        Assert.Equal(0, await TestDb.CountRowsAsync(conn));     // every row failed
+        Assert.Equal(0, loader.CurrentItemCount);               // none "loaded"
+        Assert.Equal(5, loader.CurrentErrorCount);              // all five captured
+        Assert.Equal(new long[] { 1, 2, 3, 4, 5 }, failures);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_in_Skip_mode_aborts_when_MaxErrorCount_is_reached()
+    {
+        using var conn = TestDb.CreateConnection();
+        await TestDb.CreateEmptyTableAsync(conn);
+
+        var loader = new DbLoader<PersonRecord>
+        (
+            conn,
+            "INSERT INTO People (first_name, no_such_column) VALUES (@FirstName, @Age)"
+        )
+        {
+            ErrorHandling = RowErrorHandling.Skip,
+            MaxErrorCount = 3
+        };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await loader.LoadAsync(CreateTestRecords(10).ToAsyncEnumerable())
+        );
+
+        Assert.Contains("MaxErrorCount", ex.Message, StringComparison.Ordinal);
+        Assert.NotNull(ex.InnerException);
+        Assert.Equal(3, loader.CurrentErrorCount);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_in_Abort_mode_propagates_the_first_failure()
+    {
+        using var conn = TestDb.CreateConnection();
+        await TestDb.CreateEmptyTableAsync(conn);
+
+        var loader = new DbLoader<PersonRecord>
+        (
+            conn,
+            "INSERT INTO People (first_name, no_such_column) VALUES (@FirstName, @Age)"
+        );
+
+        await Assert.ThrowsAsync<Microsoft.Data.Sqlite.SqliteException>
+        (
+            async () => await loader.LoadAsync(CreateTestRecords(5).ToAsyncEnumerable())
+        );
+
+        Assert.Equal(0, loader.CurrentErrorCount); // never tracked in Abort mode
+    }
+
+
+
     [Fact]
     public async Task LoadAsync_when_IsDryRun_is_true_and_BatchSize_is_set_does_not_flush_batches()
     {


### PR DESCRIPTION
## Summary

Adds configurable row-level error handling to `DbLoader`, allowing failed rows to be captured and skipped instead of aborting the entire load.

## New public surface

```csharp
public enum RowErrorHandling { Abort, Skip }

public sealed class RowFailedEventArgs<TRecord> : EventArgs
{
    public TRecord Record { get; }
    public Exception Exception { get; }
    public long ItemIndex { get; }   // 1-based, after SkipItemCount rows
}

class DbLoader<TRecord> {
    public RowErrorHandling ErrorHandling { get; set; }   // default Abort
    public int MaxErrorCount { get; set; }                // default 0 = unlimited
    public int CurrentErrorCount { get; }                 // read-only, resets each LoadAsync
    public event EventHandler<RowFailedEventArgs<TRecord>>? RowFailed;
}
```

## Behavior

- **`Abort`** (default, v0.4.0 behavior) — first failure rolls back the auto-managed transaction and propagates.
- **`Skip`** — catch on per-row `ExecuteAsync`; fire `RowFailed` with the record + exception + 1-based item index; advance `CurrentErrorCount`; continue. If `MaxErrorCount > 0` and the count is reached, the load aborts with an `InvalidOperationException` whose `InnerException` is the last underlying provider exception.
- `OperationCanceledException` is excluded from Skip — cancellation always propagates.

## Scope limitation

Skip mode only applies on the **per-record path** (`BatchSize == 1`). A failed `BatchSize-N` batch can't be safely attributed to a single row without per-item retry, so it still aborts in Skip mode. Documented on the enum.

## Closes
- **#24** — Add row-level error handling strategy to DbLoader

## Test plan
- [x] 6 new tests: defaults (Abort, 0), MaxErrorCount negative-reject, all-rows-fail Skip path + `RowFailed` event payload, MaxErrorCount reached abort, Abort mode still propagates.
- [x] **190 tests pass** (was 184).

## Stack
Second PR of the v0.5.0 stack. Base: `feat/loader-dry-run` (O01 → #192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)