### PR TITLE
chore: bump TestKit/Xunit to 0.9.0 and Bcl to 10.0.9

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -434,7 +434,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
     /// <summary>
     /// When non-null, this function is invoked before extraction begins to determine
-    /// the total record count, which is then reported via <c>DbReport.TotalItemCount</c>.
+    /// the total record count, which is then reported via <see cref="Report.TotalItemCount"/>.
     /// Assign <see cref="DefaultTotalCountQuery"/> to use the library's built-in
     /// <c>SELECT COUNT(*)</c> subquery, or supply a custom function for a more efficient
     /// query. Defaults to <c>null</c> (total count is not fetched).

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -71,10 +71,10 @@
     prevent NuGet from resolving an older transitive version — no runtime assembly is copied.
   -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -110,13 +110,13 @@
 
   <!-- Shared dependencies (all TFMs) -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.10" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.7.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.6.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.9.0" />
   </ItemGroup>
 
   <!-- Copy native SQLite DLL to output for .NET Framework (no RID-based probing) -->


### PR DESCRIPTION
Bumps the test-side packages now that vNext is on Abstractions 0.15.0 (which folded in the original 0.14.x consolidation work).

### Package bumps
- `Wolfgang.Etl.TestKit` 0.7.0 → **0.9.0**, `.Xunit` 0.6.0 → **0.9.0** (both test projects)
- `Microsoft.Bcl.AsyncInterfaces` 10.0.5 → **10.0.9** (src + both test projects; TestKit 0.9.0's floor)

### What's NOT in this PR anymore
The original `0.14.1` Abstractions bump + `DbReport.TotalItemCount` consolidation + XML-cref repointing + `PublicAPI.Shipped.txt` cleanup landed on vNext via the v0.5.0 stack (PR #192). Rebasing onto vNext absorbed those changes — only the test-side bumps survive here.

The one remaining DbExtractor.cs hunk just repoints the now-inherited `TotalItemCount` cref from `<c>DbReport.TotalItemCount</c>` to `<see cref=\"Report.TotalItemCount\"/>` (proper cref, now that it lives on the base class).

### Verification
- **219/219** unit tests pass on net10.0 (was 217 — TestKit 0.9.0 contract tests added 2 new cases).
- Multi-TFM Release build clean across all 11 TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)