### PR TITLE
ci: release.yaml integration-test gate — protected-files split for v0.5.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,11 +98,12 @@ jobs:
       - name: Run multi-framework tests with coverage
         shell: pwsh
         run: |
-          # Exclude *.Tests.Integration.* — those need Docker / Testcontainers,
-          # which the release runner doesn't provide. The integration matrix is
-          # exercised by pr.yaml's test-integration job (with proper services:
-          # blocks per RDBMS) on every PR, so release-time re-validation isn't
-          # adding signal. Match the per-language SDK extensions (cs / vb / fs).
+          # Exclude *.Tests.Integration.* from THIS Windows job — it runs the
+          # unit suite only. Integration tests need Testcontainers (Linux), and
+          # are gated by the dedicated test-integration matrix job below
+          # (publish-nuget needs:[…, test-integration-all]) so a release still
+          # can't ship if any provider's integration suite is red.
+          # Match the per-language SDK extensions (cs / vb / fs).
           $testProjects = Get-ChildItem -Path './tests' -Recurse -Include '*Test*.csproj', '*Test*.vbproj', '*Test*.fsproj' |
             Where-Object { $_.Name -notmatch '\.Tests\.Integration\.(cs|vb|fs)proj$' }
 
@@ -568,10 +569,102 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
-  # Publish to NuGet (only if validation passed)
+  # ============================================================================
+  # RDBMS INTEGRATION (release-time gate) — closes the gap flagged in #206.
+  # Mirrors pr.yaml's test-integration matrix but runs against the released
+  # tag's commit instead of a PR head. Testcontainers (Linux only) — sqlite
+  # included so a single matrix shape covers every supported provider.
+  # ============================================================================
+  test-integration:
+    name: "Integration / ${{ matrix.rdbms }} (${{ matrix.tfm }})"
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        rdbms: [sqlserver, postgres, mysql, mariadb, sqlite]
+        tfm: [net8.0, net10.0]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Locate integration project
+        id: locate
+        shell: bash
+        run: |
+          # Match all three project extensions so a future VB/F# rewrite is found.
+          proj=$(find ./tests -type f \
+            \( -name "*.Tests.Integration.csproj" \
+            -o -name "*.Tests.Integration.vbproj" \
+            -o -name "*.Tests.Integration.fsproj" \) \
+            | head -n1)
+          if [ -z "$proj" ]; then
+            echo "ℹ️  No integration project found — skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Integration project: $proj"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "project=$proj" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
+        if: steps.locate.outputs.found == 'true'
+        run: |
+          dotnet test "${{ steps.locate.outputs.project }}" \
+            --configuration Release \
+            --framework ${{ matrix.tfm }} \
+            --filter "Category=${{ matrix.rdbms }}" \
+            -p:TreatWarningsAsErrors=true \
+            --logger "console;verbosity=normal" \
+            --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
+            --results-directory "./TestResults-Integration"
+
+      - name: Upload integration test results
+        if: always() && steps.locate.outputs.found == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-integration-${{ matrix.rdbms }}-${{ matrix.tfm }}-trx
+          path: TestResults-Integration/
+
+  # ============================================================================
+  # INTEGRATION AGGREGATOR (release-time)
+  # Single stable job that rolls the matrix into one pass/fail signal — same
+  # pattern as pr.yaml's test-integration-all. publish-nuget needs THIS job,
+  # so the matrix can grow / change TFMs without re-wiring the publish gate.
+  # ============================================================================
+  test-integration-all:
+    name: "Integration (all)"
+    needs: test-integration
+    runs-on: ubuntu-latest
+    if: always()
+    env:
+      INTEGRATION_RESULT: ${{ needs.test-integration.result }}
+    steps:
+      - name: Check matrix result
+        run: |
+          echo "test-integration = $INTEGRATION_RESULT"
+          if [ "$INTEGRATION_RESULT" = "success" ]; then
+            echo "✅ Integration aggregator passes (all cells succeeded)"
+            exit 0
+          fi
+          echo "❌ Integration aggregator FAILS — release gate blocks the publish."
+          exit 1
+
+  # Publish to NuGet (only if validation + integration passed)
   publish-nuget:
     name: Publish to NuGet.org
-    needs: pack-and-validate
+    needs: [pack-and-validate, test-integration-all]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
## Why this PR exists

Splits the single protected-file diff out of PR #213 (`vNext -> main` for v0.5.0) so the release merge doesn't have to admin-bypass the entire vNext merge.

Per `feedback_admin_bypass_all_or_nothing.md`: admin "Bypass and merge" waives ALL ruleset rules at once. Splitting the protected file into its own one-file PR keeps the v0.5.0 release merge under normal review gates.

## Diff

This commit is the **release.yaml** changes from [#208](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/208) — carried verbatim from vNext to main:

- New `test-integration` matrix job (5 RDBMS × 2 TFMs = 10 cells) between `pack-and-validate` and `publish-nuget`
- New `test-integration-all` aggregator (stable-named single job rolling the matrix into one pass/fail signal)
- `publish-nuget` `needs:` now includes `test-integration-all` — release blocks on the matrix
- Misleading "release-time re-validation isn't adding signal" comment removed from the Windows unit-test step (release.yaml lines 100-107)

**No source / package / docs changes** — just the workflow file.

## Closes
- **#206** — release.yaml skips integration tests (when this lands; #208 already closed it on vNext)

## Merge plan

1. **Admin-bypass merge this PR to main** (the protected-files guard fires only because release.yaml is in the changed-files list, but the diff itself is identical to what already lives on vNext).
2. Merge main back into vNext (fast-forward of just this commit) — alternatively the next `vNext -> main` PR (#213) carries the same diff and will be a no-op for this file.
3. PR #213 becomes mergeable through the normal review path with no protected-files guard firing.

## Refs
- **#208** — original landing on vNext
- **#213** — the v0.5.0 release PR this unblocks
- **#206** — issue being closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)