### PR TITLE
tests: add Coyote systematic-concurrency suite for DbCommandBuilder cache (#137)

### DIFF
--- a/.github/workflows/concurrency.yaml
+++ b/.github/workflows/concurrency.yaml
@@ -1,0 +1,75 @@
+# Coyote systematic-concurrency testing.
+#
+# The Tests.Concurrency project drives DbCommandBuilder's cache (and,
+# over time, other race-prone public APIs) through Microsoft Coyote's
+# TestingEngine. On a per-PR run the iteration budget is small
+# (default 100); the scheduled workflow bumps it to 10 000 so each
+# invariant is checked under a much wider set of interleavings.
+#
+# Refs #137.
+
+name: Concurrency (Coyote)
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Coyote scheduling iterations per property (default 10000)"
+        required: false
+        default: "10000"
+        type: string
+  schedule:
+    # Weekly Sunday 09:00 UTC. Stryker 06:00, gc-profile 07:00, then
+    # a two-hour gap, then this run. Prevents runner-pool contention
+    # if any of the earlier weeklies overrun.
+    - cron: '0 9 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  concurrency:
+    name: Coyote (${{ inputs.iterations || '10000' }} iters)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj
+          dotnet build tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj \
+            --no-restore \
+            --configuration Release
+
+      - name: Run Coyote concurrency suite
+        # Iteration count is read from an env var at test time; runtime-
+        # configurable without a rebuild.
+        env:
+          COYOTE_ITERATIONS: ${{ inputs.iterations || '10000' }}
+        run: |
+          mkdir -p reports
+          dotnet test tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj \
+            --no-build \
+            --configuration Release \
+            --filter 'Category=Concurrency' \
+            --logger "console;verbosity=detailed" \
+            --logger "trx;LogFileName=concurrency.trx" \
+            --results-directory reports/ \
+            2>&1 | tee reports/concurrency.log
+
+      - name: Upload concurrency reports
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: concurrency-reports
+          path: reports/
+          retention-days: 60

--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -61,6 +61,7 @@
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.SourceLink/Wolfgang.Etl.DbClient.Tests.SourceLink.csproj" />
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Wolfgang.Etl.DbClient.Tests.Snapshots.csproj" />
     <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj" />
+    <Project Path="tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj" />
   </Folder>
 </Solution>
 

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -49,6 +49,7 @@
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Unit" />
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Snapshots" />
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Fuzz" />
+    <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Tests.Concurrency" />
     <InternalsVisibleTo Include="Wolfgang.Etl.DbClient.Benchmarks" />
   </ItemGroup>
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/DbCommandBuilderCacheConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/DbCommandBuilderCacheConcurrencyTests.cs
@@ -1,0 +1,147 @@
+// Coyote systematic-testing driver for DbCommandBuilder's SQL cache.
+//
+// The cache is a ConcurrentDictionary<Type, TypeMetadata>. Concurrent
+// consumers of the same TRecord race each other on first access — the
+// invariant is: every thread ends up with the SAME SQL string (equal by
+// value; ideally reference-equal via the cache). Coyote's scheduler
+// explores thousands of interleavings of those concurrent calls,
+// covering paths that a "run this test 10 000 times" stress test would
+// never reproduce reliably.
+//
+// Coyote's engine works without IL rewriting for tests that use
+// `TestingEngine.Create(config, action).Run()` directly — the engine
+// takes control of the scheduler for the duration of `action`. That's
+// what these xunit facts do. If we ever want the deeper systematic
+// coverage that rewriting provides (every `await` intercepted, not
+// just the ones inside our test action), a follow-up can add a
+// coyote-rewrite step to the CI build pipeline.
+//
+// Refs #137.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using Microsoft.Coyote;
+using Microsoft.Coyote.SystematicTesting;
+using Wolfgang.Etl.DbClient;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Concurrency;
+
+[ExcludeFromCodeCoverage]
+[UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+[Table("concurrent_probe")]
+internal sealed class ConcurrentProbe
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("value")]
+    public string Value { get; set; } = "";
+}
+
+public class DbCommandBuilderCacheConcurrencyTests
+{
+    // Iteration budget for the schedule-exploration engine. Low on PR,
+    // higher on the scheduled workflow (env override picked up below).
+    private static int Iterations =>
+        int.TryParse(Environment.GetEnvironmentVariable("COYOTE_ITERATIONS"), out var n) && n > 0
+            ? n
+            : 100;
+
+    /// <summary>
+    /// Under any interleaving of N concurrent BuildSelect callers on the
+    /// same TRecord, every caller must observe the same SQL string.
+    /// A missing lock / race in the cache would surface as one caller
+    /// getting a partially-built or stale-metadata version.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public void BuildSelect_is_race_free_under_concurrent_access()
+    {
+        RunUnderCoyote(() =>
+        {
+            const int workers = 4;
+            var results = new string[workers];
+            var tasks = new Task[workers];
+            for (var i = 0; i < workers; i++)
+            {
+                var idx = i;
+                tasks[i] = Task.Run(() =>
+                {
+                    results[idx] = DbCommandBuilder.BuildSelect<ConcurrentProbe>();
+                });
+            }
+            Task.WaitAll(tasks);
+
+            // All workers must have received the same string. Reference
+            // equality would be stronger (proves cache hit), but string
+            // interning could confuse it — value equality is enough for
+            // the race-free invariant.
+            var first = results[0];
+            for (var i = 1; i < workers; i++)
+            {
+                Microsoft.Coyote.Specifications.Specification.Assert(
+                    string.Equals(results[i], first, StringComparison.Ordinal),
+                    "Worker {0} observed a different SELECT SQL than worker 0: '{1}' vs '{2}'.",
+                    i, results[i], first);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Same invariant, INSERT flavour. Insert has a separate lazy under
+    /// TypeMetadata so its race path is distinct from Select's.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public void BuildInsert_is_race_free_under_concurrent_access()
+    {
+        RunUnderCoyote(() =>
+        {
+            const int workers = 4;
+            var results = new string[workers];
+            var tasks = new Task[workers];
+            for (var i = 0; i < workers; i++)
+            {
+                var idx = i;
+                tasks[i] = Task.Run(() =>
+                {
+                    results[idx] = DbCommandBuilder.BuildInsert<ConcurrentProbe>();
+                });
+            }
+            Task.WaitAll(tasks);
+
+            var first = results[0];
+            for (var i = 1; i < workers; i++)
+            {
+                Microsoft.Coyote.Specifications.Specification.Assert(
+                    string.Equals(results[i], first, StringComparison.Ordinal),
+                    "Worker {0} observed a different INSERT SQL than worker 0.",
+                    i);
+            }
+        });
+    }
+
+    // ------------------------------------------------------------------
+
+    private static void RunUnderCoyote(Action body)
+    {
+        var config = Configuration.Create()
+            .WithTestingIterations((uint)Iterations)
+            .WithMaxSchedulingSteps(500)
+            .WithVerbosityEnabled(Microsoft.Coyote.Logging.VerbosityLevel.Info);
+
+        using var engine = TestingEngine.Create(config, body);
+        engine.Run();
+
+        var report = engine.TestReport;
+        Assert.True(
+            report.NumOfFoundBugs == 0,
+            $"Coyote found {report.NumOfFoundBugs} bug(s). " +
+            $"First: {(report.BugReports.Count > 0 ? report.BugReports.First() : "(no repro)")}");
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- net10.0 only: Coyote's scheduler rewrites IL, and it targets
+         .NET 8+ specifically. Running the concurrency suite across
+         every TFM would multiply hours of exploration time without
+         changing what races the scheduler explores. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;CA1707;CA1062;CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.DbClient\Wolfgang.Etl.DbClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" allowedVersions="(,3.0.0)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Coyote" Version="1.7.11" />
+    <PackageReference Include="Microsoft.Coyote.Test" Version="1.7.11" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes the tooling half of [Etl-DbClient#137](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/137). Coyote systematic-schedule exploration + first two properties + scheduled workflow. Deeper IL-rewriting, 24h soak, and additional properties are follow-ups.

## New

- **\`tests/Wolfgang.Etl.DbClient.Tests.Concurrency/\`** — net10.0 project, Microsoft.Coyote 1.7.11 + Microsoft.Coyote.Test. Two starter properties, both \`[Trait("Category", "Concurrency")]\`:
  - \`BuildSelect_is_race_free_under_concurrent_access\`
  - \`BuildInsert_is_race_free_under_concurrent_access\`

  Each spawns 4 workers on the same TRecord, joins, asserts every worker observed the same SQL string. Coyote's \`TestingEngine\` takes control of the scheduler and systematically explores interleavings. Coyote's \`Specification.Assert\` (not xunit's) inside the body so the engine can capture the failure into a reproducible schedule.

- **\`.github/workflows/concurrency.yaml\`** — \`workflow_dispatch\` + weekly Sunday 09:00 UTC. Iteration budget env-driven (\`COYOTE_ITERATIONS\`, default 10 000 for scheduled). \`--filter Category=Concurrency\`. 60d artifact retention.

## Not in this PR (follow-up scope of #137)

- **IL rewriting via \`coyote rewrite\`** — would intercept every await inside PRODUCTION code, not just awaits inside the test body. Requires wiring into the CI build pipeline.
- **24-hour soak test on self-hosted runner** — blocked on runner availability decision.
- **More properties** (Extractor cancellation mid-enumeration, Loader cancellation mid-batch, disposal races). Each is a distinct Coyote-scenario write-up; land as separate PRs.

## Design notes

- Local \`ConcurrentProbe\` record isolates from shared fixtures — a schema tweak on \`PersonRecord\` etc. can't invalidate the race invariants.
- Weekly slot chosen to avoid overlap: Stryker 06:00, gc-profile 07:00, then a 2-hour gap, then this at 09:00.

## Verified locally

2/2 pass at the default 100-iter budget.

**Test-code note** (per \`feedback_test_changes_need_approval.md\`): entirely a new test project. Runtime csproj gains one \`InternalsVisibleTo\` entry.

**Touches a protected workflow file** — admin-bypass merge expected per \`feedback_protected_config_files_guard.md\`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>