### PR TITLE
ci: add SLSA build-provenance attestation + consumer verify docs (#138)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1015,6 +1015,35 @@ jobs:
     with:
       version: ${{ github.event.release.tag_name }}
 
+  # SLSA build provenance attestation — proves the .nupkg / .snupkg
+  # attached to the Release were built by THIS workflow at THIS commit,
+  # signed via GitHub's OIDC identity with Sigstore's keyless CA.
+  # Consumers can verify with `gh attestation verify <.nupkg> --owner
+  # Chris-Wolfgang --repo Etl-DbClient` (see SECURITY.md).
+  # Refs #138.
+  attest-build-provenance:
+    name: Attest build provenance (SLSA)
+    needs: [pack-and-validate, publish-nuget]
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # OIDC token for Sigstore keyless signing
+      contents: read
+      attestations: write   # required to write attestation to the repo
+    steps:
+      - name: Download packed artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nuget-packages
+          path: ./packages
+
+      - name: Attest .nupkg / .snupkg provenance
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v3.0.0
+        with:
+          subject-path: |
+            packages/*.nupkg
+            packages/*.snupkg
+
   # Attach NuGet packages and coverage report to the GitHub Release page
   update-release-artifacts:
     name: Attach Artifacts to Release

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,35 @@ Facts a maintainer would need at 2am if the release identity is compromised. Gen
 - **Owner**: @Chris-Wolfgang.
 - **Downstream consumers**: none known inside the Wolfgang.* org at time of writing; the package is public on nuget.org, so unknown downstream consumers may exist. Re-check via `dotnet-outdated`, GitHub code-search, and the NuGet package's `Used By` dependents list before communicating during an incident.
 - **Package coordinates for unlisting**: `Wolfgang.Etl.DbClient` on nuget.org — https://www.nuget.org/packages/Wolfgang.Etl.DbClient/.
+
+## Supply-chain verification (consumer-side)
+
+Every published `Wolfgang.Etl.DbClient` NuGet has:
+
+1. **A CycloneDX SBOM** (`Wolfgang.Etl.DbClient.bom.json`) attached to the GitHub Release, listing every direct + transitive dependency at release time.
+2. **A SLSA-3 build provenance attestation** signed by Sigstore's keyless CA using GitHub's OIDC identity. The attestation proves the `.nupkg` + `.snupkg` were built by `.github/workflows/release.yaml` at a specific commit SHA — no local build was substituted, no bit was flipped between build and publish.
+
+To verify a package you downloaded from nuget.org actually came from this repo's release pipeline:
+
+```bash
+# 1. Download the package from nuget.org (or your local NuGet feed).
+curl -sSL -o Wolfgang.Etl.DbClient.<version>.nupkg \
+  "https://api.nuget.org/v3-flatcontainer/wolfgang.etl.dbclient/<version>/wolfgang.etl.dbclient.<version>.nupkg"
+
+# 2. Verify the SLSA attestation.
+gh attestation verify Wolfgang.Etl.DbClient.<version>.nupkg \
+  --owner Chris-Wolfgang \
+  --repo Etl-DbClient
+```
+
+The `gh attestation verify` command:
+- Fetches the attestation from Sigstore's public transparency log.
+- Confirms the attestation was signed by `Chris-Wolfgang/Etl-DbClient`'s OIDC identity (GitHub-verified, unforgeable).
+- Confirms the workflow was `.github/workflows/release.yaml`.
+- Confirms the artifact's SHA-256 matches the one recorded at build time.
+
+Any mismatch = the file you downloaded didn't come from a legitimate release, or was tampered with in transit / on your local cache.
+
+For the SBOM, download the `Wolfgang.Etl.DbClient.bom.json` asset from the GitHub Release and validate with any CycloneDX-aware SBOM tooling (`cyclonedx-cli`, Grype, Trivy, GitHub's Dependency Graph, etc.).
+
+Refs [#138](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/138).


### PR DESCRIPTION
Second half of the supply-chain hardening AC from [Etl-DbClient#138](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/138).

**Already in the tree** (from prior work): SBOM generation is wired into \`pack-and-validate\` — every packed \`.nupkg\` gets a matching \`Wolfgang.Etl.DbClient.bom.json\` via \`dotnet CycloneDX\`, attached to the GitHub Release.

**This PR adds:**

1. **\`attest-build-provenance\` job** in \`release.yaml\`. Runs after \`publish-nuget\`. Downloads the packed \`.nupkg\` + \`.snupkg\` and calls \`actions/attest-build-provenance@v3\`. The action:
   - Signs each artifact via Sigstore's Fulcio keyless CA using GitHub's OIDC identity.
   - Records the attestation in Sigstore's public Rekor transparency log.
   - No secrets, no long-lived keys.
   - permissions: \`id-token: write\` (OIDC) + \`attestations: write\` (record).
2. **\`SECURITY.md\` — new "Supply-chain verification (consumer-side)" section**. Spells out what each artifact carries and the exact \`gh attestation verify …\` recipe consumers use to prove the chain from GitHub commit → published NuGet is intact. Any mismatch = tampering.

## Not in this PR

- **NuGet package signing** via a code-signing certificate. Deferred: needs a cost + trust-authority decision (Sigstore support in \`nuget verify\` is still limited; a paid cert has renewal + compromise-recovery cost). Tracked as follow-up on [#138](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/138).

## Verification demo (for a future release)

\`\`\`bash
curl -sSL -o pkg.nupkg "https://api.nuget.org/v3-flatcontainer/wolfgang.etl.dbclient/<v>/wolfgang.etl.dbclient.<v>.nupkg"
gh attestation verify pkg.nupkg --owner Chris-Wolfgang --repo Etl-DbClient
\`\`\`

**Touches a protected workflow file** — admin-bypass merge expected per \`feedback_protected_config_files_guard.md\`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>