### PR TITLE
chore(inspectcode): [UsedImplicitly] Widget record in AotSmoke consumer

### DIFF
--- a/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Program.cs
@@ -23,12 +23,12 @@ namespace Wolfgang.Etl.DbClient.Example.AotSmoke;
 
 // Widget's getters are read by Dapper's reflection-driven row
 // materializer inside DbExtractor.ExtractAsync — invisible to
-// static analysis. `[UsedImplicitly(WithMembers)]` matches the
-// convention the rest of this repo uses for reflection-consumed
-// surfaces (see: DbClient's own [PublicAPI]/[UsedImplicitly]
-// annotations landed in #211).
+// static analysis. Match the 2-arg form the rest of this repo
+// uses for reflection-consumed surfaces (see EmployeeRecord,
+// ProductRecord, InventoryRecord, BenchmarkRecord, and DbClient's
+// own [PublicAPI]/[UsedImplicitly] annotations landed in #211).
 [DbTable("widget")]
-[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+[UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
 public record Widget
 {
     [DbColumn("id")]

--- a/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Program.cs
@@ -16,11 +16,19 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.Data.Sqlite;
 
 namespace Wolfgang.Etl.DbClient.Example.AotSmoke;
 
+// Widget's getters are read by Dapper's reflection-driven row
+// materializer inside DbExtractor.ExtractAsync — invisible to
+// static analysis. `[UsedImplicitly(WithMembers)]` matches the
+// convention the rest of this repo uses for reflection-consumed
+// surfaces (see: DbClient's own [PublicAPI]/[UsedImplicitly]
+// annotations landed in #211).
 [DbTable("widget")]
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 public record Widget
 {
     [DbColumn("id")]


### PR DESCRIPTION
Third and final PR in the InspectCode-cleanup stack. Base: [#243](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/243). Retarget this + #243 to vNext after #242 merges.

InspectCode's \`UnusedAutoPropertyAccessor.Global\` fired on \`Widget.Id\`, \`Widget.Name\`, and \`Widget.Price\` — the record's init-only getters are read by Dapper's reflection-driven row materializer inside \`DbExtractor.ExtractAsync\`, invisible to static analysis.

Fix per the convention already established in this repo (introduced by #211 for the \`src/\` project): annotate the reflection-consumed type with \`[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]\`. \`AotSmoke.csproj\` already references JetBrains.Annotations — no csproj changes.

Added a code comment on \`Widget\` explaining the Dapper tie-in so a future maintainer reading the file doesn't need to hunt through PR history.

**Verified**:
- \`dotnet build -c Release\` on AotSmoke — 0 warnings, 0 errors.
- \`jb inspectcode\` re-run against the full \`.slnx\` after this and its two predecessor PRs (#242, #243) — **0 findings**.

Full stack:
- **#242** — CheckNamespace false-positive suppressed on \`IsExternalInit\` polyfill.
- **#243** — 3 redundant using directives removed across AotSmoke + CoverageBackfillTests.
- **#244** (this) — \`[UsedImplicitly]\` on \`Widget\`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>