### PR TITLE
feat: ManageConnection for pool-friendly open/close (#31)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -326,6 +326,34 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// When <see langword="true"/>, the extractor opens the connection before
+    /// the first command runs and closes it after the enumeration ends. The
+    /// connection is NOT disposed — it's returned to the pool for reuse,
+    /// which plays better with connection-pool lifetime in web apps and
+    /// hosted services.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Default <see langword="false"/> preserves the v0.4.0 behavior: the
+    /// caller is responsible for opening the connection before calling
+    /// <c>ExtractAsync</c>.
+    /// </para>
+    /// <para>
+    /// Ignored on the owned-connection ctor path (the
+    /// <c>(DbProviderFactory, connectionString, …)</c> overload). That path
+    /// always manages and disposes the connection because it created it.
+    /// </para>
+    /// <para>
+    /// If the connection is already open when <c>ExtractAsync</c> starts,
+    /// it's left open — the extractor only closes connections it itself
+    /// opened.
+    /// </para>
+    /// </remarks>
+    public bool ManageConnection { get; set; }
+
+
+
+    /// <summary>
     /// When non-null, this function is invoked before extraction begins to determine
     /// the total record count, which is then reported via <c>DbReport.TotalItemCount</c>.
     /// Assign <see cref="DefaultTotalCountQuery"/> to use the library's built-in
@@ -375,16 +403,22 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     public async Task<int> CountAsync(CancellationToken cancellationToken = default)
     {
         var query = TotalCountQuery ?? DefaultTotalCountQuery;
+        var needsOpen = (_ownsConnection || ManageConnection) && _connection.State != ConnectionState.Open;
 
-        if (_ownsConnection && _connection.State != ConnectionState.Open)
+        if (!needsOpen)
         {
-            await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            return await query(cancellationToken).ConfigureAwait(false);
+        }
 
-            try
-            {
-                return await query(cancellationToken).ConfigureAwait(false);
-            }
-            finally
+        await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            return await query(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (_ownsConnection)
             {
 #if NET5_0_OR_GREATER
                 await _connection.DisposeAsync().ConfigureAwait(false);
@@ -392,9 +426,16 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 _connection.Dispose();
 #endif
             }
+            else
+            {
+#if NET5_0_OR_GREATER
+                await _connection.CloseAsync().ConfigureAwait(false);
+#else
+                _connection.Close();
+                await Task.CompletedTask.ConfigureAwait(false);
+#endif
+            }
         }
-
-        return await query(cancellationToken).ConfigureAwait(false);
     }
 
 
@@ -449,11 +490,15 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         LogExtractionStarted();
 
         // Owned-connection ctor path: open before the first query, dispose after.
+        // ManageConnection=true path: open before the first query, CLOSE (don't
+        // dispose) after — connection returns to the pool, caller keeps it.
         // try/finally in an async iterator is OK in C# 8+; the iterator runtime
         // routes break/exception through the finally on Dispose.
-        if (_ownsConnection && _connection.State != ConnectionState.Open)
+        var openedHere = false;
+        if ((_ownsConnection || ManageConnection) && _connection.State != ConnectionState.Open)
         {
             await _connection.OpenAsync(token).ConfigureAwait(false);
+            openedHere = true;
         }
 
         try
@@ -501,6 +546,16 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 await _connection.DisposeAsync().ConfigureAwait(false);
 #else
                 _connection.Dispose();
+#endif
+            }
+            else if (openedHere)
+            {
+                // ManageConnection path — close (do NOT dispose; caller owns it).
+#if NET5_0_OR_GREATER
+                await _connection.CloseAsync().ConfigureAwait(false);
+#else
+                _connection.Close();
+                await Task.CompletedTask.ConfigureAwait(false);
 #endif
             }
         }

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -272,6 +272,32 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
 
     /// <summary>
