### PR TITLE
tests: add Snapshot project — DbCommandBuilder SQL emitter (#140)

### DIFF
--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -56,6 +56,7 @@
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj" />
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.DocExamples/Wolfgang.Etl.DbClient.Tests.DocExamples.csproj" />
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.SourceLink/Wolfgang.Etl.DbClient.Tests.SourceLink.csproj" />
+    <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Wolfgang.Etl.DbClient.Tests.Snapshots.csproj" />
   </Folder>
 </Solution>
 

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -47,6 +47,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Unit" />
+    <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Snapshots" />
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Benchmarks" />
   </ItemGroup>
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Insert_orders_skips_identity_and_notmapped.verified.txt
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Insert_orders_skips_identity_and_notmapped.verified.txt
@@ -1,0 +1,1 @@
+﻿INSERT INTO orders (customer_id, total, placed_utc) VALUES (@CustomerId, @Total, @PlacedUtc)

--- a/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Select_order_lines_composite_key.verified.txt
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Select_order_lines_composite_key.verified.txt
@@ -1,0 +1,1 @@
+﻿SELECT order_id AS OrderId, line_no AS LineNo, sku AS Sku, qty AS Qty FROM order_lines

--- a/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Select_orders.verified.txt
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Select_orders.verified.txt
@@ -1,0 +1,1 @@
+﻿SELECT id AS Id, customer_id AS CustomerId, total AS Total, placed_utc AS PlacedUtc FROM orders

--- a/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Update_order_lines_where_by_composite_key.verified.txt
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Update_order_lines_where_by_composite_key.verified.txt
@@ -1,0 +1,1 @@
+﻿UPDATE order_lines SET sku = @Sku, qty = @Qty WHERE order_id = @OrderId AND line_no = @LineNo

--- a/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Update_orders_where_by_identity_key.verified.txt
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Snapshots/SqlSnapshotTests.Update_orders_where_by_identity_key.verified.txt
@@ -1,0 +1,1 @@
+﻿UPDATE orders SET customer_id = @CustomerId, total = @Total, placed_utc = @PlacedUtc WHERE id = @Id

--- a/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/SqlSnapshotTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/SqlSnapshotTests.cs
@@ -1,0 +1,106 @@
+// Snapshot tests over DbCommandBuilder's SQL emitter.
+//
+// Targeted unit tests already assert the shape of individual clauses; these
+// lock in the WHOLE STRING for a set of representative record shapes so a
+// refactor that accidentally changes formatting (extra whitespace, reordered
+// parameter names, changed quoting style) fails the PR with a visible diff.
+//
+// First run of any test writes a `<name>.received.txt` alongside the
+// `<name>.verified.txt` snapshot. Review the .received file, and if the
+// change is intentional, replace the .verified file with it. The pre-
+// commit and CI runs both fail if a `.received.txt` is present.
+//
+// Snapshot files land under tests/.../Snapshots/ per the #140 AC.
+//
+// Refs #140.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+using VerifyTests;
+using VerifyXunit;
+using Wolfgang.Etl.DbClient;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Snapshots;
+
+[ExcludeFromCodeCoverage]
+[UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+[Table("orders")]
+internal sealed class OrderRecord
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("customer_id")]
+    public int CustomerId { get; set; }
+
+    [Column("total")]
+    public decimal Total { get; set; }
+
+    [Column("placed_utc")]
+    public DateTime PlacedUtc { get; set; }
+
+    // NotMapped: verifies the builder skips this column in SELECT / INSERT
+    // / UPDATE without leaving artefacts in the generated SQL.
+    [NotMapped]
+    public string DisplayName { get; set; } = "";
+}
+
+[ExcludeFromCodeCoverage]
+[UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+[Table("order_lines")]
+internal sealed class OrderLineRecord
+{
+    // Composite key: verifies the builder handles multi-column WHERE
+    // clauses on UPDATE without regressing to single-key SQL.
+    [Key]
+    [Column("order_id")]
+    public int OrderId { get; set; }
+
+    [Key]
+    [Column("line_no")]
+    public int LineNo { get; set; }
+
+    [Column("sku")]
+    public string Sku { get; set; } = "";
+
+    [Column("qty")]
+    public int Qty { get; set; }
+}
+
+public class SqlSnapshotTests
+{
+    // Redirect Verify's snapshot files into a Snapshots/ subfolder to
+    // match #140's AC. Configured once via ModuleInitializer.
+    [ModuleInitializer]
+    public static void Init() => Verifier.DerivePathInfo(
+        (sourceFile, _, type, method) =>
+            new PathInfo(
+                directory: Path.Combine(Path.GetDirectoryName(sourceFile) ?? ".", "Snapshots"),
+                typeName: type.Name,
+                methodName: method.Name));
+
+    [Fact]
+    public Task Select_orders() => Verifier.Verify(DbCommandBuilder.BuildSelect<OrderRecord>());
+
+    [Fact]
+    public Task Insert_orders_skips_identity_and_notmapped() =>
+        Verifier.Verify(DbCommandBuilder.BuildInsert<OrderRecord>());
+
+    [Fact]
+    public Task Update_orders_where_by_identity_key() =>
+        Verifier.Verify(DbCommandBuilder.BuildUpdate<OrderRecord>());
+
+    [Fact]
+    public Task Select_order_lines_composite_key() =>
+        Verifier.Verify(DbCommandBuilder.BuildSelect<OrderLineRecord>());
+
+    [Fact]
+    public Task Update_order_lines_where_by_composite_key() =>
+        Verifier.Verify(DbCommandBuilder.BuildUpdate<OrderLineRecord>());
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Wolfgang.Etl.DbClient.Tests.Snapshots.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Wolfgang.Etl.DbClient.Tests.Snapshots.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- net10.0 only: Verify.Xunit needs net6+; the SQL-shape and
+         generator-output-shape checks are TFM-agnostic (they don't
+         depend on runtime BCL versioning), so running once is enough. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;CA1707;CA1062</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.DbClient\Wolfgang.Etl.DbClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" allowedVersions="(,3.0.0)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Verify.Xunit" Version="27.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes [Etl-DbClient#140](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/140).

Adds \`tests/Wolfgang.Etl.DbClient.Tests.Snapshots/\` — a net10.0-only xunit project using the [Verify](https://github.com/VerifyTests/Verify) framework. Snapshot-tests the SQL emitted by \`DbCommandBuilder\` for a representative set of record shapes so accidental format drift (extra whitespace, reordered parameter names, changed quoting style) fails the PR with a visible diff.

## Coverage

Five snapshot targets, one per shape class:

| Test | What it locks in |
|---|---|
| \`Select_orders\` | Baseline SELECT with column→property AS aliasing |
| \`Insert_orders_skips_identity_and_notmapped\` | \`[Key][Identity]\` column + \`[NotMapped]\` property both omitted |
| \`Update_orders_where_by_identity_key\` | WHERE clause on identity key |
| \`Select_order_lines_composite_key\` | Composite-key record, all key columns in SELECT |
| \`Update_order_lines_where_by_composite_key\` | WHERE with \`AND\` across both composite-key columns |

## Design

- **Snapshots directory**: \`ModuleInitializer\` hooks \`Verifier.DerivePathInfo\` to redirect snapshots into a \`Snapshots/\` subfolder per the AC.
- **Test-local record types** (\`OrderRecord\`, \`OrderLineRecord\`): a schema tweak in \`Tests.Unit\`'s \`PersonRecord\` can't accidentally invalidate the snapshots.
- **Verify.Xunit 27.0.0**: multi-tfm but net6+ only — hence net10.0-only target here, not the full net462→net10 matrix Tests.Unit runs.

## Wiring

- **Runtime csproj**: added \`InternalsVisibleTo\` for \`Wolfgang.Etl.DbClient.Tests.Snapshots\` alongside the existing entries. \`DbCommandBuilder\` is \`internal static\` — the snapshot tests need direct call access.
- **\`.slnx\`**: new project registered under \`/tests/\`.
- **\`.gitignore\`**: no change — the repo already has \`*.received.*\` covering Verify's iteration files.

## Verified locally

5/5 tests passed after the standard first-run promotion (Verify writes \`.received.txt\` on first run → dev reviews → promotes to \`.verified.txt\` → subsequent runs diff).

**Test-code note** (per \`feedback_test_changes_need_approval.md\`): entirely a new test project, no changes to existing tests. Runtime csproj gains one \`InternalsVisibleTo\` entry which is safe and additive.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>