### PR TITLE
ci: suppress VSTHRD200 on AsAsyncEnumerable adapter (#213)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -738,7 +738,15 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
     // Local IAsyncEnumerable adapter over a materialized List<T>. Used by the
     // chunked-commit path; avoiding the System.Linq.Async extension keeps the
     // src/ project dependency-free of that package.
+    //
+    // VSTHRD200: the rule wants methods returning "awaitable" types to end with
+    // "Async". IAsyncEnumerable<T> is NOT directly awaitable — callers use
+    // `await foreach`, not `await`. Renaming to `AsAsyncEnumerableAsync` would
+    // be double-"Async" noise and inconsistent with the BCL convention
+    // (`Enumerable.ToAsyncEnumerable`, `AsyncEnumerable.Create`, etc.).
+#pragma warning disable VSTHRD200
     private static async IAsyncEnumerable<TRecord> AsAsyncEnumerable(List<TRecord> source)
+#pragma warning restore VSTHRD200
     {
         foreach (var item in source)
         {


### PR DESCRIPTION
## Why

Stage 2 Windows on #213 surfaces **VSTHRD200** firing on the `AsAsyncEnumerable` adapter method introduced in #194 (BatchCommitSize). All 11 TFMs flagged.

The rule expects methods returning "awaitable" types to end with `Async` — but **`IAsyncEnumerable<T>` is NOT directly awaitable**. Callers use `await foreach`, not `await`. Renaming to `AsAsyncEnumerableAsync` would be:

- **Double-"Async" noise** (Async in both the type name and the method name)
- **Inconsistent with the BCL**: `Enumerable.ToAsyncEnumerable`, `AsyncEnumerable.Create`, `System.Linq.AsyncEnumerable.From*` — none have the suffix

## Fix

Narrow `#pragma warning disable VSTHRD200` around the method signature only, with the rationale documented inline:

```csharp
// VSTHRD200: IAsyncEnumerable<T> is NOT directly awaitable — callers use
// , not . BCL convention (Enumerable.ToAsyncEnumerable,
// AsyncEnumerable.Create) doesn't use the suffix either.
#pragma warning disable VSTHRD200
private static async IAsyncEnumerable<TRecord> AsAsyncEnumerable(List<TRecord> source)
#pragma warning restore VSTHRD200
```

This is more honest than either renaming away from the BCL convention or extending the project-level `.editorconfig` to silence the rule everywhere (it should still fire on `Task`/`ValueTask` returns that genuinely need the suffix).

## Test plan
- [x] `dotnet build src/Wolfgang.Etl.DbClient -c Release` — 0 warnings, 0 errors across all 11 TFMs.
- [ ] Stage 2 Windows on this PR (the exact configuration that failed #213).

## Refs
- **#213** — v0.5.0 release PR this unblocks
- **#194** — originally introduced the adapter (BatchCommitSize, M25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)