### PR TITLE
feat(sourcegen): [DbKey] attribute + Update/Delete const emit (#23)

### DIFF
--- a/src/Wolfgang.Etl.DbClient.SourceGenerator/DbTableGenerator.cs
+++ b/src/Wolfgang.Etl.DbClient.SourceGenerator/DbTableGenerator.cs
@@ -19,18 +19,25 @@ namespace Wolfgang.Etl.DbClient.SourceGenerator;
 ///         <c>col AS Property</c> when the column and property names
 ///         differ (matching runtime <c>DbCommandBuilder.BuildSelect</c>)
 ///         </description></item>
+///   <item><description><c>public const string Update</c> — an
+///         <c>UPDATE … SET … WHERE …</c> whose SET covers every non-key
+///         column and whose WHERE covers every <c>[DbKey]</c> property.
+///         Emitted only when the type has at least one <c>[DbKey]</c>
+///         property AND at least one non-key mapped column.</description></item>
+///   <item><description><c>public const string Delete</c> — a
+///         <c>DELETE FROM … WHERE …</c> whose WHERE covers every
+///         <c>[DbKey]</c> property. Emitted only when the type has at
+///         least one <c>[DbKey]</c> property.</description></item>
 ///   <item><description><c>public static void Bind(Dapper.DynamicParameters
 ///         parameters, T record)</c> — reflection-free binder</description></item>
 /// </list>
-///
-/// Update / Delete are still TODO — they need a <c>[DbKey]</c> attribute
-/// (or key-inference rule) before an emit target is well-defined.
 /// </summary>
 [Generator(LanguageNames.CSharp)]
 public sealed class DbTableGenerator : IIncrementalGenerator
 {
     private const string DbTableAttributeFullName = "Wolfgang.Etl.DbClient.DbTableAttribute";
     private const string DbColumnAttributeFullName = "Wolfgang.Etl.DbClient.DbColumnAttribute";
+    private const string DbKeyAttributeFullName = "Wolfgang.Etl.DbClient.DbKeyAttribute";
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -101,7 +108,10 @@ public sealed class DbTableGenerator : IIncrementalGenerator
                 continue;
             }
 
-            columns.Add(new ColumnModel(member.Name, columnName));
+            var isKey = member.GetAttributes().Any(a =>
+                a.AttributeClass?.ToDisplayString() == DbKeyAttributeFullName);
+
+            columns.Add(new ColumnModel(member.Name, columnName, isKey));
         }
 
         if (columns.Count == 0)
@@ -164,6 +174,43 @@ public sealed class DbTableGenerator : IIncrementalGenerator
           .AppendLine("\";");
         sb.AppendLine();
 
+        // Update / Delete SQL constants — emitted only when the type has
+        // at least one [DbKey] property. Update additionally needs at
+        // least one non-key column to have anything to SET.
+        var keyColumns = model.Columns.Where(c => c.IsKey).ToList();
+        var setColumns = model.Columns.Where(c => !c.IsKey).ToList();
+
+        if (keyColumns.Count > 0)
+        {
+            var whereClause = string.Join
+            (
+                " AND ",
+                keyColumns.Select(c => c.ColumnName + " = @" + c.PropertyName)
+            );
+
+            if (setColumns.Count > 0)
+            {
+                var setClause = string.Join
+                (
+                    ", ",
+                    setColumns.Select(c => c.ColumnName + " = @" + c.PropertyName)
+                );
+
+                sb.Append("    public const string Update = \"UPDATE ")
+                  .Append(model.TableName)
+                  .Append(" SET ").Append(setClause)
+                  .Append(" WHERE ").Append(whereClause)
+                  .AppendLine("\";");
+                sb.AppendLine();
+            }
+
+            sb.Append("    public const string Delete = \"DELETE FROM ")
+              .Append(model.TableName)
+              .Append(" WHERE ").Append(whereClause)
+              .AppendLine("\";");
+            sb.AppendLine();
+        }
+
         // Bind helper — reflection-free DynamicParameters population.
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// Reflection-free Dapper parameter binder generated for this record.");
@@ -195,5 +242,5 @@ public sealed class DbTableGenerator : IIncrementalGenerator
 
 
 
-    private sealed record ColumnModel(string PropertyName, string ColumnName);
+    private sealed record ColumnModel(string PropertyName, string ColumnName, bool IsKey);
 }

