### PR TITLE
ci: add license-audit workflow (#148)

### DIFF
--- a/.github/license-allowlist.json
+++ b/.github/license-allowlist.json
@@ -1,0 +1,12 @@
+{
+  "$comment": "Allowlisted SPDX license identifiers for direct + transitive NuGet dependencies. Adding to this list requires reviewer sign-off. See docs/LICENSE-AUDIT.md for policy.",
+  "allowed": [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "MS-PL",
+    "Microsoft.NETCore.Platforms",
+    "0BSD"
+  ]
+}

--- a/.github/license-allowlist.json
+++ b/.github/license-allowlist.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Allowlisted SPDX license identifiers for direct + transitive NuGet dependencies. Adding to this list requires reviewer sign-off. See docs/LICENSE-AUDIT.md for policy.",
+  "$comment": "Allowlist for direct + transitive NuGet dependencies. Entries are SPDX license identifiers except where nuget-license emits a package-name placeholder in place of a real SPDX ID (currently just Microsoft.NETCore.Platforms, which is effectively MIT). Adding to this list requires reviewer sign-off. See docs/LICENSE-AUDIT.md for policy.",
   "allowed": [
     "MIT",
     "Apache-2.0",

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -1,0 +1,83 @@
+# License audit for transitive dependencies.
+#
+# Dependabot tracks dependency versions and CVE alerts but does NOT
+# check licenses. A new transitive dependency under an incompatible
+# license (GPL, AGPL, OSL, BSL, ...) silently leaks into a work
+# distributed under MIT — real procurement / legal exposure for
+# downstream consumers.
+#
+# Tool: `nuget-license` (dotnet global tool). Enumerates every
+# transitive NuGet package, captures its declared license, fails
+# the run on anything outside the allowlist below.
+#
+# Allowlist source: .github/license-allowlist.json
+#
+# Refs #148.
+
+name: License audit
+
+on:
+  pull_request:
+    paths:
+      - "**/*.csproj"
+      - "Directory.Build.props"
+      - "Directory.Packages.props"
+      - ".github/license-allowlist.json"
+      - ".github/workflows/license-audit.yaml"
+  push:
+    branches: [main]
+  # Nightly scan catches newly-published transitive updates
+  # (packages we don't control the version of).
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+
+      - name: Install nuget-license
+        run: dotnet tool install --global nuget-license
+
+      - name: Load allowlist
+        id: allowlist
+        run: |
+          # Flatten JSON array to a comma-separated list for the CLI.
+          list=$(jq -r '.allowed | join(",")' .github/license-allowlist.json)
+          echo "types=$list" >> "$GITHUB_OUTPUT"
+
+      - name: Run audit (fail on non-allowlisted)
+        run: |
+          nuget-license \
+            --input src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj \
+            --allowed-license-types ${{ steps.allowlist.outputs.types }} \
+            --output JsonPretty \
+            --file-output license-report.json
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: license-report
+          path: license-report.json
+          retention-days: 30

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -32,8 +32,6 @@ on:
     - cron: "17 4 * * *"
   workflow_dispatch:
 
-permissions: read-all
-
 jobs:
   audit:
     name: Audit
@@ -67,10 +65,14 @@ jobs:
           echo "types=$list" >> "$GITHUB_OUTPUT"
 
       - name: Run audit (fail on non-allowlisted)
+        env:
+          ALLOWED_LICENSES: ${{ steps.allowlist.outputs.types }}
         run: |
+          # Pass the allowlist via env + quoted expansion so an entry
+          # containing whitespace can't split into additional CLI args.
           nuget-license \
             --input src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj \
-            --allowed-license-types ${{ steps.allowlist.outputs.types }} \
+            --allowed-license-types "$ALLOWED_LICENSES" \
             --output JsonPretty \
             --file-output license-report.json
 

--- a/docs/LICENSE-AUDIT.md
+++ b/docs/LICENSE-AUDIT.md
@@ -34,11 +34,11 @@ Requires reviewer sign-off in the same PR. The PR description must include:
 2. **Why the license is acceptable** for a library distributed under MIT — link the license text and a one-line risk assessment.
 3. **Whether attribution requirements** apply (e.g. copyleft-adjacent licenses that require notice preservation). If so, add the notice to `THIRD-PARTY-NOTICES.md`.
 
-Copyleft (GPL / LGPL / AGPL), source-restrictive (OSL, EPL), and non-OSI (BSL, PolyForm, SSPL) licenses will not be accepted.
+Copyleft licenses will not be accepted. This covers the strong-copyleft family (GPL / LGPL / AGPL) and also the weak-copyleft licenses that still impose source-availability obligations on distribution (EPL, OSL, MPL). Non-OSI source-available licenses (BSL, PolyForm, SSPL) are likewise rejected.
 
 ## `THIRD-PARTY-NOTICES.md`
 
-Follow-up work: auto-generate `THIRD-PARTY-NOTICES.md` from `license-report.json` at release time and pack it into the NuGet under `THIRD-PARTY-NOTICES.md`. Tracked as a scope of [#148](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/148).
+Follow-up work: auto-generate `THIRD-PARTY-NOTICES.md` from `license-report.json` at release time and pack it into the NuGet. Tracked separately in [#239](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/239) so it doesn't get orphaned when this PR closes [#148](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/148).
 
 ## Baseline
 

--- a/docs/LICENSE-AUDIT.md
+++ b/docs/LICENSE-AUDIT.md
@@ -1,0 +1,50 @@
+# License audit policy
+
+## Why
+
+Dependabot tracks dependency *versions* (and CVE alerts). It does not check the *licenses* of transitive dependencies. A new transitive dependency with an incompatible license (GPL, AGPL, OSL, BSL) would silently leak into a derivative work distributed under MIT — a real procurement / legal exposure for downstream consumers of `Wolfgang.Etl.DbClient`.
+
+## What runs
+
+`.github/workflows/license-audit.yaml` runs on every PR that touches a csproj / `Directory.Build.props` / `Directory.Packages.props` / the allowlist itself, on push to `main`, and nightly at 04:17 UTC (catches transitive updates we don't control).
+
+Tool: `nuget-license` (dotnet global tool). Enumerates every transitive package under `src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj`, reads its declared license, fails the run if any package's license is not in the allowlist below. The full report is uploaded as an artifact (`license-report`) for 30 days.
+
+## Allowlist
+
+Source of truth: [`.github/license-allowlist.json`](../.github/license-allowlist.json).
+
+Currently accepted:
+
+| SPDX identifier | Notes |
+|---|---|
+| `MIT` | Standard permissive. |
+| `Apache-2.0` | Standard permissive; includes patent grant. |
+| `BSD-2-Clause` | Standard permissive. |
+| `BSD-3-Clause` | Standard permissive; no-endorsement clause. |
+| `MS-PL` | Microsoft Public License — permissive; used by some MS OSS. |
+| `0BSD` | Public-domain equivalent; used by some SPDX-normalised metadata. |
+| `Microsoft.NETCore.Platforms` | Placeholder ID nuget-license emits for a Microsoft package whose license URL points at `dotnet/runtime`. Effectively MIT. |
+
+## Adding an entry
+
+Requires reviewer sign-off in the same PR. The PR description must include:
+
+1. **Which dependency** requires the new license (direct or transitive; if transitive, which direct dep pulls it in).
+2. **Why the license is acceptable** for a library distributed under MIT — link the license text and a one-line risk assessment.
+3. **Whether attribution requirements** apply (e.g. copyleft-adjacent licenses that require notice preservation). If so, add the notice to `THIRD-PARTY-NOTICES.md`.
+
+Copyleft (GPL / LGPL / AGPL), source-restrictive (OSL, EPL), and non-OSI (BSL, PolyForm, SSPL) licenses will not be accepted.
+
+## `THIRD-PARTY-NOTICES.md`
+
+Follow-up work: auto-generate `THIRD-PARTY-NOTICES.md` from `license-report.json` at release time and pack it into the NuGet under `THIRD-PARTY-NOTICES.md`. Tracked as a scope of [#148](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/148).
+
+## Baseline
+
+The first run's `license-report.json` is the baseline. If any current transitive package fails the initial audit, the fix is to either:
+
+1. Confirm the license is genuinely acceptable and add it to the allowlist per the rules above; or
+2. Replace the dependency with a permissively-licensed alternative.
+
+Refs [#148](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/148).


### PR DESCRIPTION
Closes #148.

Enumerates every transitive NuGet dependency of the runtime csproj and fails the run on any license outside the allowlist. Dependabot tracks *versions* + CVEs; this closes the *license* gap for procurement / downstream-consumer compliance.

**Tool**: \`nuget-license\` (dotnet global tool). Well-maintained OSS, no paid-tier dependency.

**Files**:
- \`.github/workflows/license-audit.yaml\` — SHA-pinned actions (actions/checkout@v7.0.0, actions/setup-dotnet@v5.0.0, actions/upload-artifact@v7.0.0). Triggers: PR paths (csproj / Directory.Build.props / Directory.Packages.props / allowlist / own workflow file), push to main, nightly 04:17 UTC (catches uncontrolled transitive updates), workflow_dispatch. Uploads \`license-report.json\` artifact (30-day retention).
- \`.github/license-allowlist.json\` — source of truth. Currently: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, MS-PL, 0BSD, Microsoft.NETCore.Platforms.
- \`docs/LICENSE-AUDIT.md\` — policy: allowlist rationale, how to add an entry (PR must justify), what's rejected (copyleft, source-restrictive, non-OSI). Notes THIRD-PARTY-NOTICES.md pack-into-NuGet as a follow-up scope of #148.

**Baseline**: first run establishes ground truth. If any current transitive package fails, either allowlist + justify, or replace the dep.

**Follow-up (deferred, still tracked under #148)**: auto-generate \`THIRD-PARTY-NOTICES.md\` from \`license-report.json\` at release time and pack it into the NuGet.

Note: \`.github/workflows/*.yaml\` is protected. Admin-bypass merge is the expected path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>