+    /// When <see langword="true"/>, the loader opens the connection before the
+    /// first command runs and closes it after the load ends. The connection
+    /// is NOT disposed — it's returned to the pool for reuse, which plays
+    /// better with connection-pool lifetime in web apps and hosted services.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Default <see langword="false"/> preserves the v0.4.0 behavior: the
+    /// caller is responsible for opening the connection before calling
+    /// <c>LoadAsync</c>.
+    /// </para>
+    /// <para>
+    /// Ignored on the owned-connection ctor path (the
+    /// <c>(DbProviderFactory, connectionString, …)</c> overload). That path
+    /// always manages and disposes the connection because it created it.
+    /// </para>
+    /// <para>
+    /// If the connection is already open when <c>LoadAsync</c> starts, it's
+    /// left open — the loader only closes connections it itself opened.
+    /// </para>
+    /// </remarks>
+    public bool ManageConnection { get; set; }
+
+
+
+    /// <summary>
     /// When <see langword="true"/>, the loader runs the full pipeline —
     /// enumerates the source, evaluates <c>SkipItemCount</c> /
     /// <c>MaximumItemCount</c>, increments progress counters, fires the
@@ -524,11 +550,14 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         LogLoadingStarted();
 
         // Owned-connection ctor path: open before the first execute, dispose at
-        // the end. Wrapped in try/finally so the connection is released even
-        // when LoadWith*Async throws (the caller's exception still propagates).
-        if (_ownsConnection && _connection.State != ConnectionState.Open)
+        // the end. ManageConnection=true path: open before, CLOSE (don't dispose)
+        // after. Wrapped in try/finally so the connection is released even when
+        // LoadWith*Async throws (the caller's exception still propagates).
+        var openedHere = false;
+        if ((_ownsConnection || ManageConnection) && _connection.State != ConnectionState.Open)
         {
             await _connection.OpenAsync(token).ConfigureAwait(false);
+            openedHere = true;
         }
 
         try
@@ -552,6 +581,15 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
                 await _connection.DisposeAsync().ConfigureAwait(false);
 #else
                 _connection.Dispose();
+#endif
+            }
+            else if (openedHere)
+            {
+#if NET5_0_OR_GREATER
+                await _connection.CloseAsync().ConfigureAwait(false);
+#else
+                _connection.Close();
+                await Task.CompletedTask.ConfigureAwait(false);
 #endif
             }
         }

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ManageConnection.get -> bool
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ManageConnection.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.BatchCommitSize.get -> int
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.BatchCommitSize.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CurrentErrorCount.get -> int
@@ -7,6 +9,8 @@ Wolfgang.Etl.DbClient.DbLoader<TRecord>.ErrorHandling.get -> Wolfgang.Etl.DbClie
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.ErrorHandling.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.IsDryRun.get -> bool
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.IsDryRun.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.ManageConnection.get -> bool
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.ManageConnection.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.MaxErrorCount.get -> int
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.MaxErrorCount.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.RowFailed -> System.EventHandler<Wolfgang.Etl.DbClient.RowFailedEventArgs<TRecord>!>?

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -603,6 +603,72 @@ public class DbExtractorTests
 
 
 
