### PR TITLE
fix: add SourceGenerator project to .slnx (v0.5.0 release recovery)

### DIFF
--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -48,6 +48,7 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj" />
+    <Project Path="src/Wolfgang.Etl.DbClient.SourceGenerator/Wolfgang.Etl.DbClient.SourceGenerator.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj" />


### PR DESCRIPTION
## Why

The v0.5.0 release run (run [28483571230](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/runs/28483571230)) **failed at Pack & Validate NuGet AND Build & Deploy Documentation with the same root cause:**

The `Wolfgang.Etl.DbClient.SourceGenerator` project was added to `src/` in #200 (O09) but **never added to the .slnx**. Solution-level `dotnet build` doesn't compile it, so its DLL is missing when downstream stages need it.

### Symptoms

**Pack:**
> `error: Could not find a part of the path 'src/Wolfgang.Etl.DbClient.SourceGenerator/bin/Release/netstandard2.0'` [from PackSourceGenerator MSBuild target trying to embed the analyzer]

**Docs:**
> `warning: FailedToResolveAnalyzer: SourceGenerator.dll … Try build with `dotnet build -c Release` before running docfx`
> Followed by CS0234 errors on `Microsoft.CodeAnalysis` types.

### Why it didn't surface earlier

The runtime csproj has `<ProjectReference OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />` to the source-gen. With `ReferenceOutputAssembly=false`, MSBuild does NOT transitively build it as part of the runtime's build. Solution-level builds only include projects IN the solution — and it wasn't. **PR CI didn't catch this** because pr.yaml runs `dotnet test` per-project (which triggers the ProjectReference chain), not `dotnet build` on the solution.

## Fix

One-line addition to `Wolfgang.Etl.DbClient.slnx` under the existing `/src/` folder.

## Verification (local)

- `dotnet build --configuration Release` — 0 warnings / 0 errors; `src/Wolfgang.Etl.DbClient.SourceGenerator/bin/Release/netstandard2.0/Wolfgang.Etl.DbClient.SourceGenerator.dll` now present.
- `dotnet pack src/Wolfgang.Etl.DbClient --no-build --configuration Release` — successfully creates `Wolfgang.Etl.DbClient.0.5.0.nupkg` + `.snupkg` with the analyzer embedded at `analyzers/dotnet/cs/`.

## Recovery plan

1. Merge this PR to main.
2. The failed v0.5.0 tag was already deleted via `gh release delete v0.5.0 --cleanup-tag`.
3. Re-create v0.5.0: `gh release create v0.5.0 --target main --title "v0.5.0 — robustness + extractor ergonomics + source generator" --notes-file /c/tmp/v050-notes.md`
4. release.yaml re-fires against the new main tip (with this fix).
5. Merge main back into vNext so this fix propagates forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)