### PR TITLE
feat: DbExtractor.CountAsync (#32)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -351,6 +351,54 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
 
+    /// <summary>
+    /// Runs the configured <see cref="TotalCountQuery"/> (or the built-in
+    /// <see cref="DefaultTotalCountQuery"/> if none is assigned) and returns
+    /// the result. Useful when the caller wants the total count without
+    /// actually streaming the rows — for example, sizing a progress bar
+    /// before kicking off the extract.
+    /// </summary>
+    /// <param name="cancellationToken">Token to cancel the count query.</param>
+    /// <returns>The row count reported by the underlying query.</returns>
+    /// <remarks>
+    /// <para>
+    /// Doesn't mutate any state on the extractor — does not touch
+    /// <c>DbReport.TotalItemCount</c>, the stopwatch, or any of the
+    /// progress counters. Safe to call any number of times before, during
+    /// (different cancellation token), or after an <c>ExtractAsync</c>.
+    /// </para>
+    /// <para>
+    /// Opens the connection on the owned-connection ctor path before running
+    /// the query and disposes it after — same lifecycle as a full extraction.
+    /// </para>
+    /// </remarks>
+    public async Task<int> CountAsync(CancellationToken cancellationToken = default)
+    {
+        var query = TotalCountQuery ?? DefaultTotalCountQuery;
+
+        if (_ownsConnection && _connection.State != ConnectionState.Open)
+        {
+            await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                return await query(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+#if NET5_0_OR_GREATER
+                await _connection.DisposeAsync().ConfigureAwait(false);
+#else
+                _connection.Dispose();
+#endif
+            }
+        }
+
+        return await query(cancellationToken).ConfigureAwait(false);
+    }
+
+
+
     /// <inheritdoc/>
     protected override DbReport CreateProgressReport()
     {

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.BatchCommitSize.get -> int
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.BatchCommitSize.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CurrentErrorCount.get -> int

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -565,4 +565,56 @@ public class DbExtractorTests
 
         Assert.Equal(3, results.Count);
     }
+
+
+
+    // ------------------------------------------------------------------
+    // CountAsync (#32)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task CountAsync_uses_default_count_query_and_returns_row_count()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 7);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People");
+
+        var count = await extractor.CountAsync();
+
+        Assert.Equal(7, count);
+    }
+
+
+
+    [Fact]
+    public async Task CountAsync_with_custom_TotalCountQuery_returns_that_value()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 4);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People")
+        {
+            TotalCountQuery = _ => Task.FromResult(42)
+        };
+
+        var count = await extractor.CountAsync();
+
+        Assert.Equal(42, count);
+    }
+
+
+
+    [Fact]
+    public async Task CountAsync_does_not_affect_progress_state()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 5);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People");
+
+        var count = await extractor.CountAsync();
+
+        // CountAsync runs the count query but does not touch the progress
+        // counters — those advance only when ExtractAsync streams rows.
+        Assert.Equal(5, count);
+        Assert.Equal(0, extractor.CurrentItemCount);
+    }
 }


### PR DESCRIPTION
## Summary

New public surface:

```csharp
DbExtractor<TRecord>.CountAsync(CancellationToken = default) -> Task<int>
```

Runs the configured `TotalCountQuery` (or the built-in `DefaultTotalCountQuery` if none is assigned) and returns the result. Useful when the caller wants the row count **without** actually streaming — e.g. sizing a progress bar or validating expectations before kicking off an extract.

## Semantics

- **Side-effect free** on the extractor's state: no stopwatch update, no `TotalItemCount` mutation, no counter increments. Safe to call any number of times before, during (with a separate cancellation token), or after an `ExtractAsync`.
- **Owned-connection lifecycle preserved**: when the extractor owns the connection, `CountAsync` opens it before the query and disposes it after — same dispose path as a full extraction. Uses `DisposeAsync` on net5.0+ and the synchronous `Dispose` elsewhere.

## Closes
- **#32** — Add CountAsync convenience method to DbExtractor

## Test plan
- [x] 3 new tests: default count query against a real SQLite DB, custom `TotalCountQuery` override, and confirming `CurrentItemCount` stays at 0.
- [x] **197 tests pass** (was 194).

## Stack
Fourth PR of the v0.5.0 stack. Base: `feat/loader-batch-commit` (O03 → #194).

🤖 Generated with [Claude Code](https://claude.com/claude-code)