### PR TITLE
ci: gate release.yaml on the integration matrix (#206)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,11 +98,12 @@ jobs:
       - name: Run multi-framework tests with coverage
         shell: pwsh
         run: |
-          # Exclude *.Tests.Integration.* — those need Docker / Testcontainers,
-          # which the release runner doesn't provide. The integration matrix is
-          # exercised by pr.yaml's test-integration job (with proper services:
-          # blocks per RDBMS) on every PR, so release-time re-validation isn't
-          # adding signal. Match the per-language SDK extensions (cs / vb / fs).
+          # Exclude *.Tests.Integration.* from THIS Windows job — it runs the
+          # unit suite only. Integration tests need Testcontainers (Linux), and
+          # are gated by the dedicated test-integration matrix job below
+          # (publish-nuget needs:[…, test-integration-all]) so a release still
+          # can't ship if any provider's integration suite is red.
+          # Match the per-language SDK extensions (cs / vb / fs).
           $testProjects = Get-ChildItem -Path './tests' -Recurse -Include '*Test*.csproj', '*Test*.vbproj', '*Test*.fsproj' |
             Where-Object { $_.Name -notmatch '\.Tests\.Integration\.(cs|vb|fs)proj$' }
 
@@ -568,10 +569,102 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
-  # Publish to NuGet (only if validation passed)
+  # ============================================================================
+  # RDBMS INTEGRATION (release-time gate) — closes the gap flagged in #206.
+  # Mirrors pr.yaml's test-integration matrix but runs against the released
+  # tag's commit instead of a PR head. Testcontainers (Linux only) — sqlite
+  # included so a single matrix shape covers every supported provider.
+  # ============================================================================
+  test-integration:
+    name: "Integration / ${{ matrix.rdbms }} (${{ matrix.tfm }})"
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        rdbms: [sqlserver, postgres, mysql, mariadb, sqlite]
+        tfm: [net8.0, net10.0]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Locate integration project
+        id: locate
+        shell: bash
+        run: |
+          # Match all three project extensions so a future VB/F# rewrite is found.
+          proj=$(find ./tests -type f \
+            \( -name "*.Tests.Integration.csproj" \
+            -o -name "*.Tests.Integration.vbproj" \
+            -o -name "*.Tests.Integration.fsproj" \) \
+            | head -n1)
+          if [ -z "$proj" ]; then
+            echo "ℹ️  No integration project found — skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Integration project: $proj"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "project=$proj" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
+        if: steps.locate.outputs.found == 'true'
+        run: |
+          dotnet test "${{ steps.locate.outputs.project }}" \
+            --configuration Release \
+            --framework ${{ matrix.tfm }} \
+            --filter "Category=${{ matrix.rdbms }}" \
+            -p:TreatWarningsAsErrors=true \
+            --logger "console;verbosity=normal" \
+            --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
+            --results-directory "./TestResults-Integration"
+
+      - name: Upload integration test results
+        if: always() && steps.locate.outputs.found == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-integration-${{ matrix.rdbms }}-${{ matrix.tfm }}-trx
+          path: TestResults-Integration/
+
+  # ============================================================================
+  # INTEGRATION AGGREGATOR (release-time)
+  # Single stable job that rolls the matrix into one pass/fail signal — same
+  # pattern as pr.yaml's test-integration-all. publish-nuget needs THIS job,
+  # so the matrix can grow / change TFMs without re-wiring the publish gate.
+  # ============================================================================
+  test-integration-all:
+    name: "Integration (all)"
+    needs: test-integration
+    runs-on: ubuntu-latest
+    if: always()
+    env:
+      INTEGRATION_RESULT: ${{ needs.test-integration.result }}
+    steps:
+      - name: Check matrix result
+        run: |
+          echo "test-integration = $INTEGRATION_RESULT"
+          if [ "$INTEGRATION_RESULT" = "success" ]; then
+            echo "✅ Integration aggregator passes (all cells succeeded)"
+            exit 0
+          fi
+          echo "❌ Integration aggregator FAILS — release gate blocks the publish."
+          exit 1
+
+  # Publish to NuGet (only if validation + integration passed)
   publish-nuget:
     name: Publish to NuGet.org
-    needs: pack-and-validate
+    needs: [pack-and-validate, test-integration-all]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
## Summary

Closes the release-gate gap from #206: `release.yaml`'s unit-test job has always excluded `*.Tests.Integration.*` (Windows runner, no Testcontainers / Docker), and there was no compensating integration job at release time. A release could ship to NuGet while any provider's integration suite was red — `pr.yaml` caught it at PR time but a re-tag or force-push could bypass that.

## New jobs (between `Validate Release Build` and `Publish to NuGet.org`)

### `test-integration` — 10 cells, Ubuntu
| | net8.0 | net10.0 |
|---|:---:|:---:|
| sqlserver | ✓ | ✓ |
| postgres | ✓ | ✓ |
| mysql | ✓ | ✓ |
| mariadb | ✓ | ✓ |
| sqlite | ✓ | ✓ |

Mirrors pr.yaml's existing matrix. Testcontainers spawns the DB container per cell. Same `dotnet test` invocation — only difference is the artifact name (`release-integration-*` vs `integration-*`).

### `test-integration-all` — aggregator
Stable-named single job that rolls the 10 cells into one pass/fail signal. `publish-nuget needs:` this job, so the matrix can grow (Oracle, CockroachDB, …) or change TFMs without re-wiring the publish gate. Mirrors the pattern `pr.yaml` uses for the same matrix.

## Wiring

```
                                          ┌──> test-integration (5×2) ──> test-integration-all ──┐
validate-release ──┬──> pack-and-validate ─┤                                                     ├──> publish-nuget
                   │                       └─────────────────────────────────────────────────────┘
                   └──> trigger-docs
```

Any matrix cell failure blocks the NuGet push — same gate semantics as the existing unit / coverage / DocFX-verify gates.

## Drive-by

Rewrote the misleading comment at the Windows unit-test step (release.yaml:100-107) that read *"release-time re-validation isn't adding signal"* — that rationale no longer holds now that the release-time integration matrix is in place.

## Closes
- **#206** — release.yaml skips integration tests

## ⚠️ Protected-files note
This PR touches `.github/workflows/release.yaml` and will likely trip the "Detect .NET Projects" guard. Maintainer **admin-bypass and merge** is the expected merge path (per `feedback_protected_config_files_guard.md` / `feedback_admin_bypass_all_or_nothing.md` — be deliberate, all ruleset gates are waived together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)