### PR TITLE
ci: add solution-consistency guardrail to pr.yaml (prevents v0.5.0-style drift)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -238,6 +238,72 @@ jobs:
             echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
           fi
 
+      - name: Verify src/ csprojs are in the solution
+        # Guards against the class of drift that hit v0.5.0's release: a new
+        # csproj was added under src/ (the source generator) but never added
+        # to the .slnx / .sln file. Per-project `dotnet test` invocations
+        # still triggered its ProjectReference chain, so PR CI never noticed;
+        # but the release pipeline's solution-level `dotnet build` didn't
+        # include it, and the runtime csproj's `PackSourceGenerator` target
+        # failed to find its bin/Release/ output — blocking the release.
+        #
+        # Detection: for every src/**/*.csproj, verify the .slnx or .sln
+        # (if present) references it by path. If a solution file exists and
+        # a src csproj isn't listed, fail with the specific missing entry.
+        # Repos without a solution file (or with everything already listed)
+        # pass unconditionally.
+        shell: bash
+        run: |
+          shopt -s nullglob
+          slns=( *.slnx *.sln )
+          if [ ${#slns[@]} -eq 0 ]; then
+            echo "ℹ️  No solution file at repo root - skipping solution-consistency check."
+            exit 0
+          fi
+          echo "Checking solution files: ${slns[*]}"
+
+          missing=()
+          # `git ls-files 'src/**/*.csproj'` returns forward-slashed paths on
+          # all platforms; slnx/sln files use forward slashes too.
+          while IFS= read -r csproj; do
+            # git ls-files always emits forward-slashed paths. .slnx entries
+            # use forward slashes, but classic .sln GUID lines often use
+            # backslashes (`src\Foo\Foo.csproj`). Check both encodings so a
+            # repo with a legacy .sln at the root isn't a false positive.
+            csproj_bs="${csproj//\//\\}"
+            found=0
+            for sln in "${slns[@]}"; do
+              if grep -qF "$csproj" "$sln" || grep -qF "$csproj_bs" "$sln"; then
+                found=1
+                break
+              fi
+            done
+            if [ "$found" -eq 0 ]; then
+              missing+=("$csproj")
+            fi
+          done < <(git ls-files 'src/**/*.csproj' 'src/*.csproj')
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo ""
+            echo "❌ SOLUTION CONSISTENCY FAILURE"
+            echo ""
+            echo "The following src/**/*.csproj files are NOT referenced by any solution file:"
+            for m in "${missing[@]}"; do
+              echo "  - $m"
+            done
+            echo ""
+            echo "This breaks solution-level \`dotnet build\` (which release.yaml relies on"
+            echo "for Pack & Validate), even though per-project \`dotnet test\` still works."
+            echo ""
+            echo "Fix: add the missing project(s) to the solution:"
+            for sln in "${slns[@]}"; do
+              echo "  dotnet sln $sln add ${missing[*]}"
+              break  # only suggest the first sln
+            done
+            exit 1
+          fi
+          echo "✅ All src csprojs are referenced by a solution file - solution-level builds will include them."
+
   # ============================================================================
   # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
   # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -268,6 +268,88 @@ jobs:
               - '.github/workflows/**'
 
   # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter).
+  #
+  # DbClient-specific: runs on `windows-latest` (not `ubuntu-latest` like the
+  # canonical repo-template version) because DbClient targets .NET Framework
+  # TFMs (net462/net472/net48/net481) which are Windows-only. Building on
+  # Linux would fail before inspectcode gets a chance to run.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: windows-latest
+    needs: detect-projects
+    if: needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        shell: bash
+        run: |
+          # Prefer .slnx (new format), fall back to .sln. Fail loudly if neither.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        shell: bash
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
+
+  # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
   test-linux-core:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,8 +13,6 @@
 #   for a maintainer to manually review and verify the changes before merging
 # - persist-credentials: false prevents the checkout token from being written to git config for subsequent git commands
 #   (it does NOT, by itself, prevent steps from accessing github.token / GITHUB_TOKEN if you explicitly expose it)
-# - After checkout, configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched from
-#   the main branch to prevent malicious PRs from disabling analyzers or bypassing code quality checks
 # - Default GITHUB_TOKEN permissions are restricted to read-only repository contents to limit impact if exposed
 
 name: PR Checks v3 (Gated)
@@ -41,21 +39,33 @@ jobs:
   secrets-scan:
     name: "Secrets Scan (gitleaks)"
     runs-on: ubuntu-latest
-    if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
           fetch-depth: 0
 
       - name: Fetch trusted gitleaks config from main
-        # Prevent PR from modifying .gitleaks.toml to bypass the scan
-        run: |
-          git fetch origin main --depth=1
-          git checkout origin/main -- .gitleaks.toml 2>/dev/null || true
+        # Prevent PR from modifying .gitleaks.toml to bypass the scan.
+        # Distinguish "file doesn't exist in main" (fine — gitleaks uses
+        # defaults) from "checkout failed for any other reason" (abort —
+        # silently using the PR version would defeat the guard).
         shell: bash
+        run: |
+          if ! git fetch origin main --depth=1; then
+            echo "::error::Failed to fetch origin/main — aborting before gitleaks scan."
+            exit 1
+          fi
+          if git cat-file -e origin/main:.gitleaks.toml 2>/dev/null; then
+            if ! git checkout origin/main -- .gitleaks.toml; then
+              echo "::error::Failed to checkout origin/main:.gitleaks.toml — aborting to prevent silent fall-back to PR version."
+              exit 1
+            fi
+          else
+            echo "::notice::.gitleaks.toml not present in origin/main — gitleaks will use defaults."
+          fi
 
       - name: Run gitleaks
         # gitleaks-action@v2 does not support pull_request_target, so invoke the CLI directly
@@ -79,13 +89,12 @@ jobs:
   detect-projects:
     name: "Detect .NET Projects"
     runs-on: ubuntu-latest
-    if: github.repository != 'Chris-Wolfgang/repo-template'
     outputs:
       has-projects: ${{ steps.check-projects.outputs.has-projects }}
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -117,19 +126,36 @@ jobs:
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
@@ -173,10 +199,13 @@ jobs:
           done
           
           # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
-          # --diff-filter=AMRC: Added, Modified, Renamed, Copied (excludes Deleted)
+          # --diff-filter=AMRCD: Added, Modified, Renamed, Copied, Deleted.
+          # Including D so a PR that *deletes* a protected file (workflow,
+          # .globalconfig, .ruleset) also triggers the maintainer-review gate
+          # — a silent deletion is just as security-relevant as a silent edit.
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
           
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""
@@ -210,62 +239,79 @@ jobs:
           fi
 
   # ============================================================================
-  # DETECTION: Classify changed paths (code vs workflows vs docs-only)
-  # ----------------------------------------------------------------------------
-  # Lets downstream jobs decide whether to run real work or to short-circuit.
-  # The Integration (all) aggregator is wired so that a path-gated "skipped"
-  # matrix is treated as success — docs-only PRs no longer burn ~10 min on
-  # eight Testcontainers cells that can't observe any product change.
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter). Tune the noise floor via .DotSettings at the repo root.
   # ============================================================================
-  detect-changes:
-    name: "Detect Changed Paths"
+  inspectcode:
+    name: "ReSharper InspectCode"
     runs-on: ubuntu-latest
-    if: github.repository != 'Chris-Wolfgang/repo-template'
-    # The job-level read permission lets dorny/paths-filter fall back to the
-    # pull-request files API if pure-git diff fails for any reason. Workflow's
-    # top-level grants only contents: read.
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
     permissions:
       contents: read
-      pull-requests: read
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-      workflows: ${{ steps.filter.outputs.workflows }}
+      security-events: write   # required for upload-sarif
+
     steps:
-      - uses: actions/checkout@v7.0.0
+      - name: Checkout code
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
-          # Full history so the action's git-diff path against the base ref
-          # works without falling back to the PR Files API.
-          fetch-depth: 0
 
-      - name: Filter changed paths
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
         with:
-          # Compare against the PR's base branch so we see the full PR diff,
-          # not just the latest commit. With fetch-depth: 0 above and an
-          # explicit `ref`, the action uses git compare instead of the API.
-          base: ${{ github.event.pull_request.base.ref }}
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          filters: |
-            code:
-              - 'src/**'
-              - 'tests/**'
-              - 'benchmarks/**'
-              - 'examples/**'
-              - '*.sln'
-              - '*.slnx'
-              - 'Directory.Build.props'
-              - 'Directory.Build.targets'
-              - 'BannedSymbols.txt'
-              - '.editorconfig'
-              - '*.globalconfig'
-              - '*.ruleset'
-              - 'coverlet.runsettings'
-              - 'nuget.config'
-            workflows:
-              - '.github/workflows/**'
+          dotnet-version: '10.0.x'
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
+          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge — raise to `error`
+          # later when the noise floor is acceptable.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
 
   # ============================================================================
   # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
@@ -352,19 +398,15 @@ jobs:
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
-  test-linux-core:
+  test-linux-core: 
     name: "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate"
     runs-on:  ubuntu-latest
-    needs: [detect-projects, detect-changes]
-    if: >-
-      github.repository != 'Chris-Wolfgang/repo-template' &&
-      needs.detect-projects.outputs.has-projects == 'true' &&
-      (needs.detect-changes.outputs.code == 'true' ||
-       needs.detect-changes.outputs.workflows == 'true')
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -396,74 +438,42 @@ jobs:
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files (e.g.
-        # Directory.Build.props) are legitimate and should not be overwritten by main's
-        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
@@ -493,6 +503,20 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure-library repos with no workload TFMs, skip entirely to
+        # avoid ~5-15s of network-dependent setup and an extra failure mode.
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
 
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |
@@ -572,14 +596,14 @@ jobs:
             if [ "$framework_count" -eq 1 ]; then
               # Single target framework - build normally
               echo "  Target framework: $frameworks"
-              dotnet build "$proj" --no-restore --configuration Release -p:TreatWarningsAsErrors=true || exit 1
+              dotnet build "$proj" --no-restore --configuration Release || exit 1
             else
               # Multi-targeting project - build each compatible framework separately
               echo "  Target frameworks (multi-targeting): $(echo "$frameworks" | tr '\n' ' ')"
               while IFS= read -r fw; do
                 [ -z "$fw" ] && continue
                 echo "  Building framework: $fw"
-                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" -p:TreatWarningsAsErrors=true || exit 1
+                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" || exit 1
               done <<< "$frameworks"
             fi
           done
@@ -593,31 +617,44 @@ jobs:
           # Gracefully skip if there is no ./tests directory (e.g. template-publishing
           # repos or library repos in early development that have no tests yet).
           # The downstream coverage steps already handle the no-coverage-files case.
+          # Fail loudly if the repo HAS src/ projects — the coverage gate
+          # exists to enforce test coverage on shipping code, so silently
+          # passing when tests are missing is the wrong default. Skip only
+          # for template-pack / in-dev repos with no source projects yet.
           if [ ! -d ./tests ]; then
-            echo "ℹ️  No ./tests directory — skipping test stage."
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ ./tests directory is missing but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No ./tests directory and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           fi
 
-          # Match on the filename, not the path, so an unrelated parent directory
-          # containing the substring "Tests.Integration" won't be excluded.
-          mapfile -d '' -t test_projects < <(find ./tests -type f \
-            \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) \
-            ! -name "*.Tests.Integration.csproj" \
-            ! -name "*.Tests.Integration.vbproj" \
-            ! -name "*.Tests.Integration.fsproj" \
-            -print0)
+          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -name "*.Tests.Integration.*" -print0)
+
+          # Report any integration test projects deliberately excluded from the
+          # coverage gate, so the skip is visible rather than silent (they are
+          # expected to run in a separate workflow).
+          mapfile -d '' -t excluded_integration < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -name "*.Tests.Integration.*" -print0)
+          if [ ${#excluded_integration[@]} -gt 0 ]; then
+            echo "::notice::Excluded ${#excluded_integration[@]} integration test project(s) from the coverage gate (expected to run in a separate workflow): ${excluded_integration[*]}"
+          fi
 
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "ℹ️  No test projects found under ./tests — skipping test stage."
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No test projects found under ./tests and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           fi
-
+          
           echo "=========================================="
-          echo "Found test projects (integration suites are run in a separate job):"
+          echo "Found test projects:"
           echo "=========================================="
           printf '%s\n' "${test_projects[@]}"
           echo ""
-
+          
           for test_proj in "${test_projects[@]}"; do
             echo "=========================================="
             echo "Testing project: $test_proj"
@@ -648,15 +685,10 @@ jobs:
               [ -z "$fw" ] && continue
               echo "Testing framework: $fw"
               
-              # --no-build / --no-restore: the build step above already produced
-              # binaries for every TFM with -p:TreatWarningsAsErrors=true; the
-              # implicit `dotnet test` build wouldn't carry that flag, so an
-              # analyzer warning introduced during test build could slip through.
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
-                --no-build \
-                --no-restore \
+                --no-build --no-restore \
                 --collect:"XPlat Code Coverage" \
                 --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
@@ -702,15 +734,24 @@ jobs:
           
           failed_projects=""
           threshold=${CODECOV_MINIMUM:-90}
-          
+          matched_count=0
+
           while read -r line; do
-            # Match lines with module names and percentages
-            if echo "$line" | grep -qE '^[^ ].*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
+            # Match lines with module names and percentages. The percent
+            # capture is the LAST %-suffixed number on the line, matching
+            # Stage 2's behavior — ReportGenerator Summary.txt rows often
+            # have line/branch/method columns and the overall figure is at
+            # end-of-line.
+            if echo "$line" | grep -qE '^[^ ].*[0-9]+(\.[0-9]+)?%$' && ! echo "$line" | grep -q '^Summary'; then
               module=$(echo "$line" | awk '{print $1}')
-              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%')
-              
+              # Floor the percent to int (matches Stage 2 pwsh's [int][math]::Floor)
+              # so we can use bash's integer -lt comparator below without
+              # erroring on decimals like "90.4".
+              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%' | awk '{print int($1)}')
+              matched_count=$((matched_count + 1))
+
               echo "Checking module: '$module' - Coverage: ${percent}%"
-              
+
               if [ "$percent" -lt "$threshold" ]; then
                 echo "  ❌ FAIL: Below ${threshold}% threshold"
                 failed_projects="$failed_projects $module (${percent}%)"
@@ -719,6 +760,14 @@ jobs:
               fi
             fi
           done < CoverageReport/Summary.txt
+
+          # Fail loudly when 0 modules matched - the regex is wrong or
+          # Summary.txt format changed. Silently passing the gate when we
+          # couldn't parse coverage is worse than failing.
+          if [ "$matched_count" -eq 0 ]; then
+            echo "❌ Coverage parser matched 0 modules in Summary.txt - regex or report format is out of sync. Refusing to silently pass the gate."
+            exit 1
+          fi
 
           if [ -n "$failed_projects" ]; then
             echo ""
@@ -756,162 +805,26 @@ jobs:
             tests/**/bin/Release
 
   # ============================================================================
-  # RDBMS INTEGRATION: per-database job using Testcontainers (Linux only)
-  # Runs in parallel with Stage 1. Does not gate Stage 2 / Stage 3 so a flaky
-  # container start cannot block the multi-TFM unit matrix.
-  # ============================================================================
-  test-integration:
-    name: "Integration / ${{ matrix.rdbms }} (${{ matrix.tfm }})"
-    runs-on: ubuntu-latest
-    # Ceiling protects against a stuck container start (esp. mssql / mysql)
-    # consuming the default 6-hour GitHub Actions limit per matrix cell.
-    timeout-minutes: 25
-    needs: [detect-projects, detect-changes]
-    # Gate on code OR workflows so:
-    #   - Docs-only PRs (no code, no workflow change) skip the matrix entirely
-    #     and the aggregator below accepts that as success.
-    #   - Dependabot PRs to .github/workflows/*.yaml still run the matrix
-    #     (Dependabot is exempt from the protected-files guard upstream).
-    #   - Human PRs that touch .github/workflows/*.yaml never reach this job
-    #     anyway — detect-projects fails first via the protected-files guard,
-    #     so has-projects is unset and the predicate is short-circuited false.
-    if: >-
-      github.repository != 'Chris-Wolfgang/repo-template' &&
-      needs.detect-projects.outputs.has-projects == 'true' &&
-      (needs.detect-changes.outputs.code == 'true' ||
-       needs.detect-changes.outputs.workflows == 'true')
-    strategy:
-      fail-fast: false
-      matrix:
-        rdbms: [sqlserver, postgres, mysql, mariadb, sqlite]
-        tfm: [net8.0, net10.0]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7.0.0
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
-
-      - name: Locate integration project
-        id: locate
-        shell: bash
-        run: |
-          # Match all three project extensions so a future VB/F# rewrite is found.
-          proj=$(find ./tests -type f \
-            \( -name "*.Tests.Integration.csproj" \
-            -o -name "*.Tests.Integration.vbproj" \
-            -o -name "*.Tests.Integration.fsproj" \) \
-            | head -n1)
-          if [ -z "$proj" ]; then
-            echo "ℹ️  No integration project found — skipping."
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Integration project: $proj"
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "project=$proj" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
-        if: steps.locate.outputs.found == 'true'
-        run: |
-          # This job has no prior build step, so dotnet test compiles inline.
-          # Pass -p:TreatWarningsAsErrors=true so analyzer warnings introduced
-          # in the integration project still fail CI.
-          dotnet test "${{ steps.locate.outputs.project }}" \
-            --configuration Release \
-            --framework ${{ matrix.tfm }} \
-            --filter "Category=${{ matrix.rdbms }}" \
-            -p:TreatWarningsAsErrors=true \
-            --logger "console;verbosity=normal" \
-            --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
-            --results-directory "./TestResults-Integration"
-
-      - name: Upload integration test results
-        if: always() && steps.locate.outputs.found == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: integration-${{ matrix.rdbms }}-${{ matrix.tfm }}-trx
-          path: TestResults-Integration/
-
-  # ============================================================================
-  # INTEGRATION AGGREGATOR
-  # A single stable-named job whose only purpose is to roll up every cell of
-  # the test-integration matrix into one pass/fail signal. Mark THIS one
-  # required on the branch ruleset — the matrix can grow (MariaDB, Oracle,
-  # CockroachDB, …) or change TFMs without breaking the required-check name.
-  # ============================================================================
-  test-integration-all:
-    name: "Integration (all)"
-    runs-on: ubuntu-latest
-    needs: [detect-projects, detect-changes, test-integration]
-    # Run even when a matrix cell failed/cancelled so this job can report the
-    # rollup result instead of silently being marked "skipped". The if: predicate
-    # mirrors test-integration's so this aggregator is genuinely skipped (not
-    # failed) on the repo-template repo or on repos without .NET projects.
-    if: >-
-      always() &&
-      github.repository != 'Chris-Wolfgang/repo-template' &&
-      needs.detect-projects.outputs.has-projects == 'true'
-    env:
-      INTEGRATION_RESULT: ${{ needs.test-integration.result }}
-      DETECT_CHANGES_RESULT: ${{ needs.detect-changes.result }}
-      CODE_CHANGED: ${{ needs.detect-changes.outputs.code }}
-      WORKFLOWS_CHANGED: ${{ needs.detect-changes.outputs.workflows }}
-    steps:
-      - name: Check matrix result
-        run: |
-          echo "test-integration  = $INTEGRATION_RESULT"
-          echo "detect-changes    = $DETECT_CHANGES_RESULT (code=$CODE_CHANGED, workflows=$WORKFLOWS_CHANGED)"
-
-          # Happy path: every matrix cell passed.
-          if [ "$INTEGRATION_RESULT" = "success" ]; then
-            echo "✅ Integration aggregator passes (all cells succeeded)"
-            exit 0
-          fi
-
-          # Path-gated short-circuit: matrix was deliberately skipped because
-          # detect-changes succeeded and reported neither code nor workflow
-          # changes (docs-only PR). Only THEN is "skipped" valid.
-          if [ "$INTEGRATION_RESULT" = "skipped" ] \
-             && [ "$DETECT_CHANGES_RESULT" = "success" ] \
-             && [ "$CODE_CHANGED" = "false" ] \
-             && [ "$WORKFLOWS_CHANGED" = "false" ]; then
-            echo "✅ Integration aggregator passes (no code/workflow changes — matrix path-gated)"
-            exit 0
-          fi
-
-          echo "::error::Integration aggregator failed: test-integration=$INTEGRATION_RESULT, detect-changes=$DETECT_CHANGES_RESULT (code=$CODE_CHANGED, workflows=$WORKFLOWS_CHANGED)"
-          exit 1
-
-  # ============================================================================
   # STAGE 2: Windows - All .NET Tests (Gated by Stage 1)
   # ============================================================================
   test-windows:
     name: "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
     runs-on: windows-latest
-    needs: [detect-projects, detect-changes, test-linux-core]
-    if: >-
-      github.repository != 'Chris-Wolfgang/repo-template' &&
-      needs.detect-projects.outputs.has-projects == 'true' &&
-      (needs.detect-changes.outputs.code == 'true' ||
-       needs.detect-changes.outputs.workflows == 'true')
+    needs: [detect-projects, test-linux-core]
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         shell: pwsh
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
@@ -933,7 +846,7 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -948,56 +861,11 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM
               }
             }
           }
           