+    // ------------------------------------------------------------------
+    // ManageConnection (#31)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ManageConnection_defaults_to_false()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People");
+
+        Assert.False(extractor.ManageConnection);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_ManageConnection_is_true_opens_a_closed_connection_and_closes_it_after()
+    {
+        // Shared-cache in-memory SQLite so a Close()→Open() cycle preserves
+        // schema + data (plain :memory: drops it).
+        var connString = $"Data Source=mc_extractor_{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+        using var keeper = new Microsoft.Data.Sqlite.SqliteConnection(connString);
+        await keeper.OpenAsync();
+        await TestDb.CreateEmptyTableAsync(keeper);
+        using (var seed = keeper.CreateCommand())
+        {
+            seed.CommandText = "INSERT INTO People (first_name, last_name, age) VALUES ('Ada','Lovelace',36),('Alan','Turing',41),('Grace','Hopper',85)";
+            await seed.ExecuteNonQueryAsync();
+        }
+
+        using var conn = new Microsoft.Data.Sqlite.SqliteConnection(connString);
+        Assert.Equal(System.Data.ConnectionState.Closed, conn.State);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People")
+        {
+            ManageConnection = true
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(3, records.Count);
+        Assert.Equal(System.Data.ConnectionState.Closed, conn.State);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_ManageConnection_is_true_leaves_already_open_connections_open()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 3);
+        Assert.Equal(System.Data.ConnectionState.Open, conn.State);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People")
+        {
+            ManageConnection = true
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        // We only close what we opened. The caller had it open; it stays open.
+        Assert.Equal(3, records.Count);
+        Assert.Equal(System.Data.ConnectionState.Open, conn.State);
+    }
+
+
+
     [Fact]
     public async Task CountAsync_does_not_affect_progress_state()
     {

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -851,6 +851,53 @@ public class DbLoaderTests
 
 
     // ------------------------------------------------------------------
+    // ManageConnection (#31)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ManageConnection_defaults_to_false()
+    {
+        using var conn = TestDb.CreateConnection();
+        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.False(loader.ManageConnection);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_when_ManageConnection_is_true_opens_a_closed_connection_and_closes_it_after()
+    {
+        // Shared-cache in-memory SQLite so a Close()→Open() cycle preserves
+        // the table (plain :memory: drops it).
+        var connString = $"Data Source=mc_loader_{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+        using var keeper = new Microsoft.Data.Sqlite.SqliteConnection(connString);
+        await keeper.OpenAsync();
+        await TestDb.CreateEmptyTableAsync(keeper);
+
+        using var conn = new Microsoft.Data.Sqlite.SqliteConnection(connString);
+        Assert.Equal(System.Data.ConnectionState.Closed, conn.State);
+
+        var loader = new DbLoader<PersonRecord>
+        (
+            conn,
+            "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)"
+        )
+        {
+            ManageConnection = true
+        };
+
+        await loader.LoadAsync(CreateTestRecords(4).ToAsyncEnumerable());
+
+        Assert.Equal(System.Data.ConnectionState.Closed, conn.State);
+        // Re-open and verify the 4 rows landed AND the connection wasn't disposed.
+        await conn.OpenAsync();
+        Assert.Equal(4, await TestDb.CountRowsAsync(conn));
+    }
+
+
+
+    // ------------------------------------------------------------------
     // BatchCommitSize (#22)
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

New public surface (mirrored on both Extractor and Loader):

```csharp
DbExtractor<TRecord>.ManageConnection { get; set; } // bool, default false
DbLoader<TRecord>.ManageConnection    { get; set; } // bool, default false
```

When `true`, the extractor/loader **opens** the connection before the first command and **closes** (not disposes) it after the operation ends. The connection returns to the ADO.NET pool, ready for reuse — better fit for connection-pool lifetime in web apps and hosted services. Default `false` preserves the v0.4.0 behavior (caller opens the connection).

## Rules

- Already-open connection stays open — we close only what we opened.
- On the **owned-connection ctor path** (`DbProviderFactory` overload from v0.4.0), `ManageConnection` is ignored because that path always **disposes** the connection it created.
- `CountAsync` follows the same open-then-close lifecycle.
- Uses `CloseAsync` on net5.0+ and the synchronous `Close` elsewhere.

## Closes
- **#31** — Add connection pooling-friendly open/close per operation

## Test plan
- [x] 5 new tests: defaults on both, end-to-end open-closed-extract/load + verify-closed for both, and (extractor only) confirming an already-open caller-managed connection is left open.
- [x] **202 tests pass** (was 197).

Tests use Microsoft.Data.Sqlite's shared-cache in-memory mode (`Data Source=name;Mode=Memory;Cache=Shared`) instead of plain `:memory:` because plain mode drops schema+data when the only connection is closed, defeating a close-then-reopen verification.

## Stack
Fifth PR of the v0.5.0 stack. Base: `feat/extractor-count-async` (O04 → #195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)