### PR TITLE
feat: ValidateSchemaOnStart opt-in on DbExtractor/DbLoader (#20 option B)

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -354,6 +354,30 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
+    /// When <see langword="true"/>, the extractor calls
+    /// <see cref="DbSchemaValidator.ValidateAsync{TRecord}(System.Data.Common.DbConnection, System.Threading.CancellationToken)"/>
+    /// before the first row is fetched. If the mapped
+    /// <c>[Table]</c>/<c>[Column]</c> names don't match the database,
+    /// the extractor throws <see cref="InvalidOperationException"/>
+    /// before touching production data.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Default: <see langword="false"/>. Opting in adds a single
+    /// zero-row round-trip at the top of each <c>ExtractAsync</c>
+    /// call — negligible compared to a real extract, but not free.
+    /// Use it in a first-run smoke path or a health check, not
+    /// inside every loop iteration on a per-message pipeline.
+    /// </para>
+    /// <para>
+    /// Refs <see href="https://github.com/Chris-Wolfgang/Etl-DbClient/issues/20">#20</see>.
+    /// </para>
+    /// </remarks>
+    public bool ValidateSchemaOnStart { get; set; }
+
+
+
+    /// <summary>
     /// Optional override for the parameter set passed to Dapper. Setting this
     /// property takes precedence over any <c>IDictionary&lt;string,object&gt;</c>
     /// supplied via the constructor — useful when the command is a stored
@@ -582,6 +606,11 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
         try
         {
+            if (ValidateSchemaOnStart)
+            {
+                await DbSchemaValidator.ValidateAsync<TRecord>(_connection, token).ConfigureAwait(false);
+            }
+
             ApplyServerPaging(_commandText, Parameters ?? _dynamicParameters, out var commandText, out var param);
 
             if (TotalCountQuery != null)

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -298,6 +298,29 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
 
     /// <summary>
+    /// When <see langword="true"/>, the loader calls
+    /// <see cref="DbSchemaValidator.ValidateAsync{TRecord}(System.Data.Common.DbConnection, System.Threading.CancellationToken)"/>
+    /// before the first row is written. If the mapped
+    /// <c>[Table]</c>/<c>[Column]</c> names don't match the database,
+    /// the loader throws <see cref="InvalidOperationException"/>
+    /// before writing anything.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Default: <see langword="false"/>. Opting in adds a single
+    /// zero-row round-trip at the top of each <c>LoadAsync</c>
+    /// call. Cheap for batch jobs, avoid on hot per-message
+    /// pipelines.
+    /// </para>
+    /// <para>
+    /// Refs <see href="https://github.com/Chris-Wolfgang/Etl-DbClient/issues/20">#20</see>.
+    /// </para>
+    /// </remarks>
+    public bool ValidateSchemaOnStart { get; set; }
+
+
+
+    /// <summary>
     /// When greater than <c>1</c>, the loader replaces N per-row
     /// <c>INSERT</c>s with a single multi-row <c>INSERT … VALUES (…), (…), …</c>
     /// statement. The single biggest single-line perf win available
@@ -621,6 +644,11 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
         try
         {
+            if (ValidateSchemaOnStart)
+            {
+                await DbSchemaValidator.ValidateAsync<TRecord>(_connection, token).ConfigureAwait(false);
+            }
+
             if (_ownsTransaction)
             {
                 await LoadWithAutoTransactionAsync(items, token).ConfigureAwait(false);

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -2,3 +2,7 @@
 static Wolfgang.Etl.DbClient.DbSchemaValidator.Validate<TRecord>(System.Data.Common.DbConnection! connection) -> void
 static Wolfgang.Etl.DbClient.DbSchemaValidator.ValidateAsync<TRecord>(System.Data.Common.DbConnection! connection, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Wolfgang.Etl.DbClient.DbSchemaValidator
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ValidateSchemaOnStart.get -> bool
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ValidateSchemaOnStart.set -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.ValidateSchemaOnStart.get -> bool
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.ValidateSchemaOnStart.set -> void

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/ValidateSchemaOnStartTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/ValidateSchemaOnStartTests.cs
@@ -1,0 +1,190 @@
+// Tests for the opt-in ValidateSchemaOnStart property on
+// DbExtractor and DbLoader (#20, option B).
+//
+// The contract:
+//   * Default is false: mapping mismatches don't throw until the real
+//     query runs.
+//   * When true: extractor/loader invoke DbSchemaValidator BEFORE the
+//     first row is touched, so a copy-paste column typo fails fast
+//     with the validator's clear message rather than a driver-level
+//     "no such column" surfaced deep inside the read loop.
+//   * When true and mapping is correct: extract/load succeed normally.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+public class ValidateSchemaOnStartTests
+{
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("widget")]
+    public sealed class Widget
+    {
+        [Key]
+        [Column("id")] public int Id { get; set; }
+        [Column("name")] public string Name { get; set; } = "";
+        [Column("price")] public decimal Price { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [Table("widget")]
+    public sealed class BadWidget
+    {
+        [Column("id")] public int Id { get; set; }
+        [Column("name")] public string Name { get; set; } = "";
+        [Column("does_not_exist")] public string Ghost { get; set; } = "";
+    }
+
+    private static SqliteConnection CreateSeededConnection()
+    {
+        var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            CREATE TABLE widget (id INTEGER PRIMARY KEY, name TEXT NOT NULL, price REAL NOT NULL);
+            INSERT INTO widget (id, name, price) VALUES
+                (1, 'a', 1.0),
+                (2, 'b', 2.0);
+        ";
+        cmd.ExecuteNonQuery();
+        return conn;
+    }
+
+
+
+    [Fact]
+    public void Extractor_ValidateSchemaOnStart_defaults_to_false()
+    {
+        using var conn = CreateSeededConnection();
+        var sut = new DbExtractor<Widget>(conn, "SELECT id AS Id, name AS Name, price AS Price FROM widget");
+        Assert.False(sut.ValidateSchemaOnStart);
+    }
+
+
+
+    [Fact]
+    public async Task Extractor_ValidateSchemaOnStart_true_throws_before_first_row_when_mapping_wrong()
+    {
+        using var conn = CreateSeededConnection();
+        var sut = new DbExtractor<BadWidget>(conn, "SELECT id AS Id, name AS Name FROM widget")
+        {
+            ValidateSchemaOnStart = true,
+        };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in sut.ExtractAsync().ConfigureAwait(false))
+            {
+                Assert.Fail("Validator should have thrown before yielding any row.");
+            }
+        }).ConfigureAwait(false);
+
+        Assert.Contains("does_not_exist", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(0, sut.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task Extractor_ValidateSchemaOnStart_true_succeeds_when_mapping_correct()
+    {
+        using var conn = CreateSeededConnection();
+        var sut = new DbExtractor<Widget>(conn, "SELECT id AS Id, name AS Name, price AS Price FROM widget")
+        {
+            ValidateSchemaOnStart = true,
+        };
+
+        var rows = new List<Widget>();
+        await foreach (var row in sut.ExtractAsync().ConfigureAwait(false))
+        {
+            rows.Add(row);
+        }
+
+        Assert.Equal(2, rows.Count);
+    }
+
+
+
+    [Fact]
+    public void Loader_ValidateSchemaOnStart_defaults_to_false()
+    {
+        using var conn = CreateSeededConnection();
+        var sut = new DbLoader<Widget>(conn, "INSERT INTO widget (id, name, price) VALUES (@Id, @Name, @Price)");
+        Assert.False(sut.ValidateSchemaOnStart);
+    }
+
+
+
+    [Fact]
+    public async Task Loader_ValidateSchemaOnStart_true_throws_before_first_write_when_mapping_wrong()
+    {
+        using var conn = CreateSeededConnection();
+        var sut = new DbLoader<BadWidget>
+        (
+            conn,
+            "INSERT INTO widget (id, name) VALUES (@Id, @Name)"
+        )
+        {
+            ValidateSchemaOnStart = true,
+        };
+
+        var items = ToAsync(new[]
+        {
+            new BadWidget { Id = 10, Name = "x", Ghost = "g" },
+        });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await sut.LoadAsync(items).ConfigureAwait(false)).ConfigureAwait(false);
+
+        Assert.Contains("does_not_exist", ex.Message, StringComparison.Ordinal);
+
+        using var count = conn.CreateCommand();
+        count.CommandText = "SELECT COUNT(*) FROM widget";
+        var after = Convert.ToInt64(count.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(2L, after);
+    }
+
+
+
+    [Fact]
+    public async Task Loader_ValidateSchemaOnStart_true_succeeds_when_mapping_correct()
+    {
+        using var conn = CreateSeededConnection();
+        var sut = new DbLoader<Widget>
+        (
+            conn,
+            "INSERT INTO widget (id, name, price) VALUES (@Id, @Name, @Price)"
+        )
+        {
+            ValidateSchemaOnStart = true,
+        };
+
+        await sut.LoadAsync(ToAsync(new[]
+        {
+            new Widget { Id = 10, Name = "x", Price = 9m },
+        })).ConfigureAwait(false);
+
+        using var count = conn.CreateCommand();
+        count.CommandText = "SELECT COUNT(*) FROM widget";
+        var after = Convert.ToInt64(count.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+        Assert.Equal(3L, after);
+    }
+
+
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            yield return item;
+            await Task.Yield();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `ValidateSchemaOnStart` property to `DbExtractor<TRecord>` and `DbLoader<TRecord>`. When `true`, each worker calls `DbSchemaValidator.ValidateAsync<TRecord>` before touching the first row.

A copy-paste `[Column]` typo now throws the validator's clear diagnostic (missing columns + what the table actually has) BEFORE production data is read or written — instead of surfacing as a provider-specific `"no such column: does_not_exist"` deep inside the read/write loop.

## Behaviour

- Default: `false` — no behaviour change for existing consumers.
- When `true`: one zero-row `SELECT * FROM <table> WHERE 1=0` at the top of `ExtractAsync` / `LoadAsync`. Cheap for batch jobs.
- Docs on the property warn against enabling it on hot per-message pipelines.

## Stacking

Base branch: `feat/schema-validation` (PR #271, which introduces `DbSchemaValidator` itself). This PR is **option B** of #20 — the property that wires up the validator on the two consumer types. Merges cleanly to `vNext` after #271 lands.

## Test plan

- [x] `dotnet build -c Release` clean across all 11 TFMs.
- [x] 6 new tests (extractor + loader × default-false / opt-in-throws / opt-in-succeeds) pass on net10.0.
- [x] Assertions verify: `CurrentItemCount == 0` on throw path (extractor); destination row count unchanged on throw path (loader).
- [ ] CI runs across the full multi-TFM matrix.

Closes #20 (in combination with #271).

🤖 Generated with [Claude Code](https://claude.com/claude-code)