### PR TITLE
ci: add ApiCompat release gate vs previous NuGet version (#136)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -668,10 +668,116 @@ jobs:
           echo "❌ Integration aggregator FAILS — release gate blocks the publish."
           exit 1
 
-  # Publish to NuGet (only if validation + integration passed)
+  # ABI compatibility gate: for a PATCH/MINOR release, break the build
+  # if the new package's public surface is binary-incompatible with the
+  # last version on nuget.org. MAJOR releases record intentional breaks
+  # in compat-suppressions.txt (checked in) so they don't recur silently.
+  # Refs #136.
+  api-compat:
+    name: ApiCompat vs last NuGet
+    needs: pack-and-validate
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Download packed artifacts
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: nuget-packages
+          path: ./packages
+
+      - name: Install ApiCompat tool
+        run: dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
+
+      - name: Run ApiCompat
+        id: apicompat
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Determine package id + version from the freshly-packed .nupkg
+          new_nupkg=$(ls packages/Wolfgang.Etl.DbClient.*.nupkg | grep -v '.symbols.nupkg' | head -1)
+          if [ -z "$new_nupkg" ]; then
+            echo "❌ No runtime .nupkg in ./packages"
+            ls -la packages/
+            exit 1
+          fi
+          fname=$(basename "$new_nupkg" .nupkg)
+          # Wolfgang.Etl.DbClient.<major>.<minor>.<patch>[-suffix] → strip the id prefix
+          new_version=${fname#Wolfgang.Etl.DbClient.}
+          echo "New package: Wolfgang.Etl.DbClient@$new_version"
+
+          # Look up the previous stable version from nuget.org (excludes the
+          # version we're about to publish + any pre-release tags).
+          prev_version=$(curl -sSf \
+            "https://api.nuget.org/v3-flatcontainer/wolfgang.etl.dbclient/index.json" \
+            | jq -r --arg new "$new_version" '.versions
+              | map(select(test("-") | not))
+              | map(select(. != $new))
+              | .[-1] // empty')
+
+          if [ -z "$prev_version" ]; then
+            echo "ℹ️  No prior stable version on nuget.org — first release or first stable. Skipping compat check."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Previous stable: Wolfgang.Etl.DbClient@$prev_version"
+          echo "prev-version=$prev_version" >> "$GITHUB_OUTPUT"
+
+          # Download previous nupkg
+          mkdir -p prev
+          curl -sSfL \
+            "https://api.nuget.org/v3-flatcontainer/wolfgang.etl.dbclient/$prev_version/wolfgang.etl.dbclient.$prev_version.nupkg" \
+            -o "prev/prev.nupkg"
+
+          # Extract both nupkgs
+          unzip -q "$new_nupkg" -d new
+          unzip -q "prev/prev.nupkg" -d prev/pkg
+
+          # Compare per TFM. All TFMs the package declares must be
+          # binary-compatible with the same TFM in the previous version
+          # (unless suppressed in compat-suppressions.txt or this is a
+          # MAJOR bump — the workflow doesn't distinguish; suppressions
+          # are the escape hatch).
+          suppression_arg=""
+          if [ -f compat-suppressions.txt ]; then
+            suppression_arg="--suppression-file compat-suppressions.txt"
+          fi
+
+          exit_code=0
+          for new_dll in $(find new/lib -name Wolfgang.Etl.DbClient.dll); do
+            tfm=$(basename "$(dirname "$new_dll")")
+            prev_dll="prev/pkg/lib/$tfm/Wolfgang.Etl.DbClient.dll"
+            if [ ! -f "$prev_dll" ]; then
+              echo "ℹ️  TFM $tfm is new in this release (no previous DLL) — skipping."
+              continue
+            fi
+            echo ""
+            echo "🔍 ApiCompat: $tfm"
+            if ! apicompat --left "$prev_dll" --right "$new_dll" $suppression_arg; then
+              echo "❌ ApiCompat FAILED for $tfm"
+              exit_code=1
+            fi
+          done
+          exit $exit_code
+
+  # Publish to NuGet (only if validation + integration + api-compat passed)
   publish-nuget:
     name: Publish to NuGet.org
-    needs: [pack-and-validate, test-integration-all]
+    needs: [pack-and-validate, test-integration-all, api-compat]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -694,7 +694,7 @@ jobs:
             10.0.x
 
       - name: Download packed artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: nuget-packages
           path: ./packages
@@ -705,28 +705,38 @@ jobs:
       - name: Run ApiCompat
         id: apicompat
         shell: bash
+        env:
+          PKG_ID: Wolfgang.Etl.DbClient
         run: |
           set -euo pipefail
-          # Determine package id + version from the freshly-packed .nupkg
-          new_nupkg=$(ls packages/Wolfgang.Etl.DbClient.*.nupkg | grep -v '.symbols.nupkg' | head -1)
+
+          # Determine package id + version from the freshly-packed .nupkg.
+          # Use find (not `ls <glob>`) so an empty match returns cleanly
+          # instead of tripping `set -e` before the friendly diagnostic.
+          new_nupkg=$(find packages -maxdepth 1 -name "${PKG_ID}.*.nupkg" ! -name '*.symbols.nupkg' | head -1)
           if [ -z "$new_nupkg" ]; then
             echo "❌ No runtime .nupkg in ./packages"
-            ls -la packages/
+            ls -la packages/ || true
             exit 1
           fi
           fname=$(basename "$new_nupkg" .nupkg)
-          # Wolfgang.Etl.DbClient.<major>.<minor>.<patch>[-suffix] → strip the id prefix
-          new_version=${fname#Wolfgang.Etl.DbClient.}
-          echo "New package: Wolfgang.Etl.DbClient@$new_version"
+          # <PKG_ID>.<major>.<minor>.<patch>[-suffix] → strip the id prefix
+          new_version=${fname#${PKG_ID}.}
+          echo "New package: ${PKG_ID}@$new_version"
 
           # Look up the previous stable version from nuget.org (excludes the
-          # version we're about to publish + any pre-release tags).
-          prev_version=$(curl -sSf \
-            "https://api.nuget.org/v3-flatcontainer/wolfgang.etl.dbclient/index.json" \
-            | jq -r --arg new "$new_version" '.versions
-              | map(select(test("-") | not))
-              | map(select(. != $new))
-              | .[-1] // empty')
+          # version we're about to publish + any pre-release tags). Parse
+          # with python3 — guaranteed on ubuntu-latest and doesn't depend
+          # on `jq` staying on the runner image.
+          pkg_lc=$(printf '%s' "$PKG_ID" | tr '[:upper:]' '[:lower:]')
+          prev_version=$(
+            curl -sSf "https://api.nuget.org/v3-flatcontainer/${pkg_lc}/index.json" \
+            | NEW_VERSION="$new_version" python3 -c 'import json,os,sys
+data=json.load(sys.stdin)
+new=os.environ["NEW_VERSION"]
+stable=[v for v in data.get("versions",[]) if "-" not in v and v!=new]
+print(stable[-1] if stable else "")'
+          )
 
           if [ -z "$prev_version" ]; then
             echo "ℹ️  No prior stable version on nuget.org — first release or first stable. Skipping compat check."
@@ -740,7 +750,7 @@ jobs:
           # Download previous nupkg
           mkdir -p prev
           curl -sSfL \
-            "https://api.nuget.org/v3-flatcontainer/wolfgang.etl.dbclient/$prev_version/wolfgang.etl.dbclient.$prev_version.nupkg" \
+            "https://api.nuget.org/v3-flatcontainer/${pkg_lc}/$prev_version/${pkg_lc}.$prev_version.nupkg" \
             -o "prev/prev.nupkg"
 
           # Extract both nupkgs

--- a/compat-suppressions.txt
+++ b/compat-suppressions.txt
@@ -1,0 +1,18 @@
+# ApiCompat suppression file.
+#
+# Records intentional ABI-breaking changes that ApiCompat would
+# otherwise flag as compat failures. Additions require:
+#
+# 1. A MAJOR version bump (SemVer forbids ABI breaks in PATCH/MINOR).
+# 2. A migration guide under docs/migrations/ (see docs/migrations/README.md).
+# 3. An ADR under docs/adr/ if the break reflects a design decision.
+#
+# Format (one per line):
+#   <diagnostic-id>|<left-signature>|<right-signature>
+# e.g.:
+#   CP0002|M:Wolfgang.Etl.DbClient.DbLoader.LoadAsync|
+#
+# Full syntax:
+#   https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/
+#
+# Empty baseline — no intentional breaks recorded yet.

--- a/compat-suppressions.txt
+++ b/compat-suppressions.txt
@@ -4,8 +4,9 @@
 # otherwise flag as compat failures. Additions require:
 #
 # 1. A MAJOR version bump (SemVer forbids ABI breaks in PATCH/MINOR).
-# 2. A migration guide under docs/migrations/ (see docs/migrations/README.md).
-# 3. An ADR under docs/adr/ if the break reflects a design decision.
+# 2. A migration guide under docs/migrations/ (convention: #149).
+# 3. An ADR under docs/adr/ if the break reflects a design decision
+#    (convention: #150).
 #
 # Format (one per line):
 #   <diagnostic-id>|<left-signature>|<right-signature>


### PR DESCRIPTION
Closes #136.

PublicApiAnalyzers (RS0016/RS0017) catches added/removed signatures via \`PublicAPI.Shipped.txt\`. It does NOT catch behavioural ABI breaks that consumers' pre-compiled assemblies trip over at runtime — default-value changes, nullability annotation flips, binary-layout shifts.

Adds \`Microsoft.DotNet.ApiCompat.Tool\` as a release gate:
\`pack-and-validate → api-compat (NEW) → publish-nuget\`

**Flow**:
1. Freshly-packed \`.nupkg\` = right side.
2. Previous stable version fetched from nuget.org via \`v3-flatcontainer\` (excludes pre-releases + the version we're about to publish).
3. Both \`.nupkg\` extracted; runtime lib DLLs compared per TFM.
4. Any diagnostic ApiCompat emits fails the job unless suppressed in \`compat-suppressions.txt\`.
5. Fresh TFM in the new package → skip with info log, not failure.
6. First release (no prior stable) → skip cleanly.

**\`compat-suppressions.txt\`** (empty baseline) documents the escape hatch for intentional MAJOR-release breaks. Additions require MAJOR bump + migration guide + ADR per header comment. Aligns with the \`docs/migrations/\` and \`docs/adr/\` conventions from #149 / #150.

Note: \`release.yaml\` is a protected file. Admin-bypass merge is the expected path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>