### PR TITLE
ci: add ReSharper InspectCode job to pr.yaml (#202)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -268,6 +268,88 @@ jobs:
               - '.github/workflows/**'
 
   # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter).
+  #
+  # DbClient-specific: runs on `windows-latest` (not `ubuntu-latest` like the
+  # canonical repo-template version) because DbClient targets .NET Framework
+  # TFMs (net462/net472/net48/net481) which are Windows-only. Building on
+  # Linux would fail before inspectcode gets a chance to run.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: windows-latest
+    needs: detect-projects
+    if: needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        shell: bash
+        run: |
+          # Prefer .slnx (new format), fall back to .sln. Fail loudly if neither.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        shell: bash
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
+
+  # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
   test-linux-core:


### PR DESCRIPTION
## Summary

Adds a new `inspectcode` job to `.github/workflows/pr.yaml`, sourced from the canonical version in [`repo-template@main`](https://github.com/Chris-Wolfgang/repo-template/pull/427).

### What runs

- `JetBrains.ReSharper.GlobalTools` inspects the `.slnx` at repo root
- SARIF uploads to **GitHub Code Scanning** (Security tab + inline PR annotations)
- `error`-severity findings fail the job (`--severity=WARNING` filter surfaces warnings without gating)

Parallel with Stage 1 / 2 / 3 (no serial `needs:`), so wall-clock isn't extended (~3-5 min).

### DbClient-specific override

Runs on **`windows-latest`** rather than the canonical `ubuntu-latest`. DbClient's TFM matrix includes `net462`/`net472`/`net48`/`net481` which are .NET Framework — Windows-only. Linux build would fail before inspectcode had a chance to run.

## Additive-only

This PR **only adds the `inspectcode` job**. All existing DbClient-specific jobs are preserved verbatim:

- `detect-projects`, `detect-changes`
- `test-linux-core` (Stage 1) + coverage gate
- `test-integration` matrix (5 RDBMS × 2 TFMs)
- `test-integration-all` aggregator
- `test-windows` (Stage 2)
- `test-macos-core` (Stage 3)
- `security-scan`
- skipped-path stub jobs (`*-skipped`)

An **earlier version** of this PR was a full-file template-sync which inadvertently removed those customizations — [Copilot's review comment](#) flagged the regression correctly. This revision is force-pushed to be surgical.

## ⚠️ Protected-files note
Touches `.github/workflows/pr.yaml` → "Detect .NET Projects" guard fires. Admin-bypass merge is the expected path.

## Stack
- **This PR (A)** → `vNext`
- **#225 (B)** → stacked on A, adds solution-consistency guardrail

🤖 Generated with [Claude Code](https://claude.com/claude-code)