### PR TITLE
ci: pass StringComparer.Ordinal to Dictionary ctor (#213, MA0002)

### DIFF
--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -731,7 +731,7 @@ public class DbExtractorTests
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 10);
 
-        var dictParams = new Dictionary<string, object> { ["@Age"] = 28 };
+        var dictParams = new Dictionary<string, object>(StringComparer.Ordinal) { ["@Age"] = 28 };
         var p = new DynamicParameters();
         p.Add("@Age", 22); // overrides the dictionary value
 


### PR DESCRIPTION
## Why

Latest Stage 2 Windows failure on #213 (after #217 cleared RS0016/RS0037): single error site, all 11 TFMs.

```
DbExtractorTests.cs:734  MA0002  Use an overload that has a
                                 IEqualityComparer<string> or
                                 IComparer<string> parameter
```

A `new Dictionary<string, object>` constructed without an explicit comparer — added in the output-parameter PR (#197) when testing the dictionary-precedence override. Meziantou's MA0002 fleet-wide enforcement flags it.

## Fix

Pass `StringComparer.Ordinal` to the ctor, matching the convention already used elsewhere in this same file (e.g. line 152's parameterized-query dictionary).

```diff
-var dictParams = new Dictionary<string, object> { ["@Age"] = 28 };
+var dictParams = new Dictionary<string, object>(StringComparer.Ordinal) { ["@Age"] = 28 };
```

**Behaviorally identical** — the test's expectation (`@Age` keyed by exact name `"@Age"`) is satisfied by both default and Ordinal comparers; this just makes the choice explicit per the analyzer's contract.

## Test plan
- [x] Local net462 build: 0 warnings, 0 errors

## Refs
- **#213** — v0.5.0 release PR this unblocks
- **#197** — originally introduced this test (output parameter support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)