### PR TITLE
ci: add Semgrep SAST (free-tier layer complementary to CodeQL) (#131)

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,81 @@
+# Semgrep — SAST layer complementary to CodeQL.
+#
+# CodeQL (`codeql.yaml`) is our OSS-grade baseline. Semgrep adds a second
+# scanner with different rule packs (community C# taint, security-audit,
+# secrets, owasp-top-ten) — the goal is OVERLAPPING signal, not replacing
+# CodeQL. When both agree a finding is real, confidence is higher; when
+# only one flags it, it's usually a false positive worth documenting.
+#
+# Semgrep is free for public repos with no account required. Enterprise
+# SAST (Snyk, Veracode, Fortify, SonarQube Cloud, Checkmarx) is a project-
+# level budget decision — see #131 for that discussion; this workflow is
+# the free-tier baseline.
+#
+# Refs #131.
+
+name: Semgrep SAST
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'examples/**'
+      - '.github/workflows/semgrep.yaml'
+  push:
+    branches: [main, vNext]
+    paths:
+      - 'src/**'
+      - '.github/workflows/semgrep.yaml'
+  schedule:
+    # Weekly Wed 05:37 UTC — catches new rule releases against unchanged code.
+    - cron: '37 5 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write   # required to upload SARIF to Code Scanning
+
+jobs:
+  semgrep:
+    name: Semgrep scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install semgrep (from PyPI, no account required)
+        run: |
+          python -m pip install --user --upgrade "semgrep>=1.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run Semgrep with the community C# security rulepacks
+        # Rule packs cover:
+        #   p/csharp             — general C# lint + security patterns
+        #   p/owasp-top-ten      — OWASP Top-10 categories
+        #   p/security-audit     — cross-language security-audit set
+        #   p/secrets            — hard-coded credentials / API keys
+        # Gate: `--severity=ERROR --error` fails the run on error-severity
+        # findings only. Warning + info findings still upload to Code
+        # Scanning (visible in Security tab) but don't block merge.
+        run: |
+          set -euo pipefail
+          semgrep scan \
+            --config=p/csharp \
+            --config=p/owasp-top-ten \
+            --config=p/security-audit \
+            --config=p/secrets \
+            --sarif \
+            --output=semgrep.sarif \
+            --severity=ERROR \
+            --error \
+            --metrics=off
+
+      - name: Upload SARIF to Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep


### PR DESCRIPTION
Closes the free-tier scope of [Etl-DbClient#131](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/131). CodeQL stays as the OSS-grade baseline; this adds Semgrep as a **second, complementary** scanner so findings can be cross-referenced. When both agree a finding is real, confidence is higher; when only one flags it, it's usually a false positive worth documenting. Strictly additive.

## Why Semgrep specifically

- **Free for public repos, no account required** — installs from PyPI on the runner. No license provisioning, no secrets to manage.
- **Different rule packs than CodeQL** — the two catch overlapping but distinct issue classes (Semgrep's taint patterns for C# are more idiomatic; CodeQL's flow analysis is deeper).
- **SARIF native** → uploads to the Security tab alongside CodeQL results.

Enterprise SAST (Snyk Code, Veracode, Fortify, SonarQube Cloud, Checkmarx One) is a project-level budget decision — [#131](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/131) stays open for that discussion. This PR lands the free-tier baseline that doesn't need any license or account provisioning.

## New file

- **\`.github/workflows/semgrep.yaml\`**
  - Triggers: PR touching \`src/tests/examples\`, push to main/vNext, weekly Wed 05:37 UTC (new rule releases against unchanged code), \`workflow_dispatch\`.
  - Rule packs: \`p/csharp\`, \`p/owasp-top-ten\`, \`p/security-audit\`, \`p/secrets\`.
  - Gate: \`--severity=ERROR --error\` — only error-severity findings block merge. Warning + info still upload to Code Scanning (visible in Security tab) but don't gate. Matches the InspectCode + zizmor gating philosophy.
  - \`--metrics=off\` — no telemetry to Semgrep's server.
  - SHA-pinned actions.

Baseline scan will publish on the first push-to-vNext run after merge; any pre-existing findings triage into false-positive / fixed / accepted-risk buckets in a follow-up.

**Touches a protected workflow file** — admin-bypass merge expected per \`feedback_protected_config_files_guard.md\`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>