### PR TITLE
ci: add zizmor + actionlint workflow-YAML security audit (#153)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+# actionlint configuration.
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+#
+# Baseline: allow the self-hosted / matrix labels used elsewhere in
+# the fleet. No suppressions yet.
+self-hosted-runner:
+  # Recognised labels for `runs-on:` on top of the GitHub-hosted set.
+  labels: []
+
+# Uncomment to disable specific rules once a baseline finding is
+# confirmed intentional. Prefer fixing the finding over suppressing it.
+# config-variables: []

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,84 @@
+# Workflow YAML security audit — zizmor + actionlint.
+#
+# CodeQL scans source code. This workflow scans the GitHub Actions
+# YAML *itself* for security defects that source-code SAST can't see:
+#   - untrusted-input injection into run: blocks
+#   - missing / overly-permissive permissions: blocks
+#   - secrets leaking via expression-context expansion
+#   - third-party actions not pinned by SHA
+#
+# zizmor: security-focused static analysis (rules focus on threat model).
+# actionlint: syntax + typing + common-mistake linting (broader, less deep).
+# The two are complementary — running both covers rule sets neither
+# tool covers alone.
+#
+# Refs #153.
+
+name: Workflow security audit
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".zizmor.yml"
+      - ".github/actionlint.yaml"
+      - ".github/workflows/workflow-security.yaml"
+  push:
+    branches: [main, vNext]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  # Manual trigger for full re-scan (e.g. after tightening the config).
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to code-scanning.
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          # Gate on high-severity findings; medium / low surface in
+          # Code Scanning but don't block the PR.
+          min-severity: high
+          # Config lives in .zizmor.yml at the repo root (see below).
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        if: always()
+        with:
+          sarif_file: results.sarif
+          category: zizmor
+
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        with:
+          # PR annotations (::error / ::warning file=…) are emitted by
+          # actionlint's default GitHub Actions matcher.
+          fail-on-error: true
+          # actionlint config lives in .github/actionlint.yaml (see below).

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,14 @@
+# zizmor configuration.
+# https://docs.zizmor.sh/configuration/
+#
+# Baseline: no suppressions yet. Add rules here only when the finding
+# is intentional and documented (why the risk is accepted).
+#
+# Format for a suppression:
+#   rules:
+#     <rule-id>:
+#       ignore:
+#         - <path>:<line>:<optional-symbol>  # reason: <one line>
+#
+# See https://docs.zizmor.sh/audits/ for the rule catalog.
+rules: {}

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -176,8 +176,23 @@ When adding new configuration files that control code quality or security:
 3. Test that the file is correctly fetched from main branch.
 4. Update this documentation.
 
+## Workflow YAML audit — zizmor + actionlint
+
+`.github/workflows/workflow-security.yaml` runs on every PR that touches `.github/workflows/**` or `.github/actions/**`, and on every push to `main` / `vNext`. Two tools, complementary rule sets:
+
+- **[zizmor](https://github.com/zizmorcore/zizmor)** — security-focused static analysis. Catches untrusted-input injection into `run:` blocks, missing / overly-permissive `permissions:` blocks, secret leaks via expression-context expansion, third-party actions unpinned by SHA. Publishes SARIF to Code Scanning (category: `zizmor`). Gate: `min-severity: high` — highs fail the PR, medium/low surface in Code Scanning without blocking.
+- **[actionlint](https://github.com/rhysd/actionlint)** — syntax + typing + common-mistake linting. Broader coverage; catches issues zizmor doesn't model (shell-checker integration, matrix-expression typos, deprecated Actions syntax). Runs with `fail-on-error: true`.
+
+**Configuration**:
+- `.zizmor.yml` at the repo root — suppression list. Currently empty (no accepted findings).
+- `.github/actionlint.yaml` — self-hosted-runner labels + rule config. Currently empty.
+
+**Adding a suppression** (either tool): document *why* the finding is intentional in the config file. Prefer fixing the finding over suppressing it. Refs [#153](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/153).
+
 ## References
 
 - [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
 - [Keeping your GitHub Actions secure](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
 - [Understanding pull_request_target](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
+- [zizmor rule catalog](https://docs.zizmor.sh/audits/)
+- [actionlint rule reference](https://github.com/rhysd/actionlint/blob/main/docs/checks.md)


### PR DESCRIPTION
Closes #153.

Scans the GitHub Actions YAML *itself* for security defects source-code SAST doesn't cover — untrusted-input injection into \`run:\` blocks, missing/overly-permissive \`permissions:\`, secrets via expression-context expansion, third-party actions unpinned by SHA. zizmor + actionlint cover complementary rule sets.

**Files**:
- \`.github/workflows/workflow-security.yaml\` — two jobs (zizmor, actionlint). SHA-pinned actions (zizmorcore/zizmor-action@v0.5.7, raven-actions/actionlint@v2.2.0, actions/checkout@v7.0.0, github/codeql-action@v3.28.10). Triggers on PR paths under \`.github/workflows/**\` + push to main/vNext + workflow_dispatch. Least-privilege per job.
    - zizmor: \`min-severity: high\` (highs fail; medium/low surface in Code Scanning without blocking). SARIF category \`zizmor\`.
    - actionlint: \`fail-on-error: true\`; PR annotations via default matcher.
- \`.zizmor.yml\` — empty suppression config.
- \`.github/actionlint.yaml\` — empty config.
- \`docs/WORKFLOW_SECURITY.md\` — describes both tools + suppression-vs-fix policy.

**Baseline**: any findings on first PR run get triaged in a follow-up commit. Real fixes are preferred; intentional findings get documented suppressions.

Note: \`.github/workflows/*.yaml\` is protected. Admin-bypass merge is the expected path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>