### PR TITLE
fix: exclude SourceGenerator project from DocFX metadata (post-v0.5.0)

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -7,6 +7,9 @@
           "files": [
             "src/**/*.csproj"
           ],
+          "exclude": [
+            "src/Wolfgang.Etl.DbClient.SourceGenerator/**"
+          ],
           "src": "../"
         }
       ],


### PR DESCRIPTION
## Status of the v0.5.0 release

**NuGet publish: ✅ SHIPPED.** `Wolfgang.Etl.DbClient.0.5.0.nupkg` + `.snupkg` "Successfully published" per the [publish job log](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/runs/28485114939).

**Docs deploy: ❌ failed** on the same run with 20+ CS0234/CS0246 errors compiling the source-generator project inside DocFX.

## Why

`docfx.json`'s `metadata.src.files` glob `src/**/*.csproj` picks up the new `Wolfgang.Etl.DbClient.SourceGenerator` project. DocFX runs its own Roslyn compilation which doesn't restore/resolve the source-gen's `Microsoft.CodeAnalysis.CSharp` PackageReference the same way `dotnet build` does — every reference to `IIncrementalGenerator`, `GeneratorAttribute`, `LanguageNames`, `SourceProductionContext`, etc. is unresolvable, and DocFX exits non-zero.

**The source generator is internal analyzer machinery** — consumed via the Roslyn analyzer host (`analyzers/dotnet/cs/` in the NuGet payload), not a user-facing API surface. Its symbols shouldn't appear in the public API reference on the docs site anyway.

## Fix

One `exclude` entry in `docfx.json`:

```diff
 "src": [
   {
     "files": [
       "src/**/*.csproj"
     ],
+    "exclude": [
+      "src/Wolfgang.Etl.DbClient.SourceGenerator/**"
+    ],
     "src": "../"
   }
 ],
```

Runtime API docs (`DbExtractor`, `DbLoader`, `DbTableAttribute`, `DbColumnAttribute`, `RowFailedEventArgs`, etc.) live in `src/Wolfgang.Etl.DbClient/` and remain in scope.

## After merge

Docs will re-deploy on the next release event, OR can be manually re-triggered via `workflow_dispatch` on the docfx workflow. NuGet users are already unblocked — this PR only fixes the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)