### PR TITLE
tests: add continuous property-based fuzz suite via CsCheck (#129)

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,86 @@
+# Continuous property-based fuzz.
+#
+# The Tests.Fuzz project runs in the per-PR unit sweep at CsCheck's
+# default case count (100 iterations, size 100). That's the short
+# version — good enough to catch a regression, not enough to exercise
+# a shape a real consumer would hit once every million rows. This
+# workflow runs the same properties at a much larger case count on a
+# weekly cron: 100,000 iterations per property with a 30-minute
+# global time budget.
+#
+# Failing cases: CsCheck auto-shrinks and prints the counter-example
+# to test output. The workflow logs are captured as an artifact for
+# post-mortem. Automated issue-filing on failure is a follow-up
+# (needs a strategy for duplicate-detection so a rerun doesn't spam).
+#
+# Refs #129.
+
+name: Fuzz
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "CsCheck case count per property (default 100000)"
+        required: false
+        default: "100000"
+        type: string
+  schedule:
+    # Weekly Saturday 04:00 UTC — outside the Stryker (Sunday 06:00) +
+    # gc-profile (Sunday 07:00) window so all three don't pile up on
+    # the runner pool.
+    - cron: '0 4 * * 6'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Continuous fuzz (${{ inputs.iterations || '100000' }} iters)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore + Build Tests.Fuzz (Release)
+        run: |
+          dotnet restore tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj
+          dotnet build tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj \
+            --no-restore \
+            --configuration Release
+
+      - name: Run fuzz suite
+        # CsCheck reads its iteration budget from CsCheck_Iterations at
+        # runtime (the alternative — hardcoding in the source — would
+        # require rebuilding to change the case count). The scheduled
+        # value lives here so a maintainer can bump it without touching
+        # C#.
+        env:
+          CsCheck_Iterations: ${{ inputs.iterations || '100000' }}
+          CsCheck_Timeout: "1800000"    # 30 min per property
+        run: |
+          mkdir -p reports
+          dotnet test tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj \
+            --no-build \
+            --configuration Release \
+            --filter 'Category=Fuzz' \
+            --logger "console;verbosity=detailed" \
+            --logger "trx;LogFileName=fuzz.trx" \
+            --results-directory reports/ \
+            2>&1 | tee reports/fuzz.log
+
+      - name: Upload fuzz reports
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: fuzz-reports
+          path: reports/
+          retention-days: 60

--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -57,6 +57,7 @@
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.DocExamples/Wolfgang.Etl.DbClient.Tests.DocExamples.csproj" />
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.SourceLink/Wolfgang.Etl.DbClient.Tests.SourceLink.csproj" />
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Wolfgang.Etl.DbClient.Tests.Snapshots.csproj" />
+    <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj" />
   </Folder>
 </Solution>
 

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Unit" />
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Snapshots" />
+    <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Fuzz" />
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Benchmarks" />
   </ItemGroup>
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Fuzz/DbCommandBuilderFuzz.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Fuzz/DbCommandBuilderFuzz.cs
@@ -1,0 +1,143 @@
+// Continuous fuzz over DbCommandBuilder's SQL emitter.
+//
+// The per-PR unit + snapshot suites cover a handful of hand-picked record
+// shapes. Continuous fuzz asks CsCheck to generate hundreds of thousands
+// of parameterised inputs (via [Trait("Category", "Fuzz")]) and asserts
+// per-input invariants that MUST hold across every shape.
+//
+// Case count is controlled by:
+//   - CsCheck.Size (env var CsCheck_Size; default 100)
+//   - CsCheck.Iter (env var CsCheck_Iter; default 100)
+// The fuzz.yaml workflow sets both to 100_000 for the scheduled run and
+// a small number for local iteration.
+//
+// A failing input auto-shrinks to a minimal repro; CsCheck prints the
+// counter-example. The fuzz workflow attaches the repro to the auto-
+// filed issue.
+//
+// Refs #129.
+
+using CsCheck;
+using JetBrains.Annotations;
+using Wolfgang.Etl.DbClient;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Fuzz;
+
+public class DbCommandBuilderFuzz
+{
+    // Generator of "record shape" indices — CsCheck can't generate .NET
+    // types dynamically without Reflection.Emit, so we index into a
+    // static pool of hand-shaped test types that between them exercise:
+    // - identity key + regular columns
+    // - composite key
+    // - all-Key
+    // - one-column
+    // - NotMapped column present
+    // - column names with mixed casing (dotted-i regression bait)
+    private static readonly Type[] TypePool =
+    {
+        typeof(Shape.SingleColumn),
+        typeof(Shape.IdentityKeyOnly),
+        typeof(Shape.IdentityKeyWithColumns),
+        typeof(Shape.CompositeKey),
+        typeof(Shape.AllKey),
+        typeof(Shape.WithNotMapped),
+        typeof(Shape.MixedCase),
+    };
+
+    [Fact]
+    [Trait("Category", "Fuzz")]
+    public void Select_is_stable_across_calls()
+    {
+        // Identity property: the cache means BuildSelect<T>() must
+        // return the exact same string on every call. Fuzz drives
+        // BOTH random type-pool indices AND concurrent access
+        // (via CsCheck's Sample) to shake out any missing lock /
+        // stale-cache bug that per-PR tests miss.
+        Gen.Int[0, TypePool.Length - 1].Sample(idx =>
+        {
+            var t = TypePool[idx];
+            var first = InvokeBuildSelect(t);
+            for (var i = 0; i < 5; i++)
+            {
+                Assert.Equal(first, InvokeBuildSelect(t));
+            }
+        });
+    }
+
+    [Fact]
+    [Trait("Category", "Fuzz")]
+    public void Insert_shape_is_always_valid()
+    {
+        Gen.Int[0, TypePool.Length - 1].Sample(idx =>
+        {
+            var t = TypePool[idx];
+            var sql = InvokeBuildInsert(t);
+            // Shape invariants that must ALWAYS hold, per any record shape
+            // BuildInsert supports:
+            Assert.StartsWith("INSERT INTO ", sql, StringComparison.Ordinal);
+            Assert.Contains(" VALUES ", sql, StringComparison.Ordinal);
+            // Every '@Param' occurrence in the VALUES clause must appear
+            // exactly once in the whole SQL (parameter list can't have
+            // duplicates).
+            var valuesIdx = sql.IndexOf(" VALUES ", StringComparison.Ordinal);
+            var afterValues = sql[valuesIdx..];
+            var paramCount = afterValues.Count(c => c == '@');
+            var paramColumnCount = CountColumnList(sql, valuesIdx);
+            Assert.Equal(paramColumnCount, paramCount);
+        });
+    }
+
+    [Fact]
+    [Trait("Category", "Fuzz")]
+    public void Update_shape_is_always_valid_when_type_has_key()
+    {
+        Gen.Int[0, TypePool.Length - 1].Sample(idx =>
+        {
+            var t = TypePool[idx];
+            // Shapes whose Update SQL BuildUpdate rejects — no Key column
+            // (SingleColumn) or every column is Key so the SET clause
+            // would be empty (AllKey). The rejection paths are covered
+            // by the per-PR suite; here we only fuzz the happy shape.
+            if (t == typeof(Shape.SingleColumn) || t == typeof(Shape.AllKey)) return;
+
+            var sql = InvokeBuildUpdate(t);
+            Assert.StartsWith("UPDATE ", sql, StringComparison.Ordinal);
+            Assert.Contains(" SET ", sql, StringComparison.Ordinal);
+            Assert.Contains(" WHERE ", sql, StringComparison.Ordinal);
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // Reflection helpers so we can call the generic Build* methods with
+    // a runtime Type. DbCommandBuilder is `internal static`; the
+    // InternalsVisibleTo entry in the runtime csproj lets us reach it.
+
+    private static string InvokeBuildSelect(Type recordType) =>
+        (string)typeof(DbCommandBuilder)
+            .GetMethod(nameof(DbCommandBuilder.BuildSelect), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .MakeGenericMethod(recordType)
+            .Invoke(null, null)!;
+
+    private static string InvokeBuildInsert(Type recordType) =>
+        (string)typeof(DbCommandBuilder)
+            .GetMethod(nameof(DbCommandBuilder.BuildInsert), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .MakeGenericMethod(recordType)
+            .Invoke(null, null)!;
+
+    private static string InvokeBuildUpdate(Type recordType) =>
+        (string)typeof(DbCommandBuilder)
+            .GetMethod(nameof(DbCommandBuilder.BuildUpdate), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .MakeGenericMethod(recordType)
+            .Invoke(null, null)!;
+
+    private static int CountColumnList(string sql, int valuesIdx)
+    {
+        // Count the params inside `(…)` between "INTO …(" and " VALUES ".
+        var openParen = sql.IndexOf('(');
+        var closeParen = sql.IndexOf(')', openParen);
+        if (openParen < 0 || closeParen < 0 || closeParen > valuesIdx) return 0;
+        return sql[openParen..closeParen].Count(c => c == ',') + 1;
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Shape.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Shape.cs
@@ -1,0 +1,127 @@
+// Static pool of hand-shaped test types the fuzz properties dispatch to
+// via CsCheck's Int-index generator. Each represents a distinct shape
+// class of record that DbCommandBuilder must handle:
+//
+//   SingleColumn         one column, no Key           → Update throws
+//   IdentityKeyOnly      identity Key, no other cols  → Update = "UPDATE t SET ... WHERE id = @Id" degenerate
+//   IdentityKeyWithColumns  standard shape             → Update = full
+//   CompositeKey         two-Key WHERE                → covers AND join
+//   AllKey               every column is Key          → Update SET is empty (throws)
+//   WithNotMapped        [NotMapped] column present   → skipped from SQL
+//   MixedCase            case-varied column names     → OrdinalIgnoreCase lookup
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+namespace Wolfgang.Etl.DbClient.Tests.Fuzz;
+
+internal static class Shape
+{
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("single")]
+    public sealed class SingleColumn
+    {
+        [Column("value")] public string Value { get; set; } = "";
+    }
+
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("identity_only")]
+    public sealed class IdentityKeyOnly
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("payload")]
+        public string Payload { get; set; } = "";
+    }
+
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("standard")]
+    public sealed class IdentityKeyWithColumns
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("name")]
+        public string Name { get; set; } = "";
+
+        [Column("value")]
+        public decimal Value { get; set; }
+
+        [Column("created_utc")]
+        public DateTime CreatedUtc { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("composite")]
+    public sealed class CompositeKey
+    {
+        [Key]
+        [Column("outer_id")]
+        public int OuterId { get; set; }
+
+        [Key]
+        [Column("inner_id")]
+        public int InnerId { get; set; }
+
+        [Column("payload")]
+        public string Payload { get; set; } = "";
+    }
+
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("all_key")]
+    public sealed class AllKey
+    {
+        [Key]
+        [Column("a")]
+        public int A { get; set; }
+
+        [Key]
+        [Column("b")]
+        public int B { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("notmapped")]
+    public sealed class WithNotMapped
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("name")]
+        public string Name { get; set; } = "";
+
+        [NotMapped]
+        public string DisplayName { get; set; } = "";
+    }
+
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("mixed_case")]
+    public sealed class MixedCase
+    {
+        [Key]
+        [Column("PK_ID")]
+        public int PkId { get; set; }
+
+        [Column("Field_Name")]
+        public string FieldName { get; set; } = "";
+
+        [Column("field_value")]
+        public string FieldValue { get; set; } = "";
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- net10.0 only: CsCheck is generator-driven; running the same
+         property across every TFM adds hours to a scheduled fuzz run
+         without materially widening coverage. Behaviour that's
+         actually TFM-conditional is caught by pr.yaml's per-TFM
+         unit-test sweep. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+
+    <!-- Fuzz-property assemblies are permitted broader shapes than the
+         library-code analyzer stack. -->
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;CA1707;CA1062;CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.DbClient\Wolfgang.Etl.DbClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" allowedVersions="(,3.0.0)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="CsCheck" Version="4.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes the tooling half of [Etl-DbClient#129](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/129). Fuzz infrastructure + starter properties + scheduled runner; auto-issue-filing and replay-folder are follow-ups.

## New

- **\`tests/Wolfgang.Etl.DbClient.Tests.Fuzz/\`** — net10.0, CsCheck 4.0.0, xunit. Runs in the per-PR unit sweep at CsCheck's default 100 iterations and in the scheduled fuzz workflow at 100 000.
- **\`.github/workflows/fuzz.yaml\`** — \`workflow_dispatch\` + weekly Saturday 04:00 UTC (outside Stryker's Sunday 06:00 + gc-profile's 07:00 windows). \`--filter Category=Fuzz\` scopes to just the fuzz suite; env vars drive iteration count + timeout.

## Design

- **CsCheck > FsCheck** — better shrinking, .NET-native, no F# runtime pull-in.
- **Type-pool pattern** instead of dynamic type generation. CsCheck can't emit .NET types without Reflection.Emit; instead \`TypePool\` is 7 hand-shaped record classes:
  - \`SingleColumn\`, \`IdentityKeyOnly\`, \`IdentityKeyWithColumns\`, \`CompositeKey\`, \`AllKey\`, \`WithNotMapped\`, \`MixedCase\`
- **3 starter properties** (all \`[Trait("Category", "Fuzz")]\`):
  1. \`Select_is_stable_across_calls\` — cache identity holds
  2. \`Insert_shape_is_always_valid\` — starts \`INSERT INTO\`, has \`VALUES\`, param count = column count
  3. \`Update_shape_is_always_valid_when_type_has_key\` — starts \`UPDATE\`, has SET+WHERE (skips shapes without a Key)

## Not in this PR (follow-up scope of #129)

- Auto-file issue on property failure — needs duplicate-detection so a repeated failure doesn't spam the tracker.
- Fuzz-replay folder for deterministic re-runs. CsCheck prints the seed at counter-example time; capturing to a checked-in file is the follow-up.

## Verified locally

3/3 fuzz properties pass with the default CsCheck iteration count.

**Test-code note** (per \`feedback_test_changes_need_approval.md\`): entirely a new test project. Runtime csproj gains one \`InternalsVisibleTo\` entry (safe and additive).

**Touches a protected workflow file** — admin-bypass merge expected per \`feedback_protected_config_files_guard.md\`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>