### PR TITLE
ci: NoWarn RS0016/RS0037 in Tests.Unit for source-generator output (#213)

### DIFF
--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -12,7 +12,13 @@
          is on GHSA-2m69-gcr7-jv3q with no patched version available yet. Same
          treatment as benchmarks/.../*.csproj and Tests.Integration. Test
          assembly is never published; impact limited to local + CI runs. -->
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903</NoWarn>
+    <!-- RS0016 / RS0037: PublicApiAnalyzers fires on members emitted by the
+         DbTableGenerator source generator into this test project (the
+         [DbTable]-decorated fixtures GeneratedPerson / GeneratedOrder gain
+         a public `Insert` const + `Bind` helper). This assembly is never
+         packaged — PublicAPI.txt contract doesn't apply. Same justification
+         as the SourceGenerator project's local .editorconfig. -->
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;RS0016;RS0037</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

Latest Stage 2 Windows failure on #213 (after #216 merged): `RS0016` + `RS0037` firing on **auto-generated members** emitted by the new `DbTableGenerator` into Tests.Unit's `obj/` folder. Failures specifically on net462/net47 TFMs.

The test fixtures `GeneratedPerson` / `GeneratedOrder` (decorated with `[DbTable]`) gain a public `Insert` const + `Bind` helper from the generator. `PublicApiAnalyzers` then wants those documented in a `PublicAPI.Shipped.txt` manifest.

**Tests.Unit is never packaged** — it ships nothing, has no external consumers. The PublicAPI manifest constraint is moot, same justification as the suppressions added to the SourceGenerator project's own `.editorconfig` in #215.

## Fix

Add `RS0016;RS0037` to the existing `<NoWarn>` list on the Tests.Unit csproj, with an inline comment.

```xml
<!-- RS0016 / RS0037: PublicApiAnalyzers fires on members emitted by the
     DbTableGenerator source generator into this test project (the
     [DbTable]-decorated fixtures GeneratedPerson / GeneratedOrder gain
     a public `Insert` const + `Bind` helper). This assembly is never
     packaged — PublicAPI.txt contract doesn't apply. -->
<NoWarn>;MA0004;S1144;S6966;NU1903;RS0016;RS0037</NoWarn>
```

## Test plan
- [x] Local net462 build: 0 warnings, 0 errors
- [ ] Stage 2 Windows on this PR (the exact configuration that failed #213)

## Refs
- **#213** — v0.5.0 release PR this unblocks
- **#215** — analogous fix on the SourceGenerator project's editorconfig (same root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)