### PR TITLE
ci: add concurrency.yaml to main so workflow_dispatch works from any branch

### DIFF
--- a/.github/workflows/concurrency.yaml
+++ b/.github/workflows/concurrency.yaml
@@ -1,0 +1,94 @@
+# Coyote systematic-concurrency testing.
+#
+# The Tests.Concurrency project drives DbCommandBuilder's cache (and,
+# over time, other race-prone public APIs) through Microsoft Coyote's
+# TestingEngine. On a per-PR run the iteration budget is small
+# (default 100); the scheduled workflow bumps it to 10 000 so each
+# invariant is checked under a much wider set of interleavings.
+#
+# Refs #137.
+
+name: Concurrency (Coyote)
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Coyote scheduling iterations per property (default 10000)"
+        required: false
+        default: "10000"
+        type: string
+  schedule:
+    # Weekly Sunday 09:00 UTC. Stryker 06:00, gc-profile 07:00, then
+    # a two-hour gap, then this run. Prevents runner-pool contention
+    # if any of the earlier weeklies overrun.
+    - cron: '0 9 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  concurrency:
+    name: Coyote (${{ inputs.iterations || '10000' }} iters)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Guard so this workflow (present on main so workflow_dispatch works)
+      # doesn't fail its scheduled run when the checked-out ref pre-dates
+      # the Tests.Concurrency project — that project lives on vNext and
+      # hasn't merged to main yet. Once vNext → main, the guard is a
+      # no-op (the directory always exists) and this comment can go.
+      - name: Detect Tests.Concurrency
+        id: check
+        shell: bash
+        run: |
+          if [ -f tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Tests.Concurrency project not present on this ref — skipping Coyote suite. Merge vNext to main to enable."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore + Build (Release)
+        if: steps.check.outputs.found == 'true'
+        run: |
+          dotnet restore tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj
+          dotnet build tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj \
+            --no-restore \
+            --configuration Release
+
+      - name: Run Coyote concurrency suite
+        if: steps.check.outputs.found == 'true'
+        # Iteration count is read from an env var at test time; runtime-
+        # configurable without a rebuild.
+        env:
+          COYOTE_ITERATIONS: ${{ inputs.iterations || '10000' }}
+        run: |
+          mkdir -p reports
+          dotnet test tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj \
+            --no-build \
+            --configuration Release \
+            --filter 'Category=Concurrency' \
+            --logger "console;verbosity=detailed" \
+            --logger "trx;LogFileName=concurrency.trx" \
+            --results-directory reports/ \
+            2>&1 | tee reports/concurrency.log
+
+      - name: Upload concurrency reports
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: concurrency-reports
+          path: reports/
+          retention-days: 60


### PR DESCRIPTION
GitHub's \`workflow_dispatch\` trigger requires the workflow file to exist on the **default branch** (main). \`concurrency.yaml\` lives on vNext today — meaning it can't be manually triggered against any ref (even \`--ref vNext\`) until it also lands on main.

## What this does

Copies the workflow file verbatim from vNext + adds a **job-level guard** so the scheduled Sunday 09:00 UTC run on main silently no-ops when \`tests/Wolfgang.Etl.DbClient.Tests.Concurrency/\` isn't yet on the checked-out ref. Once vNext → main merges, the guard becomes a harmless no-op (the directory always exists) — the code-comment marks it for cleanup at that point.

## After merge

\`\`\`bash
gh workflow run concurrency.yaml --repo Chris-Wolfgang/Etl-DbClient --ref vNext
\`\`\`

… reads the workflow FILE from vNext (not main), so whichever version is on the branch you dispatched against is what runs.

## Same pattern applies to

Six other vNext-only workflows (\`fuzz.yaml\`, \`gc-profile.yaml\`, \`pr-benchmarks.yaml\`, \`cross-platform-differential.yaml\`, \`reproducible-build.yaml\`, \`semgrep.yaml\`) — all silently non-dispatchable today. If you want them main-dispatchable too, one bundled PR could add all seven with the same guard pattern.

**Touches a protected workflow file** — admin-bypass merge expected per \`feedback_protected_config_files_guard.md\`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>