--- a/src/Wolfgang.Etl.DbClient/DbKeyAttribute.cs
+++ b/src/Wolfgang.Etl.DbClient/DbKeyAttribute.cs
@@ -1,0 +1,34 @@
+using System;
+using JetBrains.Annotations;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Marks a property on a <see cref="DbTableAttribute"/>-decorated record as
+/// part of the row's identifying key. The <c>DbTableGenerator</c> source
+/// generator uses <c>[DbKey]</c> properties to build the WHERE clause of
+/// the generated <c>Update</c> and <c>Delete</c> SQL constants.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A type may carry more than one <c>[DbKey]</c> property to model a
+/// composite key. Column ordering in the emitted WHERE clause matches
+/// the property declaration order.
+/// </para>
+/// <para>
+/// <c>[DbKey]</c> is orthogonal to <see cref="DbColumnAttribute"/>:
+/// a key property may also carry a <c>[DbColumn]</c> override for the
+/// SQL column name, and the aliasing rule matches the runtime
+/// <c>DbCommandBuilder</c> emitter.
+/// </para>
+/// <para>
+/// <c>[PublicAPI]</c> marks the attribute as consumed by downstream NuGet
+/// consumers + the DbTableGenerator source generator — ReSharper has no
+/// visibility into those external / generated readers.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+[PublicAPI]
+public sealed class DbKeyAttribute : Attribute
+{
+}

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Wolfgang.Etl.DbClient.DbKeyAttribute
+Wolfgang.Etl.DbClient.DbKeyAttribute.DbKeyAttribute() -> void

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbTableGeneratorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbTableGeneratorTests.cs
@@ -44,6 +44,54 @@ public partial record GeneratedOrder
 
 
 
