### PR TITLE
fix(license-audit): pass allowlist as JSON file, not comma-string

### DIFF
--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -57,22 +57,22 @@ jobs:
       - name: Install nuget-license
         run: dotnet tool install --global nuget-license
 
-      - name: Load allowlist
-        id: allowlist
+      - name: Build allowlist file for nuget-license
         run: |
-          # Flatten JSON array to a comma-separated list for the CLI.
-          list=$(jq -r '.allowed | join(",")' .github/license-allowlist.json)
-          echo "types=$list" >> "$GITHUB_OUTPUT"
+          # nuget-license 4.x wants --allowed-license-types to point at a
+          # JSON file containing a raw array like ["MIT", "Apache-2.0"] —
+          # NOT a comma-separated string (that was the v3 form). Read the
+          # canonical allowlist (.github/license-allowlist.json has a wrapper
+          # object) and emit the raw array the tool wants.
+          jq '.allowed' .github/license-allowlist.json > allowed-licenses.json
+          echo "Allowlist ($(jq 'length' allowed-licenses.json) entries):"
+          cat allowed-licenses.json
 
       - name: Run audit (fail on non-allowlisted)
-        env:
-          ALLOWED_LICENSES: ${{ steps.allowlist.outputs.types }}
         run: |
-          # Pass the allowlist via env + quoted expansion so an entry
-          # containing whitespace can't split into additional CLI args.
           nuget-license \
             --input src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj \
-            --allowed-license-types "$ALLOWED_LICENSES" \
+            --allowed-license-types allowed-licenses.json \
             --output JsonPretty \
             --file-output license-report.json
 


### PR DESCRIPTION
Pre-existing bug in the license-audit workflow from #236 — the workflow has failed on every run since it was introduced. Not caused by any specific PR.

**Root cause**: \`nuget-license\` 4.x (currently installed on the runner as 4.0.14) reads \`--allowed-license-types\` as a **path to a JSON file** containing a raw SPDX-identifier array. The comma-separated-string form (\`--allowed-license-types "MIT,Apache-2.0,…"\`) was the v3 syntax and is silently interpreted as a nonexistent filename → the tool loads an empty allowlist → every package fails the check.

Confirmed by downloading the license-report.json artifact from a failed run: every Apache-2.0 package (AsyncFixer, Dapper, System.Memory, Microsoft.Bcl.AsyncInterfaces, etc.) has a \`ValidationErrors\` entry saying \`License "Apache-2.0" not found in list of supported licenses\` — even though \`Apache-2.0\` is on the allowlist.

**Fix**: use \`jq '.allowed' license-allowlist.json > allowed-licenses.json\` to emit the raw array the tool wants, then pass the file path.

The canonical \`.github/license-allowlist.json\` structure stays as-is (wrapper object with \`$comment\` and \`allowed\` array — the wrapper carries the maintainer-facing metadata a raw array can't). Callers extract the array at CI time.

No changes to which licenses are actually allowed. This is a plumbing fix that unblocks the gate for the first time.

Refs #236 (introduced the workflow with the wrong syntax).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>