### PR TITLE
docs: establish docs/migrations/ convention (#149)

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,30 @@
+# Migration guides
+
+Per-major-version upgrade paths for `Wolfgang.Etl.DbClient`. Each guide documents breaking changes, before/after code, deprecation timeline, and a fix-your-code cheat sheet for consumers.
+
+## Convention
+
+- **New major bumps land with the guide as part of release prep — never a follow-up.** The release PR that stamps the new `<Version>` in the csproj must also add a numbered migration guide here and link to it from CHANGELOG and the GitHub Release notes.
+- **Deprecations get flagged one minor before the removal.** If `Z.0` removes something, `Y.n` (the last minor of the previous major) marks it `[Obsolete]` with a message pointing at the migration guide. Consumers who upgrade minor-by-minor never hit an undocumented break.
+- **Guides are consumer-facing, not internal.** Explain the "before/after/why" so a downstream maintainer skimming the guide during their own upgrade window can act without opening the source.
+
+## Index
+
+*No major releases yet — the library is pre-1.0. This section will list guides once the first major bump ships.*
+
+| From | To | Guide | Released |
+|---|---|---|---|
+
+## Adding a guide
+
+1. Copy `TEMPLATE-major-version-migration.md` to `<PREV>-to-<NEXT>.md` (e.g. `0.x-to-1.0.md`, `1.x-to-2.0.md`).
+2. Fill in the sections. Every breaking-change bullet gets **before / after / why / fix pattern**.
+3. Add a row to the Index table above.
+4. Link the guide from the release CHANGELOG entry and the GitHub Release notes.
+5. Land it in the same PR as the `<Version>` bump.
+
+## Why proactively file this template
+
+Cheap to write pre-1.0 while there's nothing under time pressure. Expensive to retrofit after a major ships without one — consumers have already reverse-engineered the breaks by then, complained in issues, and abandoned the upgrade.
+
+Refs [#149](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/149).

--- a/docs/migrations/TEMPLATE-major-version-migration.md
+++ b/docs/migrations/TEMPLATE-major-version-migration.md
@@ -1,0 +1,93 @@
+# Migrating from `Wolfgang.Etl.DbClient` X.y → `Z.0`
+
+- **Previous major**: `X.y` (last minor: `X.y.z`, released YYYY-MM-DD)
+- **This major**: `Z.0.0`, released YYYY-MM-DD
+- **Effort estimate**: <one-line — "mechanical", "search + replace + review", "requires re-benchmarking", etc.>
+
+## TL;DR
+
+One paragraph. If a consumer reads only this section, what do they need to do?
+
+## Why the major bump
+
+Motivating change — the one or two things that couldn't be delivered without a breaking change. Link to the driving issue(s).
+
+## Deprecation timeline
+
+- **Deprecated in**: `X.y.z` (YYYY-MM-DD) — marked `[Obsolete]`, warning-only.
+- **Removed in**: `Z.0.0` (YYYY-MM-DD).
+- **Support window on `X.y`**: <"security patches only through YYYY-MM-DD" | "no further updates">.
+
+## Breaking-change inventory
+
+Group by category. Each entry has: **before**, **after**, **why**, **fix pattern**.
+
+### API removals
+
+#### `TypeName.MemberName`
+
+- **Before**
+  ```csharp
+  <old usage>
+  ```
+- **After**
+  ```csharp
+  <replacement usage>
+  ```
+- **Why**: <one line — what forced this>.
+- **Fix pattern**: search-and-replace | manual review required | scripted (link a script if applicable).
+
+### API renames
+
+#### `OldName` → `NewName`
+
+- **Before / After / Why / Fix pattern** — same shape as above.
+
+### Behavioral changes (no signature change)
+
+#### `TypeName.MemberName` — `<one-line summary of behavior change>`
+
+- **Before**: <old semantics>.
+- **After**: <new semantics>.
+- **Why**: <what forced this>.
+- **How to detect** — what a consumer test would show if the change affects them.
+- **Fix pattern**: how to keep the old behavior (if opt-in) or adapt.
+
+### Configuration / defaults
+
+Options whose default changed. Any consumer relying on the old default needs to set the option explicitly.
+
+### Dependencies
+
+- **Runtime dependencies**: what bumped, what got dropped, what got added.
+- **Minimum TFM**: e.g. dropped `net462` / `netstandard2.0` — link the deprecation ADR.
+
+## Fix-your-code cheat sheet
+
+Copy-pasteable snippets for the ~5 most common consumer patterns. Keep this section under one screen.
+
+```csharp
+// OLD (X.y)
+
+
+// NEW (Z.0)
+
+```
+
+## After the upgrade — verify
+
+- [ ] Build succeeds with `TreatWarningsAsErrors`.
+- [ ] Test suite passes.
+- [ ] `<any release-specific verification — allocation regression, behavior sample, integration test row>`.
+- [ ] Update your own downstream migration guide if you're a library.
+
+## Rollback
+
+If the upgrade turned up a blocker, pin back to the last `X.y.z` and open an issue on this repo with a repro. Rollback is safe — `X.y.z` remains listed on NuGet indefinitely; a `Z.0` upgrade is not a one-way door.
+
+## References
+
+- Release notes: <link to the GitHub Release>.
+- CHANGELOG entry: <link>.
+- Driving issues: `#NNN`, `#NNN`.
+- Related ADRs: [ADR-NNNN](../adr/NNNN-title.md).


### PR DESCRIPTION
Closes #149.

Creates the migration-guide structure now so it's ready when the first major bump lands — not retrofitted after consumers have already reverse-engineered the breaks.

**Files:**
- \`docs/migrations/README.md\` — index (currently empty; no majors shipped yet) + the "must land in the same PR as the \`<Version>\` bump" convention + the deprecate-one-minor-early rule.
- \`docs/migrations/TEMPLATE-major-version-migration.md\` — Nygard-style template with:
    - TL;DR
    - Why the major bump
    - Deprecation timeline
    - Breaking-change inventory (removals, renames, behavioral, defaults, dependencies)
    - Fix-your-code cheat sheet (copy-pasteable, one screen)
    - After-the-upgrade verify checklist
    - Rollback note
    - References (release notes, CHANGELOG, driving issues, ADRs)

Docs-only. No majors have shipped yet — this PR is entirely proactive per the acceptance criteria.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>