### PR TITLE
feat: DbSchemaValidator — validate [Table]/[Column] against DB schema (#20)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbSchemaValidator.cs
+++ b/src/Wolfgang.Etl.DbClient/DbSchemaValidator.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Validates that a record type's <c>[Table]</c> and <c>[Column]</c>
+/// attribute mappings match the actual database schema before you invest
+/// in an extract or load. Catches configuration errors — table renamed,
+/// column dropped, <c>[Column("wrong_name")]</c> typo — at the top of a
+/// batch instead of mid-operation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The validator is intentionally provider-agnostic. It executes
+/// <c>SELECT * FROM &lt;table&gt; WHERE 1 = 0</c> against the supplied
+/// <see cref="DbConnection"/> and inspects the resulting reader's column
+/// schema. Every provider that supports ADO.NET supports this — SQL
+/// Server, PostgreSQL, MySQL / MariaDB, SQLite, Oracle, CockroachDB —
+/// and there's no <c>INFORMATION_SCHEMA</c> dialect drift to work around.
+/// </para>
+/// <para>
+/// The zero-row filter is by-design: no rows come back, only metadata.
+/// Even against a large production table the round-trip is a millisecond.
+/// </para>
+/// <para>
+/// Type-compatibility checking (mapping a <see cref="string"/> property to
+/// an <c>INT</c> column, for example) is not implemented today — ADO.NET
+/// type mappings vary enough per provider that a best-effort check would
+/// surface more false positives than real bugs. This validator focuses on
+/// the two problems that <em>are</em> reliably diagnosable across
+/// providers: the table is missing, or a mapped column name is not on
+/// the table.
+/// </para>
+/// </remarks>
+public static class DbSchemaValidator
+{
+    /// <summary>
+    /// Synchronously validate that <typeparamref name="TRecord"/>'s
+    /// <c>[Table]</c> exists on the connected database and every mapped
+    /// column (property with no <c>[NotMapped]</c>) is present on the
+    /// table.
+    /// </summary>
+    /// <typeparam name="TRecord">The mapped record type.</typeparam>
+    /// <param name="connection">
+    /// An open or closed <see cref="DbConnection"/>. Opened by the
+    /// validator if closed; state is restored on return.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="connection"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// <typeparamref name="TRecord"/> has no <c>[Table]</c> attribute, the
+    /// table does not exist on the database, or one or more mapped column
+    /// names are not present on the table. The exception message names
+    /// the specific offender.
+    /// </exception>
+    public static void Validate<TRecord>(DbConnection connection)
+        where TRecord : notnull
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        ExtractMapping(typeof(TRecord), out var table, out var mappedColumns);
+        var openedHere = EnsureOpen(connection);
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"SELECT * FROM {table} WHERE 1 = 0";
+            cmd.CommandType = CommandType.Text;
+            using var reader = TryExecuteReader(cmd, table);
+            AssertColumnsPresent(reader, mappedColumns, table);
+        }
+        finally
+        {
+            if (openedHere)
+            {
+                connection.Close();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Async companion to <see cref="Validate{TRecord}"/>. Recommended for
+    /// server contexts where blocking the calling thread on the round-trip
+    /// is undesirable.
+    /// </summary>
+    /// <typeparam name="TRecord">The mapped record type.</typeparam>
+    /// <param name="connection">
+    /// An open or closed <see cref="DbConnection"/>. Opened by the
+    /// validator if closed; state is restored on return.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the operation.</param>
+    /// <exception cref="ArgumentNullException"/>
+    /// <exception cref="InvalidOperationException"/>
+    /// <exception cref="OperationCanceledException"/>
+    public static async Task ValidateAsync<TRecord>(
+        DbConnection connection,
+        CancellationToken cancellationToken = default)
+        where TRecord : notnull
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        ExtractMapping(typeof(TRecord), out var table, out var mappedColumns);
+        var openedHere = await EnsureOpenAsync(connection, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"SELECT * FROM {table} WHERE 1 = 0";
+            cmd.CommandType = CommandType.Text;
+            DbDataReader reader;
+            try
+            {
+                reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Schema validation failed for table '{table}': the table does not exist or cannot be queried. " +
+                    $"Underlying provider error: {ex.Message}",
+                    ex);
+            }
+            using (reader)
+            {
+                AssertColumnsPresent(reader, mappedColumns, table);
+            }
+        }
+        finally
+        {
+            if (openedHere)
+            {
+#if NET5_0_OR_GREATER
+                await connection.CloseAsync().ConfigureAwait(false);
+#else
+                connection.Close();
+#endif
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+
+    private static void ExtractMapping(Type type, out string table, out IReadOnlyList<string> columns)
+    {
+        var tableAttr = type.GetCustomAttribute<TableAttribute>();
+        if (tableAttr is null || string.IsNullOrWhiteSpace(tableAttr.Name))
+        {
+            throw new InvalidOperationException(
+                $"Type '{type.FullName}' does not have a [Table] attribute. " +
+                "Schema validation requires an explicit table mapping.");
+        }
+
+        var mapped = new List<string>();
+        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (prop.GetCustomAttribute<NotMappedAttribute>() is not null)
+            {
+                continue;
+            }
+            var columnName = prop.GetCustomAttribute<ColumnAttribute>()?.Name ?? prop.Name;
+            mapped.Add(columnName);
+        }
+
+        if (mapped.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Type '{type.FullName}' declares no mapped columns. " +
+                "Every property is [NotMapped]; nothing to validate.");
+        }
+
+        table = tableAttr.Name;
+        columns = mapped;
+    }
+
+    private static bool EnsureOpen(DbConnection connection)
+    {
+        if (connection.State == ConnectionState.Open)
+        {
+            return false;
+        }
+        connection.Open();
+        return true;
+    }
+
+    private static async Task<bool> EnsureOpenAsync(DbConnection connection, CancellationToken ct)
+    {
+        if (connection.State == ConnectionState.Open)
+        {
+            return false;
+        }
+        await connection.OpenAsync(ct).ConfigureAwait(false);
+        return true;
+    }
+
+    private static DbDataReader TryExecuteReader(DbCommand cmd, string table)
+    {
+        try
+        {
+            return cmd.ExecuteReader();
+        }
+        catch (DbException ex)
+        {
+            throw new InvalidOperationException(
+                $"Schema validation failed for table '{table}': the table does not exist or cannot be queried. " +
+                $"Underlying provider error: {ex.Message}",
+                ex);
+        }
+    }
+
+    private static void AssertColumnsPresent(
+        DbDataReader reader,
+        IReadOnlyList<string> mappedColumns,
+        string table)
+    {
+        var actual = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            actual.Add(reader.GetName(i));
+        }
+
+        var missing = mappedColumns.Where(c => !actual.Contains(c)).ToList();
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Schema validation failed for table '{table}': " +
+                $"the following mapped column(s) are missing from the database: " +
+                string.Join(", ", missing.Select(m => $"'{m}'")) + ". " +
+                $"Table has: {string.Join(", ", actual.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))}.");
+        }
+    }
+}

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+static Wolfgang.Etl.DbClient.DbSchemaValidator.Validate<TRecord>(System.Data.Common.DbConnection! connection) -> void
+static Wolfgang.Etl.DbClient.DbSchemaValidator.ValidateAsync<TRecord>(System.Data.Common.DbConnection! connection, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Wolfgang.Etl.DbClient.DbSchemaValidator

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbSchemaValidatorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbSchemaValidatorTests.cs
@@ -1,0 +1,185 @@
+// Tests for DbSchemaValidator (#20).
+//
+// The validator's contract:
+//   1. Missing [Table] → InvalidOperationException with the type FullName.
+//   2. Missing table on DB → InvalidOperationException with the table name.
+//   3. Missing column → InvalidOperationException naming BOTH the missing
+//      columns AND the columns the table actually has (so a copy-paste
+//      typo is immediately obvious).
+//   4. All mapped columns present → no throw.
+//   5. Async companion behaves identically + honours cancellation.
+//   6. Connection state is restored (Closed → Closed) after Validate.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+public class DbSchemaValidatorTests
+{
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("widget")]
+    public sealed class Widget
+    {
+        [Key]
+        [Column("id")] public int Id { get; set; }
+        [Column("name")] public string Name { get; set; } = "";
+        [Column("price")] public decimal Price { get; set; }
+        [NotMapped] public string DisplayName { get; set; } = "";
+    }
+
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    public sealed class WithoutTable
+    {
+        [Column("id")] public int Id { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("widget")]
+    public sealed class WidgetWithExtraColumn
+    {
+        [Column("id")] public int Id { get; set; }
+        [Column("name")] public string Name { get; set; } = "";
+        [Column("price")] public decimal Price { get; set; }
+        [Column("does_not_exist")] public string Ghost { get; set; } = "";
+    }
+
+    private static SqliteConnection CreateSeededConnection()
+    {
+        var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "CREATE TABLE widget (id INTEGER PRIMARY KEY, name TEXT NOT NULL, price REAL NOT NULL);";
+        cmd.ExecuteNonQuery();
+        return conn;
+    }
+
+    [Fact]
+    public void Validate_when_all_mapped_columns_exist_returns_normally()
+    {
+        using var conn = CreateSeededConnection();
+        DbSchemaValidator.Validate<Widget>(conn);
+    }
+
+    [Fact]
+    public void Validate_when_type_has_no_table_attribute_throws()
+    {
+        using var conn = CreateSeededConnection();
+        var ex = Assert.Throws<InvalidOperationException>
+        (
+            () => DbSchemaValidator.Validate<WithoutTable>(conn)
+        );
+        Assert.Contains
+        (
+            "does not have a [Table] attribute",
+            ex.Message,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void Validate_when_table_missing_throws_with_table_name()
+    {
+        using var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        var ex = Assert.Throws<InvalidOperationException>
+        (
+            () => DbSchemaValidator.Validate<Widget>(conn)
+        );
+        Assert.Contains
+        (
+            "table 'widget'",
+            ex.Message,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void Validate_when_column_missing_throws_listing_both_missing_and_actual()
+    {
+        using var conn = CreateSeededConnection();
+        var ex = Assert.Throws<InvalidOperationException>
+        (
+            () => DbSchemaValidator.Validate<WidgetWithExtraColumn>(conn)
+        );
+        Assert.Contains
+        (
+            "'does_not_exist'",
+            ex.Message,
+            StringComparison.Ordinal
+        );
+        // Names of the actual columns are also listed so a typo is
+        // immediately obvious.
+        Assert.Contains
+        (
+            "name",
+            ex.Message,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void Validate_null_connection_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => DbSchemaValidator.Validate<Widget>(null!)
+        );
+    }
+
+    [Fact]
+    public void Validate_leaves_already_open_connection_open()
+    {
+        // If the caller passed an already-open connection, the validator
+        // must NOT close it — that would be a state-mutation the caller
+        // didn't ask for. (The closed-connection-reopen path is
+        // exercised by production consumers on real DBs; SQLite in-
+        // memory can't test it because :memory: is per-connection and
+        // Close destroys the database.)
+        using var conn = CreateSeededConnection();
+        Assert.Equal(ConnectionState.Open, conn.State);
+
+        DbSchemaValidator.Validate<Widget>(conn);
+
+        Assert.Equal(ConnectionState.Open, conn.State);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_when_all_mapped_columns_exist_returns_normally()
+    {
+        await using var conn = CreateSeededConnection();
+        await DbSchemaValidator.ValidateAsync<Widget>(conn);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_when_column_missing_throws()
+    {
+        await using var conn = CreateSeededConnection();
+        await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            () => DbSchemaValidator.ValidateAsync<WidgetWithExtraColumn>(conn)
+        );
+    }
+
+    [Fact]
+    public async Task ValidateAsync_honours_cancellation()
+    {
+        await using var conn = CreateSeededConnection();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            () => DbSchemaValidator.ValidateAsync<Widget>(conn, cts.Token)
+        );
+    }
+}


### PR DESCRIPTION
Closes the option-A half of [Etl-DbClient#20](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/20). Consumers call this once at the top of a batch to catch config errors — table renamed, column dropped, \`[Column("wrong_name")]\` typo — **before** investing in an extract or load.

## Public API added

\`\`\`csharp
public static class DbSchemaValidator
{
    public static void Validate<TRecord>(DbConnection connection);
    public static Task ValidateAsync<TRecord>(DbConnection connection, CancellationToken ct = default);
}
\`\`\`

Both throw \`InvalidOperationException\` on:
- Missing \`[Table]\` attribute.
- Table does not exist on the connected database.
- One or more mapped column names not present on the table (error message lists **both** the missing columns AND every column the table actually has — copy-paste typos become immediately visible).

## Design

- **Provider-agnostic**: executes \`SELECT * FROM <table> WHERE 1 = 0\` and inspects the resulting \`DbDataReader\`'s column schema. Every ADO.NET provider supports this (SQL Server, PostgreSQL, MySQL/MariaDB, SQLite, Oracle, CockroachDB). No \`INFORMATION_SCHEMA\` dialect drift.
- **Case-insensitive column match**: SQL Server / Postgres differ on identifier case sensitivity; \`OrdinalIgnoreCase\` catches typos without false positives on a case-sensitive server.
- **No type-compat check**: ADO.NET type mappings vary too much per provider — a best-effort check would surface more false positives than real bugs. Documented in XML remarks.
- **Connection lifecycle**: opened by the validator if closed; restored to Closed on return. Already-open connections stay Open.
- Multi-TFM: \`out\` params instead of tuple return (matches \`DbExtractor.ApplyServerPaging\` — net462 lacks System.ValueTuple), \`CloseAsync\` under \`#if NET5_0_OR_GREATER\`.

## Not in this PR (still open under #20)

- **Option B**: \`ValidateSchemaOnStart\` property on \`DbExtractor\` / \`DbLoader\`. Bumps their public surface, better as a focused follow-up so this PR stays a single-type addition.

## Verified locally

- 9/9 new tests pass on net10.0.
- Clean build across the full net462 → net10 TFM matrix (11 targets).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>