### PR TITLE
ci: add ReSharper InspectCode job to pr.yaml (#202) [re-land]

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -268,6 +268,88 @@ jobs:
               - '.github/workflows/**'
 
   # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter).
+  #
+  # DbClient-specific: runs on `windows-latest` (not `ubuntu-latest` like the
+  # canonical repo-template version) because DbClient targets .NET Framework
+  # TFMs (net462/net472/net48/net481) which are Windows-only. Building on
+  # Linux would fail before inspectcode gets a chance to run.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: windows-latest
+    needs: detect-projects
+    if: needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        shell: bash
+        run: |
+          # Prefer .slnx (new format), fall back to .sln. Fail loudly if neither.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        shell: bash
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
+
+  # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
   test-linux-core:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -293,10 +293,54 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
+
+      # Rehydrate trusted config from main so a PR can't loosen
+      # analyzer rules and then get a clean InspectCode pass. Same
+      # threat model + Dependabot exemption as the test jobs above.
+      - name: Fetch trusted configuration files from main branch
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        shell: pwsh
+        run: |
+          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
+
+          git fetch origin main:main-branch
+
+          $configFiles = @(
+            ".editorconfig",
+            "Directory.Build.props",
+            "Directory.Build.targets",
+            "BannedSymbols.txt"
+          )
+
+          foreach ($configFile in $configFiles) {
+            git cat-file -e "main-branch:$configFile" 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "  ✓ Copying $configFile from main branch"
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
+            } else {
+              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
+            }
+          }
+
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
+          foreach ($pattern in $globPatterns) {
+            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
+            foreach ($file in $files) {
+              if ($file) {
+                Write-Host "  ✓ Copying $file from main branch"
+                $dir = Split-Path -Parent $file
+                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
+              }
+            }
+          }
+
+          Write-Host ""
+          Write-Host "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -313,24 +357,29 @@ jobs:
       - name: Install JetBrains.ReSharper.GlobalTools
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
 
+      # Everything below stays in pwsh so `jb` (dotnet global tool)
+      # is on PATH via the pwsh session that installed it, and we
+      # avoid depending on `jq` being present in Git Bash on
+      # windows-latest.
       - name: Run InspectCode
-        shell: bash
+        shell: pwsh
         run: |
           # Prefer .slnx (new format), fall back to .sln. Fail loudly if neither.
-          SLN=$(ls *.slnx 2>/dev/null | head -n1)
-          if [ -z "$SLN" ]; then
-            SLN=$(ls *.sln 2>/dev/null | head -n1)
-          fi
-          if [ -z "$SLN" ]; then
-            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+          $sln = (Get-ChildItem -Filter '*.slnx' -File | Select-Object -First 1).Name
+          if (-not $sln) {
+            $sln = (Get-ChildItem -Filter '*.sln' -File | Select-Object -First 1).Name
+          }
+          if (-not $sln) {
+            Write-Host "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
             exit 1
-          fi
-          echo "Inspecting: $SLN"
-          jb inspectcode "$SLN" \
-            --output=inspect.sarif \
-            --format=sarif \
-            --severity=WARNING \
+          }
+          Write-Host "Inspecting: $sln"
+          jb inspectcode $sln `
+            --output=inspect.sarif `
+            --format=sarif `
+            --severity=WARNING `
             --no-build
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload SARIF to Code Scanning
         uses: github/codeql-action/upload-sarif@v3
@@ -338,16 +387,18 @@ jobs:
           sarif_file: inspect.sarif
 
       - name: Gate on error-severity findings
-        shell: bash
+        shell: pwsh
         run: |
           # SARIF level=error fails the job; warnings still upload (visible in
           # Security → Code scanning) but don't gate merge.
-          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
-          if [ "$count" -gt 0 ]; then
-            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+          $sarif = Get-Content -Raw -Path inspect.sarif | ConvertFrom-Json
+          $errors = @($sarif.runs | ForEach-Object { $_.results } | Where-Object { $_.level -eq 'error' })
+          $count = $errors.Count
+          if ($count -gt 0) {
+            Write-Host "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
             exit 1
-          fi
-          echo "✅ No error-severity InspectCode findings."
+          }
+          Write-Host "✅ No error-severity InspectCode findings."
 
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate


### PR DESCRIPTION
Re-lands PR #224 against the fresh vNext (the previous vNext was deleted after v0.6.0 released without merging these changes to main).

Adds a new `inspectcode` job to .github/workflows/pr.yaml sourced from the canonical version in Chris-Wolfgang/repo-template@main. Runs concurrently with Stage 1/2/3 (no `needs:` on a test job) so it doesn't extend wall-clock — typically 3–5 min vs the slowest stage.

- SARIF uploads to GitHub Code Scanning (Security tab + inline PR annotations).
- `error`-severity findings fail the job; `warning`-severity surfaces in Code Scanning but doesn't gate merge.
- JetBrains.ReSharper.GlobalTools 2026.1 (installed inline).

**DbClient-specific override**: runs on `windows-latest` rather than the canonical `ubuntu-latest`. DbClient's TFM matrix includes net462/net472/net48/net481 which are .NET Framework and Windows-only.

Additive change — this PR ONLY adds the inspectcode job. All existing jobs are preserved verbatim.

Note: pr.yaml is a protected file. Admin-bypass merge is the expected path per `feedback_protected_config_files_guard.md`.

Closes #202.

Originally #224 (merged into old vNext 2026-07-02, lost when vNext was deleted post-v0.6.0).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>