### PR TITLE
ci: add PublishAot + PublishTrimmed smoke consumer + workflow (#143)

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -1,0 +1,141 @@
+# AOT / trim publish smoke test.
+#
+# Publishes examples/Wolfgang.Etl.DbClient.Example.AotSmoke with
+# <PublishAot>true</PublishAot> + <PublishTrimmed>true</PublishTrimmed>
+# and runs the resulting native binary. Surfaces IL2xxx / AOT0xxx /
+# IL3xxx warnings so we know which library surfaces the trimmer /
+# AOT compiler can't see through.
+#
+# Status: INFORMATIONAL / NON-BLOCKING today.
+#
+# Rationale: DbClient's runtime path is built on Dapper 2.1.66,
+# which currently has known trim/AOT gaps that no consumer can
+# annotate around from outside the library. Failing the PR gate
+# would block every merge on issues we can't fix without either
+# (a) a Dapper upgrade that lands its own AOT annotations, or
+# (b) rewriting the reflection paths in DbClient to something
+# trim-friendly (source-generator-driven — partially in progress
+# via #23). Until then, this workflow captures the warning-list
+# and surfaces it as a PR annotation so we can track direction of
+# travel without blocking merges.
+#
+# Blocking-mode plan:
+#   1. Land the source-generator (#23) UPDATE/DELETE/SELECT + Bind
+#      wire-up so reflection is optional at consumer opt-in.
+#   2. Consume Dapper release that ships trim annotations.
+#   3. Flip `continue-on-error` to false and enforce a max IL2xxx
+#      warning count via `--verbosity minimal` grep, as a
+#      regression gate.
+#
+# Refs #143.
+
+name: AOT + trim smoke
+
+on:
+  pull_request_target:
+    paths:
+      - "src/**"
+      - "examples/Wolfgang.Etl.DbClient.Example.AotSmoke/**"
+      - ".github/workflows/aot-smoke.yaml"
+  push:
+    branches: [main, vNext]
+    paths:
+      - "src/**"
+      - "examples/Wolfgang.Etl.DbClient.Example.AotSmoke/**"
+      - ".github/workflows/aot-smoke.yaml"
+  workflow_dispatch:
+
+jobs:
+  aot-smoke:
+    name: PublishAot + PublishTrimmed
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # pull_request_target defaults to base; scan the proposed
+          # content explicitly.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj
+
+      # Non-blocking (see file header). Captures full trim/AOT
+      # warning output so we can trend and eventually gate.
+      - name: Publish (PublishAot + PublishTrimmed)
+        id: publish
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          mkdir -p publish
+          dotnet publish \
+            examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj \
+            --configuration Release \
+            --runtime linux-x64 \
+            --self-contained true \
+            --output publish \
+            -p:PublishAot=true \
+            -p:PublishTrimmed=true \
+            -p:TrimmerSingleWarn=false \
+            2>&1 | tee publish.log
+
+      - name: Summarize trim / AOT warnings
+        if: always()
+        run: |
+          echo "## AOT + trim smoke — warning summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ ! -f publish.log ]; then
+            echo "publish step produced no log — likely errored before running dotnet." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          il2_count=$(grep -c "warning IL2" publish.log || true)
+          il3_count=$(grep -c "warning IL3" publish.log || true)
+          aot_count=$(grep -c "warning AOT" publish.log || true)
+          echo "| Category | Count |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Trim (IL2xxx) | $il2_count |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Single-file (IL3xxx) | $il3_count |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| AOT (AOT0xxx) | $aot_count |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$il2_count" -gt 0 ] || [ "$il3_count" -gt 0 ] || [ "$aot_count" -gt 0 ]; then
+            echo "<details><summary>First 20 warnings</summary>" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            grep -E "warning (IL[23]|AOT)" publish.log | head -20 >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Gate mode**: non-blocking (informational). See workflow header for the plan to move to blocking." >> "$GITHUB_STEP_SUMMARY"
+
+      # Only meaningful if publish actually succeeded — otherwise
+      # skip cleanly instead of failing.
+      - name: Run the AOT-published binary
+        if: steps.publish.outcome == 'success'
+        run: |
+          bin=publish/Wolfgang.Etl.DbClient.Example.AotSmoke
+          if [ ! -x "$bin" ]; then
+            echo "::warning::AOT-published binary not found at $bin — publish output layout may have changed."
+            exit 0
+          fi
+          "$bin"
+
+      - name: Upload publish log
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: aot-smoke-publish-log
+          path: publish.log
+          retention-days: 30