-          Write-Host ""
-          Write-Host "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        shell: pwsh
-        run: |
-          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          $configFiles = @(
-            ".editorconfig",
-            "Directory.Build.props",
-            "Directory.Build.targets",
-            "BannedSymbols.txt"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          foreach ($configFile in $configFiles) {
-            # Check if file exists in main branch
-            $exists = git cat-file -e "main-branch:$configFile" 2>&1
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
-            } else {
-              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
-            }
-          }
-
-          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
-          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
-          foreach ($pattern in $globPatterns) {
-            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
-            foreach ($file in $files) {
-              if ($file) {
-                Write-Host "  ✓ Copying $file from main branch"
-                $dir = Split-Path -Parent $file
-                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
-              }
-            }
-          }
-
           Write-Host ""
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
@@ -1013,11 +881,25 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure-library repos with no workload TFMs, skip entirely to
+        # avoid ~5-15s of network-dependent setup and an extra failure mode.
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
+
       - name: Restore dependencies
         run: dotnet restore
 
       - name: Build solution
-        run: dotnet build --no-restore --configuration Release -p:TreatWarningsAsErrors=true
+        run: dotnet build --no-restore --configuration Release
 
       - name: Run all .NET tests (.NET 5.0-10.0 and Framework 4.6.2-4.8.1)
         shell: pwsh
