### PR TITLE
feat(sourcegen): emit Select const on [DbTable] types (#23)

### DIFF
--- a/src/Wolfgang.Etl.DbClient.SourceGenerator/DbTableGenerator.cs
+++ b/src/Wolfgang.Etl.DbClient.SourceGenerator/DbTableGenerator.cs
@@ -14,11 +14,17 @@ namespace Wolfgang.Etl.DbClient.SourceGenerator;
 /// <list type="bullet">
 ///   <item><description><c>public const string Insert</c> — the canonical
 ///         <c>INSERT</c> SQL for the table</description></item>
+///   <item><description><c>public const string Select</c> — a
+///         <c>SELECT</c> covering every mapped column, aliasing
+///         <c>col AS Property</c> when the column and property names
+///         differ (matching runtime <c>DbCommandBuilder.BuildSelect</c>)
+///         </description></item>
 ///   <item><description><c>public static void Bind(Dapper.DynamicParameters
 ///         parameters, T record)</c> — reflection-free binder</description></item>
 /// </list>
 ///
-/// First v0.5.0 cut — Update / Delete / Select are TODO.
+/// Update / Delete are still TODO — they need a <c>[DbKey]</c> attribute
+/// (or key-inference rule) before an emit target is well-defined.
 /// </summary>
 [Generator(LanguageNames.CSharp)]
 public sealed class DbTableGenerator : IIncrementalGenerator
@@ -136,6 +142,26 @@ public sealed class DbTableGenerator : IIncrementalGenerator
         sb.Append("    public const string Insert = \"INSERT INTO ")
           .Append(model.TableName)
           .Append(" (").Append(colList).Append(") VALUES (").Append(paramList).AppendLine(")\";");
+        sb.AppendLine();
+
+        // Select SQL constant. Alias `col AS Property` only when the
+        // column and property names differ — the runtime
+        // DbCommandBuilder.BuildSelect follows the same rule, so the
+        // generated + reflection paths produce identical strings and
+        // consumers can cut over to the generator without a wire-level
+        // behaviour change.
+        var selectList = string.Join
+        (
+            ", ",
+            model.Columns.Select(c => string.Equals(c.ColumnName, c.PropertyName, System.StringComparison.Ordinal)
+                ? c.ColumnName
+                : c.ColumnName + " AS " + c.PropertyName)
+        );
+        sb.Append("    public const string Select = \"SELECT ")
+          .Append(selectList)
+          .Append(" FROM ")
+          .Append(model.TableName)
+          .AppendLine("\";");
         sb.AppendLine();
 
         // Bind helper — reflection-free DynamicParameters population.

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbTableGeneratorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbTableGeneratorTests.cs
@@ -77,6 +77,40 @@ public class DbTableGeneratorTests
 
 
     [Fact]
+    public void Generator_emits_Select_const_using_property_names()
+    {
+        var sql = GeneratedPerson.Select;
+
+        // No [DbColumn] overrides on GeneratedPerson — column name equals
+        // property name for every field, so BuildSelect's aliasing rule
+        // (alias only on name mismatch) collapses to a plain column list.
+        Assert.Equal
+        (
+            "SELECT FirstName, LastName, Age FROM people",
+            sql
+        );
+    }
+
+
+
+    [Fact]
+    public void Generator_emits_Select_const_with_column_aliasing_when_names_differ()
+    {
+        var sql = GeneratedOrder.Select;
+
+        // Audit is Skip=true → absent. OrderId + Customer carry [DbColumn]
+        // overrides so BuildSelect aliases `col AS Property`. Total has
+        // no override — matches property name, no alias.
+        Assert.Equal
+        (
+            "SELECT order_id AS OrderId, customer_name AS Customer, Total FROM orders",
+            sql
+        );
+    }
+
+
+
+    [Fact]
     public void Generator_emits_reflection_free_Bind_helper()
     {
         var p = new DynamicParameters();


### PR DESCRIPTION
## Summary

Extends \`DbTableGenerator\` (v0.5.0's \`Insert\` + \`Bind\` emitter) to also emit \`public const string Select\` on every \`[DbTable]\`-decorated partial type.

## Aliasing rule

Matches the runtime \`DbCommandBuilder.BuildSelect<T>()\` exactly:
- If column name equals property name → \`SELECT col, …\`
- If they differ (\`[DbColumn("customer_name")] public string Customer\`) → \`SELECT customer_name AS Customer, …\`

Byte-identical to the reflection path, so consumers can cut over without a wire-level change — DB column ordering, Dapper's binder, and downstream data all behave the same.

## Example

\`\`\`csharp
[DbTable(\"orders\")]
public partial record GeneratedOrder
{
    [DbColumn(\"order_id\")] public int OrderId { get; init; }
    [DbColumn(\"customer_name\")] public string Customer { get; init; } = \"\";
    public decimal Total { get; init; }
    [DbColumn(\"audit\", Skip = true)] public string Audit { get; init; } = \"\";
}

// Generated: SELECT order_id AS OrderId, customer_name AS Customer, Total FROM orders
_ = GeneratedOrder.Select;
\`\`\`

## Not in this PR

\`Update\` / \`Delete\` emitters. Both need a \`[DbKey]\` attribute (or a key-inference rule) so the WHERE clause has a well-defined target. Better as a focused follow-up where the key-attribute contract can be reviewed in isolation.

## Test plan

- [x] Generator + main project build clean (\`dotnet build -c Release\`).
- [x] 5/5 \`DbTableGeneratorTests\` pass on net10.0 (3 existing + 2 new).
- [ ] CI multi-TFM.

Refs #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)