### PR TITLE
chore(inspectcode): suppress CheckNamespace on IsExternalInit polyfill

### DIFF
--- a/src/Wolfgang.Etl.DbClient.SourceGenerator/IsExternalInit.cs
+++ b/src/Wolfgang.Etl.DbClient.SourceGenerator/IsExternalInit.cs
@@ -1,6 +1,12 @@
 // Polyfill for netstandard2.0 — records use init-only setters, which the C#
 // compiler emits as `[modreq(IsExternalInit)]`. The type exists in
 // netstandard2.1+ / net5.0+; we declare it ourselves for older targets.
+//
+// The C# compiler recognises this type by fully-qualified name, so the
+// namespace MUST be System.Runtime.CompilerServices even though the file
+// lives under Wolfgang.Etl.DbClient.SourceGenerator. Suppress InspectCode's
+// CheckNamespace on this one file only.
+// ReSharper disable once CheckNamespace
 namespace System.Runtime.CompilerServices
 {
     internal static class IsExternalInit { }


### PR DESCRIPTION
First of 3 stacked PRs cleaning up InspectCode findings from a local \`jb inspectcode\` run against vNext (2026-07-13).

7 findings total, 3 categories:
- **(this PR)** 1× CheckNamespace false-positive on the netstandard2.0 records polyfill.
- 2× stacked PR — 3× RedundantUsingDirective across 2 files.
- 3× stacked PR — 3× UnusedAutoPropertyAccessor.Global on a reflection-consumed record.

## This PR

InspectCode flagged \`src/Wolfgang.Etl.DbClient.SourceGenerator/IsExternalInit.cs\` — namespace \`System.Runtime.CompilerServices\` doesn't match the file's on-disk location. That's intentional: the C# compiler recognises \`IsExternalInit\` by fully-qualified name, so the polyfill MUST live in that namespace regardless of where its source file sits (standard netstandard2.0 records-with-init pattern).

Fixed with a targeted \`// ReSharper disable once CheckNamespace\` above the namespace declaration + a code comment explaining why the namespace is fixed. No behaviour change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>