### PR TITLE
feat: server-side paging on DbExtractor (#33)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -388,6 +388,51 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// When both <see cref="ServerOffset"/> and <see cref="ServerLimit"/> are
+    /// set, the extractor appends <see cref="PagingClauseTemplate"/> to the
+    /// command text before sending it. Default <see langword="null"/> disables
+    /// server-side paging (the v0.4.0 behavior — the full result set comes
+    /// back and <c>SkipItemCount</c>/<c>MaximumItemCount</c> filter
+    /// client-side).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use server-side paging for very large tables where streaming
+    /// everything to the client is wasteful. SQL Server requires an
+    /// <c>ORDER BY</c> in the command text for paging to be deterministic;
+    /// SQLite, PostgreSQL, and MySQL don't require it but you should still
+    /// include one — without a stable order, page contents drift.
+    /// </para>
+    /// </remarks>
+    public long? ServerOffset { get; set; }
+
+
+
+    /// <summary>Page size in rows. See <see cref="ServerOffset"/>.</summary>
+    public long? ServerLimit { get; set; }
+
+
+
+    /// <summary>
+    /// SQL fragment appended to the command text when both
+    /// <see cref="ServerOffset"/> and <see cref="ServerLimit"/> are set.
+    /// Bound as Dapper parameters <c>@PageOffset</c> and <c>@PageLimit</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Defaults to <c>LIMIT @PageLimit OFFSET @PageOffset</c> — the SQLite /
+    /// PostgreSQL / MySQL syntax.
+    /// </para>
+    /// <para>
+    /// For SQL Server, set to <c>OFFSET @PageOffset ROWS FETCH NEXT @PageLimit ROWS ONLY</c>
+    /// (and ensure the base SQL ends with an <c>ORDER BY</c>).
+    /// </para>
+    /// </remarks>
+    public string PagingClauseTemplate { get; set; } = "LIMIT @PageLimit OFFSET @PageOffset";
+
+
+
+    /// <summary>
     /// When non-null, this function is invoked before extraction begins to determine
     /// the total record count, which is then reported via <c>DbReport.TotalItemCount</c>.
     /// Assign <see cref="DefaultTotalCountQuery"/> to use the library's built-in
@@ -537,7 +582,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
         try
         {
-            var param = Parameters ?? _dynamicParameters;
+            ApplyServerPaging(_commandText, Parameters ?? _dynamicParameters, out var commandText, out var param);
 
             if (TotalCountQuery != null)
             {
@@ -546,7 +591,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
             long rowIndex = 0;
 
-            await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(_commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
+            await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
             {
                 token.ThrowIfCancellationRequested();
                 rowIndex++;
@@ -608,6 +653,38 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         var param = Parameters ?? _dynamicParameters;
         return _connection.ExecuteScalarAsync<int>(
             new CommandDefinition(countSql, param, _transaction, CommandTimeoutSeconds, cancellationToken: token));
+    }
+
+
+
+    /// <summary>
+    /// If <see cref="ServerOffset"/> and <see cref="ServerLimit"/> are both
+    /// set, append <see cref="PagingClauseTemplate"/> to <paramref name="commandText"/>
+    /// (returned via <paramref name="pagedCommandText"/>) and add
+    /// <c>@PageOffset</c> / <c>@PageLimit</c> to the parameter set (returned
+    /// via <paramref name="pagedParam"/>). Otherwise returns the inputs
+    /// unchanged.
+    /// </summary>
+    /// <remarks>
+    /// out parameters instead of a tuple — net462 doesn't ship
+    /// <c>System.ValueTuple</c> in the base targeting pack and we avoid the
+    /// extra package reference.
+    /// </remarks>
+    private void ApplyServerPaging(string commandText, DynamicParameters? param, out string pagedCommandText, out DynamicParameters? pagedParam)
+    {
+        if (!ServerOffset.HasValue || !ServerLimit.HasValue)
+        {
+            pagedCommandText = commandText;
+            pagedParam = param;
+            return;
+        }
+
+        var pagingParam = param ?? new DynamicParameters();
+        pagingParam.Add("@PageOffset", ServerOffset.Value);
+        pagingParam.Add("@PageLimit", ServerLimit.Value);
+
+        pagedCommandText = commandText + " " + PagingClauseTemplate;
+        pagedParam = pagingParam;
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -2,8 +2,14 @@
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ManageConnection.get -> bool
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ManageConnection.set -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.PagingClauseTemplate.get -> string!
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.PagingClauseTemplate.set -> void
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.Parameters.get -> Dapper.DynamicParameters?
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.Parameters.set -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ServerLimit.get -> long?
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ServerLimit.set -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ServerOffset.get -> long?
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ServerOffset.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.BatchCommitSize.get -> int
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.BatchCommitSize.set -> void
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.CurrentErrorCount.get -> int

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -604,6 +604,82 @@ public class DbExtractorTests
 
 
     // ------------------------------------------------------------------
+    // Server-side paging (#33)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Paging_defaults_disable_server_side_paging()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People");
+
+        Assert.Null(extractor.ServerOffset);
+        Assert.Null(extractor.ServerLimit);
+        Assert.Equal("LIMIT @PageLimit OFFSET @PageOffset", extractor.PagingClauseTemplate);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_ServerLimit_caps_rows_at_the_database()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
+        {
+            ServerOffset = 0,
+            ServerLimit = 5
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(5, records.Count);
+        Assert.Equal("First1", records[0].FirstName);
+        Assert.Equal("First5", records[4].FirstName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_ServerOffset_and_ServerLimit_returns_a_page()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
+        {
+            ServerOffset = 10,
+            ServerLimit = 5
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        // Skipped 10, took 5 → First11..First15.
+        Assert.Equal(5, records.Count);
+        Assert.Equal("First11", records[0].FirstName);
+        Assert.Equal("First15", records[4].FirstName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_only_ServerOffset_does_not_apply_paging()
+    {
+        // The clause is only appended when BOTH are set.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 10);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
+        {
+            ServerOffset = 5
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(10, records.Count); // all rows — paging disabled
+    }
+
+
+
+    // ------------------------------------------------------------------
     // Parameters property override (#27)
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

New public surface:

```csharp
DbExtractor<TRecord>.ServerOffset          { get; set; } // long?,  default null
DbExtractor<TRecord>.ServerLimit           { get; set; } // long?,  default null
DbExtractor<TRecord>.PagingClauseTemplate  { get; set; } // string, default "LIMIT @PageLimit OFFSET @PageOffset"
```

When **both** `ServerOffset` and `ServerLimit` are set, the extractor appends `PagingClauseTemplate` to the command text and binds `@PageOffset` / `@PageLimit` as Dapper parameters. This pushes paging down to the database — only one page round-trips the wire — rather than fetching everything and filtering client-side via `SkipItemCount` / `MaximumItemCount`.

## Dialects

Default `LIMIT/OFFSET` syntax fits **SQLite, PostgreSQL, MySQL**. For **SQL Server**:

```csharp
extractor.PagingClauseTemplate = "OFFSET @PageOffset ROWS FETCH NEXT @PageLimit ROWS ONLY";
// and ensure the base SQL ends with an ORDER BY — SQL Server requires it.
```

The other dialects tolerate a missing `ORDER BY`, but you should include one anyway — without a stable order, page contents drift between calls.

## Scope

- Caller-driven **single-page** mode (the simpler half of #33). Auto-paging (loop until empty) is out of scope for this PR.
- Both `ServerOffset` and `ServerLimit` must be set for paging to engage. Setting only one is a no-op — documented + tested.
- The default-count-query path is unaffected: `CountAsync` and the implicit count still report the full result set, not the current page.

## Closes
- **#33** — Add server-side paging support to DbExtractor

## Test plan
- [x] 4 new tests: defaults (null + default template), `ServerLimit`-only caps at 5 of 20 rows from offset 0, `ServerOffset=10` + `ServerLimit=5` returns the correct page (`First11..First15`), and setting only `ServerOffset` doesn't engage paging.
- [x] **209 tests pass** (was 205).

## Stack
Seventh PR of the v0.5.0 stack. Base: `feat/output-parameters` (O06 → #197).

🤖 Generated with [Claude Code](https://claude.com/claude-code)