### PR TITLE
fix: address real-bug InspectCode findings (#202 follow-up)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -882,11 +882,16 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
     private static IReadOnlyList<string> ExtractTemplateParamNames(string template)
     {
+        // `while` rather than `for` — the loop intentionally jumps the cursor past
+        // the matched parameter name in one step, which Sonar's S127 flags as
+        // "loop counter mutated in body" when the cursor is a for-loop variable.
         var names = new List<string>();
-        for (var i = 0; i < template.Length; i++)
+        var i = 0;
+        while (i < template.Length)
         {
             if (template[i] != '@')
             {
+                i++;
                 continue;
             }
             var start = i + 1;
@@ -899,7 +904,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
             {
                 names.Add(template.Substring(start, end - start));
             }
-            i = end - 1;
+            i = end;
         }
         return names;
     }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -348,7 +348,11 @@ public class DbExtractorTests
             conn,
             "SELECT id, first_name, last_name, age FROM People"
         );
-        extractor.TotalCountQuery = _ => conn.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM People");
+        // Don't capture `conn` in the lambda — ReSharper's AccessToDisposedClosure
+        // flag is technically correct: the using-scope could outlive the closure.
+        // The test only needs to prove a custom TotalCountQuery's return value is
+        // surfaced through GetProgressReport().TotalItemCount, so return a constant.
+        extractor.TotalCountQuery = _ => Task.FromResult(3);
 
         await extractor.ExtractAsync().ToListAsync();
 


### PR DESCRIPTION
## Summary

First stacked PR of the InspectCode cleanup. The local test-drive on this repo (against PR #208's pending workflow) surfaced 82 warnings + 0 errors. Of those, **2 were actionable** — both fixed here:

### 1. `AccessToDisposedClosure` — DbExtractorTests.cs:351
`TotalCountQuery_using_custom_func_returns_custom_count` assigned `extractor.TotalCountQuery = _ => conn.ExecuteScalarAsync(...)` where `conn` is a `using var`. ReSharper correctly flags that the captured `conn` could outlive the closure across the using-scope.

The test only proves a custom `TotalCountQuery`'s return value surfaces through `GetProgressReport().TotalItemCount` — replaced the conn-capturing lambda with `Task.FromResult(3)` so the closure doesn't hold any disposable.

### 2. `S127` — DbLoader.cs:902 (`ExtractTemplateParamNames`)
The parameter-name scanner used a `for (var i; …; i++)` loop and then assigned `i = end - 1` inside the body to skip past the consumed param name. Sonar's S127 flags loop-counter mutation as a smell.

Restructured to a `while (i < template.Length)` with explicit `i++` / `i = end` advancement so the cursor mutation is the loop's normal stop-condition update, not a hidden body side effect. **Same behavior, no perf change** — covered by the existing multi-row INSERT tests.

## Test plan
- [x] `dotnet test` net10.0 — **219 pass** (unchanged).

## Stack
First PR. **Refs #202** (.DotSettings noise floor + fixture cleanups in follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)