### PR TITLE
chore(inspectcode): remove 3 redundant using directives

### DIFF
--- a/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Program.cs
@@ -14,11 +14,9 @@
 // aot-smoke workflow file.
 
 using System;
-using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
-using Wolfgang.Etl.DbClient;
 
 namespace Wolfgang.Etl.DbClient.Example.AotSmoke;
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/CoverageBackfillTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/CoverageBackfillTests.cs
@@ -3,7 +3,6 @@
 // pre-release scan; this file brings them above the per-assembly gate without
 // changing production behavior.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Microsoft.Data.Sqlite;


### PR DESCRIPTION
Second of 3 stacked InspectCode-cleanup PRs. Base: [#242](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/242) (retarget to vNext after #242 merges).

Removes three genuinely-unused \`using\` directives InspectCode flagged on vNext:

- \`examples/…/AotSmoke/Program.cs\`
  - \`using System.Data.Common;\` — no \`DbConnection\`/\`DbCommand\`/\`DbTransaction\` referenced by name; the code uses \`SqliteConnection\` + generic \`DbExtractor<T>\`/\`DbLoader<T>\` which don't require the parent namespace.
  - \`using Wolfgang.Etl.DbClient;\` — redundant because the file's own namespace \`Wolfgang.Etl.DbClient.Example.AotSmoke\` implicitly imports its parents.
- \`tests/…/Tests.Unit/CoverageBackfillTests.cs\`
  - \`using System;\` — no bare System types referenced.

**Verified**: \`dotnet build --no-restore -c Release\` — 0 warnings, 0 errors.

**Test-code note** (per \`feedback_test_changes_need_approval.md\`): the CoverageBackfillTests.cs change is a single \`using\` deletion; no test method or assertion touched.

Third stacked PR follows: \`[UsedImplicitly]\` on the \`Widget\` record in AotSmoke to silence the three UnusedAutoPropertyAccessor.Global findings on Dapper-reflection-consumed properties.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>