### PR TITLE
fix: address remaining InspectCode code-quality findings (#202 follow-up)

### DIFF
--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/DbLoaderBatchSizeBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/DbLoaderBatchSizeBenchmarks.cs
@@ -103,7 +103,7 @@ public class DbLoaderBatchSizeBenchmarks : IDisposable
         }
 
         _disposed = true;
-        _conn?.Dispose();
+        _conn.Dispose();
     }
 
 

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
@@ -39,7 +39,7 @@ public class ExtractorBenchmarks : IDisposable
 
     public void Dispose()
     {
-        _connection?.Dispose();
+        _connection.Dispose();
     }
 
 

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
@@ -63,7 +63,7 @@ public class LoaderBenchmarks : IDisposable
 
     public void Dispose()
     {
-        _connection?.Dispose();
+        _connection.Dispose();
     }
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/ContractRecord.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/ContractRecord.cs
@@ -26,9 +26,12 @@ public class ContractRecord
 #if NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER
         return HashCode.Combine(Name, Value);
 #else
+        // Name is non-nullable per its declaration, so no null check needed —
+        // ReSharper's ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        // flagged the previous `Name != null` ternary as dead.
         unchecked
         {
-            return (Name != null ? StringComparer.Ordinal.GetHashCode(Name) : 0) * 397 ^ Value.GetHashCode();
+            return StringComparer.Ordinal.GetHashCode(Name) * 397 ^ Value.GetHashCode();
         }
 #endif
     }


### PR DESCRIPTION
## Summary

Second stacked PR. Four more genuine-signal findings, all in benchmarks or test fixtures:

### 1. `ConditionalAccessQualifierIsNonNullableAccordingToAPIContract` ×3
`benchmarks/.../{DbLoaderBatchSizeBenchmarks, ExtractorBenchmarks, LoaderBenchmarks}.cs` — `Dispose` methods called `_conn?.Dispose()` / `_connection?.Dispose()` on non-nullable fields. The `?.` is dead. Drop the operator.

### 2. `ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract` ×1
`tests/.../Tests.Unit/ContractRecord.cs:31` — the pre-netcoreapp2.1 `GetHashCode` fallback checked `Name != null`, but `Name` is declared non-nullable. Drop the ternary; identical hash on the existing TFM matrix.

## Deferred to M26 (the `.DotSettings` PR)

| Rule | Count | Why deferred |
|---|---:|---|
| `NonReadonlyMemberInGetHashCode` | 7 | `ContractRecord` + `ContractItem` fixtures intentionally use `{ get; set; }` for object-initializer ergonomics. Global suppression in the canonical `.DotSettings` (test-fixture exemption) is cleaner than 7 per-line attributes. |

## Status of the original 82 findings

- **PR #209 (M24)** — 2 real bugs fixed (`AccessToDisposedClosure`, `S127`)
- **This PR (M25)** — 4 code-quality cleanups fixed
- **M26 (next, `.DotSettings`)** — remaining 76 silenced as noise

## Test plan
- [x] 219 tests pass
- [x] Benchmarks Release build clean

## Stack
Base: `fix/inspectcode-real-bugs` (M24 → #209). **Refs #202**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)