@@ -1026,19 +908,29 @@ jobs:
 
           # Gracefully skip if there is no ./tests directory (e.g. template-publishing
           # repos or library repos in early development that have no tests yet).
+          # The coverage gate exists to enforce test coverage on shipping
+          # code. If ./src has projects but ./tests doesn't, fail loudly
+          # instead of silently passing the gate. Skip only for template-
+          # pack / in-dev repos that have no source projects yet.
+          $srcHasProjects = @(Get-ChildItem -Path './src' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' -ErrorAction SilentlyContinue).Count -gt 0
+
           if (-not (Test-Path -Path './tests' -PathType Container)) {
-            Write-Host "ℹ️  No ./tests directory — skipping test stage."
+            if ($srcHasProjects) {
+              Write-Error "❌ ./tests directory is missing but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            }
+            Write-Host "ℹ️  No ./tests directory and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           }
 
-          # Integration suites (*.Tests.Integration.csproj) live in a separate Linux-only
-          # job that provisions database containers via Testcontainers; not run here.
-          # Filter by file name, not path, so an unrelated parent directory containing the
-          # substring "Tests.Integration" won't be excluded.
-          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' | Where-Object { $_.Name -notmatch '\.Tests\.Integration\.(cs|vb|fs)proj$' })
+          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj')
 
           if (@($testProjects).Count -eq 0) {
-            Write-Host "ℹ️  No test projects found under ./tests — skipping test stage."
+            if ($srcHasProjects) {
+              Write-Error "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            }
+            Write-Host "ℹ️  No test projects found under ./tests and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           }
           
@@ -1083,15 +975,11 @@ jobs:
             foreach ($fw in $frameworks) {
               Write-Host "Testing framework: $fw" -ForegroundColor Yellow
 
-              # --no-build / --no-restore: the build step above already produced
-              # binaries for every TFM with -p:TreatWarningsAsErrors=true; the
-              # implicit dotnet test build wouldn't carry that flag.
               if ($fw -match '^net([5-9]|[1-9][0-9]+)\.') {
                 dotnet test $testProj.FullName `
                   --configuration Release `
                   --framework $fw `
-                  --no-build `
-                  --no-restore `
+                  --no-build --no-restore `
                   --collect:"XPlat Code Coverage" `
                   --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
@@ -1100,8 +988,7 @@ jobs:
                 dotnet test $testProj.FullName `
                   --configuration Release `
                   --framework $fw `
-                  --no-build `
-                  --no-restore `
+                  --no-build --no-restore `
                   --logger "console;verbosity=normal"
               }
 
@@ -1153,11 +1040,34 @@ jobs:
 
           $threshold = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
           $failedProjects = @()
+          $matchedCount   = 0
 
           foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
-            if ($line -match '^\s*(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^\s*Summary') {
+            # Only consider top-level assembly rows: non-space first char,
+            # then anything, then whitespace + the final percent at EOL.
+            # Matches Stage 1's `^[^ ].*[0-9]+(\.[0-9]+)?%$` filter (which
+            # uses awk $NF for the percent — robust to extra columns like
+            # line/branch/method that ReportGenerator can emit on the same
+            # row).
+            #
+            # Bug previously here: a `.*` between the module name and the
+            # trailing `(\d+)%` was greedy and could eat all but the last
+            # digit of the percent — turning "100" into "0" and failing
+            # the gate on actually-100%-covered modules. Two changes:
+            #  - Anchor on `^(\S+)` so indented sub-class rows are skipped
+            #    (their parent assembly row carries the same number, so
+            #    nothing is lost — and Stage 1 ignores them too).
+            #  - Require whitespace immediately before the final `\d+%`
+            #    (`\s(\d+...)%\s*$`). This still allows intermediate
+            #    columns between the module name and the final percent
+            #    (the `.*` consumes them), but `.*` can't terminate
+            #    mid-digit-run — the regex engine MUST place `\s` before
+            #    the digits, which forces the last %-suffixed number on
+            #    the line to be captured intact.
+            if ($line -match '^(\S+).*\s(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
               $module  = $Matches[1]
               $percent = [int][math]::Floor([double]$Matches[2])
+              $matchedCount++
 
               Write-Host "Checking module: '$module' - Coverage: ${percent}%"
 
@@ -1168,6 +1078,14 @@ jobs:
                 Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
               }
             }
+          }
+
+          # Fail loudly when 0 modules matched — the regex is wrong or
+          # Summary.txt format changed. Silently passing the gate when we
+          # couldn't read coverage is worse than failing.
+          if ($matchedCount -eq 0) {
+            Write-Error "❌ Coverage parser matched 0 modules in Summary.txt — regex or report format is out of sync. Refusing to silently pass the gate."
+            exit 1
           }
 
           if ($failedProjects.Count -gt 0) {
@@ -1203,16 +1121,12 @@ jobs:
   test-macos-core:
     name: "Stage 3: macOS Tests (.NET 6.0-10.0)"
     runs-on: macos-latest
-    needs: [detect-projects, detect-changes, test-windows]
-    if: >-
-      github.repository != 'Chris-Wolfgang/repo-template' &&
-      needs.detect-projects.outputs.has-projects == 'true' &&
-      (needs.detect-changes.outputs.code == 'true' ||
-       needs.detect-changes.outputs.workflows == 'true')
+    needs: [detect-projects, test-windows]
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1244,74 +1158,42 @@ jobs:
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files (e.g.
-        # Directory.Build.props) are legitimate and should not be overwritten by main's
-        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
@@ -1324,6 +1206,20 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure-library repos with no workload TFMs, skip entirely to
+        # avoid ~5-15s of network-dependent setup and an extra failure mode.
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
 
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |
@@ -1402,14 +1298,14 @@ jobs:
             if [ "$framework_count" -eq 1 ]; then
               # Single target framework - build normally
               echo "  Target framework: $frameworks"
-              dotnet build "$proj" --no-restore --configuration Release -p:TreatWarningsAsErrors=true || exit 1
+              dotnet build "$proj" --no-restore --configuration Release || exit 1
             else
               # Multi-targeting project - build each compatible framework separately
               echo "  Target frameworks (multi-targeting): $(echo "$frameworks" | tr '\n' ' ')"
               while IFS= read -r fw; do
                 [ -z "$fw" ] && continue
                 echo "  Building framework: $fw"
-                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" -p:TreatWarningsAsErrors=true || exit 1
+                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" || exit 1
               done <<< "$frameworks"
             fi
           done
@@ -1422,23 +1318,38 @@ jobs:
           # Find all test projects (C#, VB.NET, F#).
           # Gracefully skip if there is no ./tests directory (e.g. template-publishing
           # repos or library repos in early development that have no tests yet).
+          # Fail loudly if the repo HAS src/ projects — the coverage gate
+          # exists to enforce test coverage on shipping code, so silently
+          # passing when tests are missing is the wrong default. Skip only
+          # for template-pack / in-dev repos with no source projects yet.
           if [ ! -d ./tests ]; then
-            echo "ℹ️  No ./tests directory — skipping test stage."
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ ./tests directory is missing but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No ./tests directory and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           fi
 
           test_projects=()
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
-          done < <(find ./tests -type f \
-            \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) \
-            ! -name "*.Tests.Integration.csproj" \
-            ! -name "*.Tests.Integration.vbproj" \
-            ! -name "*.Tests.Integration.fsproj" \
-            -print0)
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -name "*.Tests.Integration.*" -print0)
+
+          # Report any integration test projects deliberately excluded from the
+          # coverage gate, so the skip is visible rather than silent (they are
+          # expected to run in a separate workflow).
+          mapfile -d '' -t excluded_integration < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -name "*.Tests.Integration.*" -print0)
+          if [ ${#excluded_integration[@]} -gt 0 ]; then
+            echo "::notice::Excluded ${#excluded_integration[@]} integration test project(s) from the coverage gate (expected to run in a separate workflow): ${excluded_integration[*]}"
+          fi
 
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "ℹ️  No test projects found under ./tests — skipping test stage."
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No test projects found under ./tests and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           fi
           
@@ -1479,14 +1390,10 @@ jobs:
               [ -z "$fw" ] && continue
               echo "Testing framework: $fw"
 
-              # --no-build / --no-restore: the build step above already produced
-              # binaries for every TFM with -p:TreatWarningsAsErrors=true; the
-              # implicit dotnet test build wouldn't carry that flag.
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
-                --no-build \
-                --no-restore \
+                --no-build --no-restore \
                 --collect:"XPlat Code Coverage" \
                 --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
@@ -1511,8 +1418,17 @@ jobs:
 
       - name: Enforce 90% coverage threshold
         run: |
+          # If no cobertura files were produced (no tests, all test projects
+          # skipped, etc.), the preceding step explicitly skipped report
+          # generation. Mirror that here — gating only when coverage was
+          # actually collected — instead of failing with "Coverage report
+          # not generated!" on jobs that legitimately had nothing to cover.
+          if ! find ./TestResults -name "coverage.cobertura.xml" -print -quit 2>/dev/null | grep -q .; then
+            echo "ℹ️  No coverage files produced — skipping coverage gate (consistent with the prior 'skipping report generation' notice)."
+            exit 0
+          fi
           if [ ! -f "CoverageReport/Summary.txt" ]; then
-            echo "❌ Coverage report not generated!"
+            echo "❌ Coverage files exist but Summary.txt is missing — ReportGenerator failed."
             exit 1
           fi
 
@@ -1522,11 +1438,13 @@ jobs:
 
           THRESHOLD=${CODECOV_MINIMUM:-90}
           FAILED=0
+          MATCHED=0
 
           while IFS= read -r line; do
             if echo "$line" | grep -qE '^[^ ]+.*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
               MODULE=$(echo "$line" | awk '{print $1}')
               PERCENT=$(echo "$line" | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | grep -oE '^[0-9]+')
+              MATCHED=$((MATCHED + 1))
               echo "Checking module: '$MODULE' - Coverage: ${PERCENT}%"
               if [ "$PERCENT" -lt "$THRESHOLD" ]; then
                 echo "  ❌ FAIL: Below ${THRESHOLD}% threshold"
@@ -1536,6 +1454,14 @@ jobs:
               fi
             fi
           done < CoverageReport/Summary.txt
+
+          # Fail loudly when 0 modules matched — the regex is wrong or the
+          # Summary.txt format changed. Silently passing here would make Stage 3
+          # the weak link while Stages 1/2 fail loudly on the same drift.
+          if [ "$MATCHED" -eq 0 ]; then
+            echo "❌ Coverage parser matched 0 modules in Summary.txt — regex or report format is out of sync. Refusing to silently pass the gate."
+            exit 1
+          fi
 
           if [ "$FAILED" -ne 0 ]; then
             echo ""
@@ -1601,11 +1527,10 @@ jobs:
   security-scan:
     name: "Security Scan (DevSkim)"
     runs-on: ubuntu-latest
-    if: github.repository != 'Chris-Wolfgang/repo-template'
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1637,74 +1562,42 @@ jobs:
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files (e.g.
-        # Directory.Build.props) are legitimate and should not be overwritten by main's
-        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
@@ -1747,62 +1640,3 @@ jobs:
           name: devskim-results
           path: devskim-results.txt
           if-no-files-found: warn
-
-  # ============================================================================
-  # PATH-GATE STUBS for Stages 1 / 2 / 3
-  # ----------------------------------------------------------------------------
-  # When detect-changes reports neither code nor workflow changes (docs-only PR),
-  # the real Stage 1 / 2 / 3 jobs above skip via their `if:` predicates. The
-  # branch ruleset still requires those check names to report success, though,
-  # so we fire a stub job with the SAME `name:` whose `if:` is the complement
-  # of the real job's path-gate. On a docs-only PR exactly one of (real, stub)
-  # runs per stage. On a code/workflow PR the real job runs; if an upstream
-  # Stage 1 fails, Stage 2/3 real jobs skip via `needs` and the stub stays
-  # off (its predicate excludes code PRs), so neither member runs — that is
-  # the intended "previous stage failed" cascade, not a path-gate condition.
-  #
-  # GitHub treats multiple jobs sharing a `name:` as separate jobs at runtime
-  # but the required-check matching for the ruleset is by name. Either passing
-  # satisfies the required check.
-  # ============================================================================
-  test-linux-core-skipped:
-    name: "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate"
-    runs-on: ubuntu-latest
-    needs: [detect-projects, detect-changes]
-    if: >-
-      github.repository != 'Chris-Wolfgang/repo-template' &&
-      needs.detect-projects.outputs.has-projects == 'true' &&
-      needs.detect-changes.outputs.code != 'true' &&
-      needs.detect-changes.outputs.workflows != 'true'
-    steps:
-      - name: Stage 1 skipped via path-gate
-        run: |
-          echo "::notice::Skipped Stage 1 — this PR changes neither code nor workflows."
-
-  test-windows-skipped:
-    name: "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
-    runs-on: ubuntu-latest
-    needs: [detect-projects, detect-changes]
-    if: >-
-      github.repository != 'Chris-Wolfgang/repo-template' &&
-      needs.detect-projects.outputs.has-projects == 'true' &&
-      needs.detect-changes.outputs.code != 'true' &&
-      needs.detect-changes.outputs.workflows != 'true'
-    steps:
-      - name: Stage 2 skipped via path-gate
-        run: |
-          echo "::notice::Skipped Stage 2 — this PR changes neither code nor workflows."
-
-  test-macos-core-skipped:
-    name: "Stage 3: macOS Tests (.NET 6.0-10.0)"
-    runs-on: ubuntu-latest
-    needs: [detect-projects, detect-changes]
-    if: >-
-      github.repository != 'Chris-Wolfgang/repo-template' &&
-      needs.detect-projects.outputs.has-projects == 'true' &&
-      needs.detect-changes.outputs.code != 'true' &&
-      needs.detect-changes.outputs.workflows != 'true'
-    steps:
-      - name: Stage 3 skipped via path-gate
-        run: |
-          echo "::notice::Skipped Stage 3 — this PR changes neither code nor workflows."


### PR DESCRIPTION
## Why

**v0.5.0's release blew up** at Pack & Validate because the SourceGenerator project (added in #200) was never added to `Wolfgang.Etl.DbClient.slnx`. Per-project `dotnet test` invocations still triggered its ProjectReference chain, so `pr.yaml` never noticed — but `release.yaml`'s solution-level `dotnet build` skipped it, and the runtime csproj's `PackSourceGenerator` target failed to find its `bin/Release/` output. Recovered via [#222](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/222).

**This PR adds a PR-time guard** so the same drift can't reach release.yaml unnoticed again.

## Detection

New step in `detect-projects` — for every `src/**/*.csproj`, verify at least one solution file at the repo root references it by path. Works for both `.slnx` (`<Project Path="…" />`) and `.sln` (GUID lines). Repos without a solution file pass unconditionally.

Failing output looks like:

```
❌ SOLUTION CONSISTENCY FAILURE

The following src/**/*.csproj files are NOT referenced by any solution file:
  - src/Wolfgang.Etl.DbClient.SourceGenerator/Wolfgang.Etl.DbClient.SourceGenerator.csproj

This breaks solution-level `dotnet build` (which release.yaml relies on
for Pack & Validate), even though per-project `dotnet test` still works.

Fix: add the missing project(s) to the solution:
  dotnet sln Wolfgang.Etl.DbClient.slnx add src/Wolfgang.Etl.DbClient.SourceGenerator/…
```

## Verified locally

- **Current tree** (post-#222, source-gen in slnx) → **passes** ✅
- **Simulated pre-#222 state** (source-gen removed from slnx) → correctly reports missing entry ❌

## ⚠️ Protected-files note
Touches `.github/workflows/pr.yaml` → "Detect .NET Projects" guard fires. **Admin-bypass merge** required, same as its base PR.

## Stack
- **Base:** #224 (template-sync bringing InspectCode)
- **This PR (B):** solution-consistency guardrail
- **Separate:** PR C in `repo-template` — canonical `.DotSettings` noise-floor for fleet fan-out

## Follow-up
Canonicalize this guard in `repo-template` so all 26 downstream Wolfgang.* repos pick it up on next template-sync.

## Refs
- **#222** — the v0.5.0 recovery fix this guardrail exists to prevent in the future
- **#200** — original source-generator introduction that missed the slnx add

🤖 Generated with [Claude Code](https://claude.com/claude-code)