### PR TITLE
docs(security): add "Release path & compromise scope" appendix (supersedes #232)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,13 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
+
+## Release path & compromise scope
+
+Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook. The fleet-canonical full runbook is tracked at [Chris-Wolfgang/repo-template#430](https://github.com/Chris-Wolfgang/repo-template/issues/430).
+
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml` (adopted in [#228](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/228)). **No long-lived `NUGET_API_KEY`** exists on the repo or account. Any legacy key on the account should be treated as an anomaly and deleted immediately.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/Etl-DbClient`).
+- **Owner**: @Chris-Wolfgang.
+- **Downstream consumers**: none inside the Wolfgang.* org today; the package is public on nuget.org.
+- **Package coordinates for unlisting**: `Wolfgang.Etl.DbClient` on nuget.org — https://www.nuget.org/packages/Wolfgang.Etl.DbClient/.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,8 +26,8 @@ Responsible disclosure of security vulnerabilities helps protect our entire comm
 
 Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook. The fleet-canonical full runbook is tracked at [Chris-Wolfgang/repo-template#430](https://github.com/Chris-Wolfgang/repo-template/issues/430).
 
-- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml` (adopted in [#228](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/228)). **No long-lived `NUGET_API_KEY`** exists on the repo or account. Any legacy key on the account should be treated as an anomaly and deleted immediately.
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml` (adopted in [#228](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/228)). The workflow mints an ephemeral push token per run via OIDC — the release path does not depend on a long-lived API key stored in GitHub secrets or on the NuGet account. During an incident, check the NuGet account for any long-lived API keys anyway (they can be created outside of CI) and delete anything you don't recognize.
 - **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/Etl-DbClient`).
 - **Owner**: @Chris-Wolfgang.
-- **Downstream consumers**: none inside the Wolfgang.* org today; the package is public on nuget.org.
+- **Downstream consumers**: none known inside the Wolfgang.* org at time of writing; the package is public on nuget.org, so unknown downstream consumers may exist. Re-check via `dotnet-outdated`, GitHub code-search, and the NuGet package's `Used By` dependents list before communicating during an incident.
 - **Package coordinates for unlisting**: `Wolfgang.Etl.DbClient` on nuget.org — https://www.nuget.org/packages/Wolfgang.Etl.DbClient/.


### PR DESCRIPTION
Supersedes #232. Refs #151.

Rescopes the deliverable from the DR-runbook PR (#232) down to what's actually load-bearing for this repo: the ~10 DbClient-specific facts a maintainer would need at 2am if the release identity is compromised.

**Dropped from the previous PR** (moved to the fleet canonical at [Chris-Wolfgang/repo-template#430](https://github.com/Chris-Wolfgang/repo-template/issues/430) — will be canonicalized once, synced to every downstream):
- Rotate credentials / revoke OAuth apps / sign out sessions
- Unlist-vs-delete rationale
- Advisory workflow walkthrough
- Consumer notification template

Those are generic and duplicated 25× across the fleet would drift within a year. GitHub and NuGet's own docs update faster than a checked-in runbook.

**Kept** (this PR):
- Release path is OIDC / NuGet Trusted Publishing (no long-lived key to rotate; any legacy key is an anomaly)
- No fallback — compromise = GitHub-account-level incident
- Owner + downstream-consumer status
- Package coordinates for unlisting

Docs-only.

**Post-merge**: close #232 without merging.