--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -45,6 +45,7 @@
     <Project Path="examples/Wolfgang.Etl.DbClient.Example/Wolfgang.Etl.DbClient.Example.csproj" />
     <Project Path="examples/Wolfgang.Etl.DbClient.Example.AutoSql/Wolfgang.Etl.DbClient.Example.AutoSql.csproj" />
     <Project Path="examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction.csproj" />
+    <Project Path="examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj" />

--- a/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Program.cs
@@ -1,0 +1,119 @@
+// AOT / trim smoke consumer for Wolfgang.Etl.DbClient.
+//
+// This project is published with <PublishAot>true</PublishAot> +
+// <PublishTrimmed>true</PublishTrimmed>. The point is to surface
+// which library surfaces the trimmer and AOT compiler can't see
+// through — Dapper's reflection-driven QueryAsync<T>, attribute
+// discovery on TRecord types, dynamic generic instantiation.
+//
+// The `aot-smoke` workflow captures IL2xxx / AOT0xxx / IL3xxx
+// warnings from `dotnet publish` and reports them. It is
+// informational (non-blocking) today because Dapper 2.1.66 has
+// known trim/AOT gaps that no consumer can annotate around from
+// the outside. Blocking-mode is a follow-up, tracked in the
+// aot-smoke workflow file.
+
+using System;
+using System.Data.Common;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Wolfgang.Etl.DbClient;
+
+namespace Wolfgang.Etl.DbClient.Example.AotSmoke;
+
+[DbTable("widget")]
+public record Widget
+{
+    [DbColumn("id")]
+    public int Id { get; init; }
+
+    [DbColumn("name")]
+    public string Name { get; init; } = "";
+
+    [DbColumn("price")]
+    public decimal Price { get; init; }
+}
+
+internal static class Program
+{
+    private static async Task<int> Main()
+    {
+        Console.WriteLine("[aot-smoke] Wolfgang.Etl.DbClient AOT + trim smoke");
+        Console.WriteLine("[aot-smoke] Runtime : " + Environment.Version);
+        Console.WriteLine("[aot-smoke] Version : " + typeof(DbExtractor<Widget>).Assembly.GetName().Version);
+
+        // In-memory SQLite so the smoke test needs no external service.
+        // "Shared cache" so extractor + loader can talk to the same store.
+        const string cs = "Data Source=:memory:";
+        await using var conn = new SqliteConnection(cs);
+        await conn.OpenAsync();
+
+        await using (var create = conn.CreateCommand())
+        {
+            create.CommandText = @"
+                CREATE TABLE widget (id INTEGER PRIMARY KEY, name TEXT NOT NULL, price REAL NOT NULL);
+                INSERT INTO widget (id, name, price) VALUES (1, 'sprocket', 1.99), (2, 'flange', 3.49), (3, 'grommet', 0.25);
+            ";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        var extractor = new DbExtractor<Widget>(conn, "SELECT id, name, price FROM widget ORDER BY id");
+        int rowCount = 0;
+        await foreach (var w in extractor.ExtractAsync())
+        {
+            rowCount++;
+            Console.WriteLine("[aot-smoke] extracted: " + w);
+        }
+
+        Console.WriteLine("[aot-smoke] extractor: CurrentItemCount=" + extractor.CurrentItemCount + " CurrentSkippedItemCount=" + extractor.CurrentSkippedItemCount);
+
+        // Loader construction + dry-run: exercise the loader ctor + ISupportDryRun
+        // path without needing to actually mutate the DB.
+        var loader = new DbLoader<Widget>
+        (
+            conn,
+            "INSERT INTO widget (id, name, price) VALUES (@Id, @Name, @Price)"
+        )
+        {
+            IsDryRun = true
+        };
+
+        var toLoad = new[]
+        {
+            new Widget { Id = 4, Name = "washer", Price = 0.10m },
+            new Widget { Id = 5, Name = "bolt", Price = 0.75m }
+        };
+
+        await loader.LoadAsync(ToAsyncEnumerable(toLoad));
+        Console.WriteLine("[aot-smoke] loader: CurrentItemCount=" + loader.CurrentItemCount + " IsDryRun=" + loader.IsDryRun);
+
+        // Attribute discovery — a common trim / AOT problem area for
+        // libraries that route on custom attributes.
+        var tableAttr = typeof(Widget).GetCustomAttributes(typeof(DbTableAttribute), inherit: false).OfType<DbTableAttribute>().FirstOrDefault();
+        Console.WriteLine("[aot-smoke] DbTableAttribute.Name = " + (tableAttr?.Name ?? "<null>"));
+
+        var columnCount = typeof(Widget).GetProperties()
+            .SelectMany(p => p.GetCustomAttributes(typeof(DbColumnAttribute), inherit: false))
+            .Count();
+        Console.WriteLine("[aot-smoke] DbColumnAttribute count on Widget = " + columnCount);
+
+        if (rowCount != 3)
+        {
+            Console.WriteLine("[aot-smoke] FAIL: expected 3 rows, got " + rowCount);
+            return 1;
+        }
+
+        Console.WriteLine("[aot-smoke] OK");
+        return 0;
+
+        static async System.Collections.Generic.IAsyncEnumerable<T> ToAsyncEnumerable<T>(System.Collections.Generic.IEnumerable<T> source)
+        {
+            foreach (var item in source)
+            {
+                yield return item;
+                await Task.Yield();
+            }
+        }
+    }
+}

--- a/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+
+    <!-- The point of this project. Surface trim + AOT warnings at
+         publish time so we know which library surfaces (Dapper
+         reflection, attribute discovery, generic instantiation) will
+         break for a consumer with <PublishAot>true</PublishAot>. -->
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <IsAotCompatible>true</IsAotCompatible>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+
+    <!-- Don't fail the local build on trim/AOT warnings — the aot-smoke
+         workflow captures them and reports; the workflow is
+         informational (see .github/workflows/aot-smoke.yaml comments). -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+
+    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 (transitive via Microsoft.Data.Sqlite)
+         is on GHSA-2m69-gcr7-jv3q with no patched version. Same treatment as
+         the other example projects. This assembly is never published; impact
+         limited to local + CI runs. -->
+    <NoWarn>$(NoWarn);NU1903</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.DbClient\Wolfgang.Etl.DbClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
+    <!-- Microsoft.Data.Sqlite for a real DbConnection to hand to the
+         extractor / loader — no external service needed. -->
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes #143.

Adds a tiny console consumer that exercises \`DbTable\`/\`DbColumn\` attributes, \`DbExtractor.ExtractAsync\`, \`DbLoader.LoadAsync\` (dry-run), and attribute discovery via reflection — against in-memory SQLite so the check needs no external service.

Consumer publishes with \`PublishAot=true\` + \`PublishTrimmed=true\` + \`IsAotCompatible=true\` + \`TrimmerSingleWarn=false\` so every IL2xxx (trim), IL3xxx (single-file), and AOT0xxx warning surfaces per call-site.

**Files:**
- \`examples/Wolfgang.Etl.DbClient.Example.AotSmoke/*\` — net10.0 console + Sqlite for a real \`DbConnection\`. Builds clean today.
- \`.github/workflows/aot-smoke.yaml\` — \`pull_request_target\` on \`src/**\`, \`examples/AotSmoke/**\`, the workflow itself; push on main/vNext; workflow_dispatch. Publishes, runs the AOT binary, uploads log, posts a per-category warning summary to the Step Summary tab.
- \`Wolfgang.Etl.DbClient.slnx\` — new project registered under \`/examples/\` (solution-consistency guard + Solution Explorer).

**Gate mode: INFORMATIONAL / NON-BLOCKING today.**

DbClient's runtime path uses Dapper 2.1.66, which has known trim/AOT gaps that no downstream consumer can annotate around from outside the library. Failing PRs on those today would block every merge on issues that need to be solved either by (a) the source generator (#23) covering enough surface that reflection becomes opt-in, or (b) a Dapper release that ships its own annotations. Workflow header spells out the plan to flip to blocking mode once those preconditions are in place.

**Immediate value**: trend + visibility. Every PR gets a warning-count table in the Step Summary so we can see whether we're moving toward or away from AOT-safety.

Touches a protected workflow file (\`.github/workflows/aot-smoke.yaml\`) — admin-bypass merge expected.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>