### PR TITLE
docs(adr): scaffold docs/adr/ with template + index + ADR-0001 (#150)

### DIFF
--- a/docs/adr/0001-source-generator-ships-in-runtime-nuget.md
+++ b/docs/adr/0001-source-generator-ships-in-runtime-nuget.md
@@ -1,0 +1,45 @@
+# ADR-0001: Source generator ships in the runtime NuGet, not as a separate package
+
+- **Status**: Accepted
+- **Date**: 2026-07-01
+- **Deciders**: @Chris-Wolfgang
+- **Tags**: `packaging`, `source-generators`
+
+## Context
+
+v0.5.0 introduced `Wolfgang.Etl.DbClient.SourceGenerator` — an `IIncrementalGenerator` targeting `netstandard2.0` that emits per-`[DbTable]` `Insert` constants and `Bind(DynamicParameters, T)` helpers. Two packaging options were on the table:
+
+1. **Separate NuGet** (`Wolfgang.Etl.DbClient.Generators`) — the original design in [#23](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/23).
+2. **Pack into the runtime NuGet** under `analyzers/dotnet/cs/` so it flows transparently to every consumer of `Wolfgang.Etl.DbClient`.
+
+Separate packaging keeps the runtime lightweight and lets consumers opt in. Bundled packaging means every consumer already has the generator — no discovery step, no "install this second package for AOT" documentation, no version-skew between the two packages.
+
+## Decision
+
+Ship the generator inside the main `Wolfgang.Etl.DbClient` NuGet under `analyzers/dotnet/cs/`. Wired via a `PackSourceGenerator` MSBuild target in `src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj` that copies the generator's `bin/Release/netstandard2.0` output into the runtime package's analyzers folder at pack time.
+
+The source-gen project is referenced by the runtime csproj with `OutputItemType="Analyzer" ReferenceOutputAssembly="false"` — the analyzer runs in-process on the consumer's compiler; the assembly is not part of the runtime's public API.
+
+## Consequences
+
+- **Positive**:
+  - Zero-friction adoption. `dotnet add package Wolfgang.Etl.DbClient` gives the consumer both the runtime and the generator; `[DbTable]` "just works" without further steps.
+  - No version-skew — the generator ships lock-step with the attributes it consumes and the runtime code that will one day integrate its output.
+  - AOT / trim readiness is a single-package promise.
+- **Negative**:
+  - Every consumer of the runtime pays for the generator DLL in their `.nupkg` closure — small (~50 KB) but not zero.
+  - Consumers who want *only* the runtime (unlikely) cannot skip the generator.
+  - `ProjectReference` with `ReferenceOutputAssembly="false"` does not force a solution-level build of the source-gen csproj. This bit us at v0.5.0 release: the generator wasn't in `.slnx`, so `dotnet build --no-restore -c Release` at the solution level skipped it, and `PackSourceGenerator` failed to find the output. Recovered via [#222](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/222) (add to slnx) and hardened by [#225](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/225) (pr.yaml solution-consistency guardrail).
+- **Neutral**:
+  - Consumers debugging generator behavior will see the analyzer under `~/.nuget/packages/wolfgang.etl.dbclient/<ver>/analyzers/dotnet/cs/`.
+
+## Alternatives considered
+
+- **Separate NuGet `Wolfgang.Etl.DbClient.Generators`** — cleaner separation, higher friction. Rejected: users don't want a second package for something that's baked into how they annotate their record types.
+- **Optional MSBuild property to skip the analyzer** — deferred. If a consumer ever complains about the analyzer footprint, revisit; not worth adding the knob preemptively.
+
+## Notes
+
+- Introduced by [#200](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/200) (in v0.5.0).
+- Release-time hazard: [#222](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/222) (slnx fix), [#225](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/225) (guardrail).
+- Related to [#23](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/23) — the source-generator umbrella issue.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,28 @@
+# ADR-NNNN: <short title, imperative>
+
+- **Status**: Proposed | Accepted | Deprecated | Superseded by [ADR-NNNN](NNNN-title.md)
+- **Date**: YYYY-MM-DD
+- **Deciders**: @Chris-Wolfgang
+- **Tags**: `<area>`, `<area>` — e.g. `packaging`, `api-shape`, `ci`
+
+## Context
+
+What forces are at play — the constraint, the constellation of alternatives, the thing about the codebase or the ecosystem that makes the decision non-obvious. Keep it short: enough that a reader six months from now can reconstruct why *this* choice was on the table.
+
+## Decision
+
+The choice, in one paragraph. Include the specific mechanism (attribute name, csproj setting, workflow step) so future readers can trace the decision to code.
+
+## Consequences
+
+- **Positive**: what this buys.
+- **Negative**: what this costs — every non-trivial decision has one.
+- **Neutral**: knock-on effects consumers should know about.
+
+## Alternatives considered
+
+Bullet list of the paths not taken and one-sentence reasons.
+
+## Notes
+
+Links to the PR that introduced the decision, related issues, external references (RFCs, other repos' ADRs).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+Non-obvious design choices in `Wolfgang.Etl.DbClient` — the "why" that would otherwise get lost between the code and the PR discussion. Format loosely follows [MADR](https://adr.github.io/madr/) via [TEMPLATE.md](TEMPLATE.md).
+
+New ADRs land alongside the PR that introduces the decision; the ADR is part of the review, not a follow-up.
+
+## Index
+
+| ID | Title | Status | Date |
+|---|---|---|---|
+| [0001](0001-source-generator-ships-in-runtime-nuget.md) | Source generator ships in the runtime NuGet, not as a separate package | Accepted | 2026-07-01 |
+
+## Statuses
+
+- **Proposed** — under review; not yet reflected in code.
+- **Accepted** — in force. New code should conform.
+- **Deprecated** — no longer in force but no replacement chosen. Do not extend.
+- **Superseded** — replaced by a later ADR (link to it in the header).
+
+## Adding an ADR
+
+1. Copy `TEMPLATE.md` to `NNNN-short-title.md` using the next number in sequence.
+2. Fill in Context, Decision, Consequences, Alternatives, Notes.
+3. Add a row to the table above.
+4. Land it in the same PR as the code change that motivates it.


### PR DESCRIPTION
Closes #150.

Adds Architecture Decision Records structure so non-obvious design choices don't get lost between the code and the PR discussion. MADR-style template.

**Files:**
- \`docs/adr/TEMPLATE.md\` — Context / Decision / Consequences / Alternatives / Notes.
- \`docs/adr/index.md\` — numbered index + status legend + "how to add an ADR" procedure.
- \`docs/adr/0001-source-generator-ships-in-runtime-nuget.md\` — retroactively documents why the v0.5.0 source generator packs into the runtime NuGet under \`analyzers/dotnet/cs\` rather than shipping as a separate \`Wolfgang.Etl.DbClient.Generators\` package (as the original #23 design proposed). Captures the release-time slnx hazard (#222) and the resulting pr.yaml solution-consistency guardrail (#225).

**Convention going forward:** new ADRs land in the same PR as the code change they motivate — the ADR is part of the review, not a follow-up.

Docs-only. DocFX build already picks up \`**/*.{md,yml}\` so ADRs render on the docs site without additional config.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>