+// Single-key fixture — verifies Update/Delete emit against a single
+// [DbKey] property with a [DbColumn] override on the key column.
+[DbTable("widgets")]
+[UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+public partial record GeneratedWidget
+{
+    [DbKey]
+    [DbColumn("widget_id")]
+    public int Id { get; init; }
+
+    public string Name { get; init; } = string.Empty;
+    public decimal Price { get; init; }
+}
+
+
+
+// Composite-key fixture — two [DbKey] properties in declaration order.
+// The WHERE clause preserves that order.
+[DbTable("order_lines")]
+[UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+public partial record GeneratedOrderLine
+{
+    [DbKey]
+    [DbColumn("order_id")]
+    public int OrderId { get; init; }
+
+    [DbKey]
+    [DbColumn("line_no")]
+    public int LineNumber { get; init; }
+
+    public string Sku { get; init; } = string.Empty;
+    public int Quantity { get; init; }
+}
+
+
+
+// Key-only fixture — no non-key columns. Update MUST NOT be emitted
+// (nothing to SET). Delete is still emitted.
+[DbTable("tokens")]
+[UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+public partial record GeneratedTokenOnly
+{
+    [DbKey]
+    public string Token { get; init; } = string.Empty;
+}
+
+
+
 public class DbTableGeneratorTests
 {
     [Fact]
@@ -106,6 +154,107 @@ public class DbTableGeneratorTests
             "SELECT order_id AS OrderId, customer_name AS Customer, Total FROM orders",
             sql
         );
+    }
+
+
+
+    [Fact]
+    public void Generator_emits_Update_const_with_single_key_and_column_aliasing()
+    {
+        var sql = GeneratedWidget.Update;
+
+        // SET covers every non-key column; WHERE uses the single [DbKey]
+        // with its [DbColumn] override.
+        Assert.Equal
+        (
+            "UPDATE widgets SET Name = @Name, Price = @Price WHERE widget_id = @Id",
+            sql
+        );
+    }
+
+
+
+    [Fact]
+    public void Generator_emits_Update_const_with_composite_key_in_declaration_order()
+    {
+        var sql = GeneratedOrderLine.Update;
+
+        Assert.Equal
+        (
+            "UPDATE order_lines SET Sku = @Sku, Quantity = @Quantity WHERE order_id = @OrderId AND line_no = @LineNumber",
+            sql
+        );
+    }
+
+
+
+    [Fact]
+    public void Generator_emits_Delete_const_with_single_key()
+    {
+        var sql = GeneratedWidget.Delete;
+
+        Assert.Equal
+        (
+            "DELETE FROM widgets WHERE widget_id = @Id",
+            sql
+        );
+    }
+
+
+
+    [Fact]
+    public void Generator_emits_Delete_const_with_composite_key()
+    {
+        var sql = GeneratedOrderLine.Delete;
+
+        Assert.Equal
+        (
+            "DELETE FROM order_lines WHERE order_id = @OrderId AND line_no = @LineNumber",
+            sql
+        );
+    }
+
+
+
+    [Fact]
+    public void Generator_emits_Delete_but_not_Update_when_type_has_no_non_key_columns()
+    {
+        // Key-only type: Update would have nothing to SET, so it's not
+        // emitted. Delete is still meaningful. Verified indirectly via
+        // reflection — a compile-time reference to a missing const would
+        // fail the build, so absence is what we assert.
+        var deleteSql = GeneratedTokenOnly.Delete;
+        Assert.Equal("DELETE FROM tokens WHERE Token = @Token", deleteSql);
+
+        var hasUpdate = typeof(GeneratedTokenOnly).GetField
+        (
+            "Update",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static
+        );
+        Assert.Null(hasUpdate);
+    }
+
+
+
+    [Fact]
+    public void Generator_does_not_emit_Update_or_Delete_when_type_has_no_key()
+    {
+        // GeneratedPerson / GeneratedOrder have no [DbKey] properties.
+        // The Update/Delete consts must not be present — a Where clause
+        // over zero keys would match every row.
+        var updateField = typeof(GeneratedPerson).GetField
+        (
+            "Update",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static
+        );
+        var deleteField = typeof(GeneratedPerson).GetField
+        (
+            "Delete",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static
+        );
+
+        Assert.Null(updateField);
+        Assert.Null(deleteField);
     }
 
 


### PR DESCRIPTION
## Summary

Adds \`Wolfgang.Etl.DbClient.DbKeyAttribute\` and teaches \`DbTableGenerator\` to emit \`public const string Update\` and \`public const string Delete\` on any \`[DbTable]\` type that has \`[DbKey]\`-marked properties.

Stacks on #276 (Select const). Together they bring the generator's surface to Insert / Select / Update / Delete + Bind — full CRUD.

## Emission rules

- **\`Update\`** — \`UPDATE <table> SET <non-key cols> WHERE <keys>\`. Emitted only when the type has at least one \`[DbKey]\` AND at least one non-key mapped column. A key-only type has nothing to SET → no const, and a missing-symbol compile error at the consumer catches the intent mismatch cleanly.
- **\`Delete\`** — \`DELETE FROM <table> WHERE <keys>\`. Emitted when at least one \`[DbKey]\` is present. A type with no keys → no const, avoiding a WHERE-clause-over-zero-keys that matches every row.

Composite keys: WHERE clause preserves property declaration order and combines with \`AND\`. Key columns may also carry a \`[DbColumn]\` override — honoured identically in the WHERE and in the parameter placeholder.

## Example

\`\`\`csharp
[DbTable(\"order_lines\")]
public partial record GeneratedOrderLine
{
    [DbKey] [DbColumn(\"order_id\")] public int OrderId { get; init; }
    [DbKey] [DbColumn(\"line_no\")]  public int LineNumber { get; init; }
    public string Sku { get; init; } = \"\";
    public int Quantity { get; init; }
}

// Generated:
// Update = \"UPDATE order_lines SET Sku = @Sku, Quantity = @Quantity WHERE order_id = @OrderId AND line_no = @LineNumber\"
// Delete = \"DELETE FROM order_lines WHERE order_id = @OrderId AND line_no = @LineNumber\"
\`\`\`

## Public API

- \`Wolfgang.Etl.DbClient.DbKeyAttribute\` (property-scoped, non-inheritable, single).
- \`Wolfgang.Etl.DbClient.DbKeyAttribute.DbKeyAttribute() -> void\`.

Recorded in \`PublicAPI.Unshipped.txt\`.

## Test plan

- [x] Generator + main project + test project all build clean (\`dotnet build -c Release\`).
- [x] 11/11 \`DbTableGeneratorTests\` pass on net10.0 (3 existing + 2 Select + 6 Update/Delete/key-guard).
- [ ] CI multi-TFM matrix.

## Not in this PR

- Wire-up of \`DbCommandBuilder\` to prefer the generated \`Update\`/\`Delete\` const over reflection when present — the reflection path stays authoritative for now; consumer opt-in reads the const directly.
- \`ValidateSchema\` emit (#20 integration) — the runtime \`DbSchemaValidator\` (#271) covers this; a compile-time equivalent is a separate design conversation.

Refs #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)