### PR TITLE
tests: add Loader cancellation-race Coyote property (#137 follow-up)

### DIFF
--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/LoaderCancellationConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/LoaderCancellationConcurrencyTests.cs
@@ -1,0 +1,139 @@
+// Loader cancellation-race property — mirror of ExtractorCancellation-
+// ConcurrencyTests, applied to the loader side of the library.
+//
+// DbLoader consumes an IAsyncEnumerable<TRecord> and writes each item to
+// the database via ExecuteAsync. The cancellation invariants:
+//
+//   1. Under any interleaving of source-enumeration progress + cancel
+//      token fire, LoadAsync terminates. Either the whole batch loads
+//      OR OperationCanceledException propagates.
+//   2. CurrentItemCount on the loader never exceeds the number of items
+//      that were actually committed to the database. If the loader
+//      increments the counter but throws before ExecuteAsync completes,
+//      downstream metrics over-report the write.
+//   3. When cancellation aborts mid-batch, previously-committed rows
+//      (in the caller's own transaction, or in auto-commit mode)
+//      remain persisted — nothing rolls back rows that were already
+//      written in earlier iterations.
+//
+// Refs #137 (Coyote follow-up scope on #265 / #268).
+
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using Microsoft.Coyote;
+using Microsoft.Coyote.SystematicTesting;
+using Microsoft.Data.Sqlite;
+using Wolfgang.Etl.DbClient;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Concurrency;
+
+[ExcludeFromCodeCoverage]
+[UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+internal sealed class LoadProbe
+{
+    public string Value { get; set; } = "";
+}
+
+public class LoaderCancellationConcurrencyTests
+{
+    private static int Iterations =>
+        int.TryParse(Environment.GetEnvironmentVariable("COYOTE_ITERATIONS"), out var n) && n > 0
+            ? n
+            : 50;
+
+    /// <summary>
+    /// LoadAsync terminates cleanly under any interleaving of source
+    /// enumeration + cancel-token fire, and CurrentItemCount matches
+    /// the actual number of rows written to the destination table.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Concurrency")]
+    public void LoadAsync_terminates_and_counts_match_under_cancellation_race()
+    {
+        RunUnderCoyote(() =>
+        {
+            using var conn = new SqliteConnection("Data Source=:memory:");
+            conn.Open();
+            using (var create = conn.CreateCommand())
+            {
+                create.CommandText = "CREATE TABLE load_probe (value TEXT NOT NULL);";
+                create.ExecuteNonQuery();
+            }
+
+            var loader = new DbLoader<LoadProbe>(
+                conn,
+                "INSERT INTO load_probe (value) VALUES (@Value)");
+
+            using var cts = new CancellationTokenSource();
+
+            var cancelTask = Task.Run(() =>
+            {
+                cts.Cancel();
+            });
+
+            var loadTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await loader.LoadAsync(GenerateAsync(5, cts.Token), cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // expected — cancellation is a valid termination path
+                }
+            });
+
+            Task.WaitAll(cancelTask, loadTask);
+
+            // Count what actually landed in the destination.
+            int actualRows;
+            using (var count = conn.CreateCommand())
+            {
+                count.CommandText = "SELECT COUNT(*) FROM load_probe;";
+                actualRows = Convert.ToInt32(count.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+            }
+
+            // Invariant: the loader's own count matches what's in the DB.
+            // If they diverge, a downstream progress metric would over-
+            // or under-report the actual write.
+            Microsoft.Coyote.Specifications.Specification.Assert(
+                loader.CurrentItemCount == actualRows,
+                "Loader CurrentItemCount ({0}) does not match rows in destination ({1}).",
+                loader.CurrentItemCount, actualRows);
+        });
+    }
+
+    private static async IAsyncEnumerable<LoadProbe> GenerateAsync(
+        int count,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return new LoadProbe { Value = $"item-{i}" };
+            await Task.Yield();
+        }
+    }
+
+    // ------------------------------------------------------------------
+
+    private static void RunUnderCoyote(Action body)
+    {
+        var config = Configuration.Create()
+            .WithTestingIterations((uint)Iterations)
+            .WithMaxSchedulingSteps(1000)
+            .WithVerbosityEnabled(Microsoft.Coyote.Logging.VerbosityLevel.Info);
+
+        using var engine = TestingEngine.Create(config, body);
+        engine.Run();
+
+        var report = engine.TestReport;
+        Assert.True(
+            report.NumOfFoundBugs == 0,
+            $"Coyote found {report.NumOfFoundBugs} bug(s). " +
+            $"First: {(report.BugReports.Count > 0 ? report.BugReports.First() : "(no repro)")}");
+    }
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj
@@ -28,6 +28,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Coyote" Version="1.7.11" />
     <PackageReference Include="Microsoft.Coyote.Test" Version="1.7.11" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
Mirror of [#268](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/268) (Extractor cancellation-race), applied to the loader side.

## Property

Under any interleaving of source-enumeration progress + cancel-token fire:

- \`LoadAsync\` terminates — either the batch completes OR \`OperationCanceledException\` propagates.
- Loader's \`CurrentItemCount\` **equals** the actual row count in the destination table. Divergence catches:
  - \`CurrentItemCount > actualRows\` — progress over-reports (loader counted but the write didn't commit).
  - \`CurrentItemCount < actualRows\` — invisible writes (rows landed but weren't counted).

Coyote's scheduler explores fire-before-first-item / fire-mid-batch / fire-after-last-item in one \`TestingIterations\` campaign.

## Fixture

In-memory SQLite, \`GenerateAsync\` yields 5 items with a \`Task.Yield()\` between each so the scheduler has interleave points inside the source-enumeration path (not just around \`LoadAsync\`'s own awaits).

## Verified locally

\`dotnet test -c Release --filter FullyQualifiedName~LoaderCancellation\` → **1/1 passed** at the default 50-iter budget.

## Note on stacking

Adds the same \`Microsoft.Data.Sqlite\` PackageReference that #268 adds. First-merger wins; second is a no-op after conflict resolution.

**Test-code note** (per \`feedback_test_changes_need_approval.md\`): entirely a new test file + one PackageReference addition. No production code touched.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>