### PR TITLE
feat: EtlPipeline extensions for DbExtractor / DbLoader (#280)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,43 @@ public class EmployeeRecord
 
 ---
 
+## 🔗 Fluent EtlPipeline chain (v0.7.0+)
+
+For end-to-end pipelines that read from a database and write somewhere else (another
+DB, a JSON file, a CSV, etc.), the class-named factories over
+[`EtlPipeline`](https://chris-wolfgang.github.io/Etl-DbClient/docs/etl-pipeline.html)
+compose cleanly with the sibling packages in the ETL family:
+
+```csharp
+// Same-database ETL: filter with server-side paging, then reload
+await EtlPipeline
+    .Create()
+    .DbExtractor<Invoice>(sourceConn, "SELECT * FROM Invoices WHERE Status = @Status")
+    .Parameters(new DynamicParameters(new { Status = "paid" }))
+    .ServerOffset(0)
+    .ServerLimit(1000)
+    .DbLoader<Invoice>(destConn, "INSERT INTO PaidInvoices (Id, Total) VALUES (@Id, @Total)")
+    .RunAsync();
+
+// Cross-package: SQL query → JSONL file (needs Wolfgang.Etl.Json)
+await EtlPipeline
+    .Create()
+    .DbExtractor<Person>(conn, "SELECT * FROM People WHERE Active = 1")
+    .JsonLineLoader<Person>("people.jsonl")
+    .RunAsync();
+```
+
+The `DbExtractor<T>` / `DbLoader<T>` factories return builder types with fluent
+setters for every knob on the underlying extractor and loader (paging,
+`CommandType`, `ManageConnection`, `Parameters`, `TotalCountQuery`,
+`ErrorHandling`); the chain transitions into the plain `IEtlPipeline<T>` on the
+first operator or terminator call. See
+[docs/etl-pipeline.md](docfx_project/docs/etl-pipeline.md) for the full surface
+and the [Example.EtlPipeline](examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/)
+runnable project.
+
+---
+
 ## ✨ Features
 
 | Feature | Description |

--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -49,6 +49,7 @@
     <Project Path="examples/Wolfgang.Etl.DbClient.Example.AutoSql/Wolfgang.Etl.DbClient.Example.AutoSql.csproj" />
     <Project Path="examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction.csproj" />
     <Project Path="examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj" />
+    <Project Path="examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Wolfgang.Etl.DbClient.Example.EtlPipeline.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj" />

--- a/docfx_project/docs/etl-pipeline.md
+++ b/docfx_project/docs/etl-pipeline.md
@@ -1,0 +1,206 @@
+# Fluent EtlPipeline chain
+
+The `DbExtractor<T>` and `DbLoader<T>` types plug into the generic
+[`EtlPipeline`](xref:Wolfgang.Etl.Abstractions.EtlPipeline) framework via a set
+of class-named factory / terminator extensions. That lets a single fluent chain
+read from a database, thread rows through operators from
+`Wolfgang.Etl.Transformers`, and write to any sink shipped by the ETL family
+— another database, JSON, CSV, `Console`, an arbitrary `LoaderBase<T, TProgress>`,
+or an `IAsyncEnumerable<T>` escape hatch.
+
+Added in **v0.7.0**. Requires `Wolfgang.Etl.Abstractions` ≥ 0.16.0.
+
+## The pattern
+
+Every source and sink hangs off the same `EtlPipeline.Create()` seed, so every
+pipeline reads the same way regardless of the format at either end:
+
+```csharp
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.DbClient;
+
+await EtlPipeline
+    .Create()
+    .DbExtractor<Person>(connection, "SELECT * FROM People WHERE Active = 1")
+    .DbLoader<Person>(destConnection, "INSERT INTO ActivePeople (Id, Name) VALUES (@Id, @Name)")
+    .RunAsync();
+```
+
+`DbExtractor<T>` returns an
+[`IDbExtractorBuilder<T>`](xref:Wolfgang.Etl.DbClient.IDbExtractorBuilder`1);
+`DbLoader<T>` returns an
+[`IDbLoaderBuilder<T>`](xref:Wolfgang.Etl.DbClient.IDbLoaderBuilder`1). Both are
+just `IEtlPipeline<T>` / `IEtlPipelineSink` with extra fluent setters — on the
+first operator or terminator call they transition seamlessly into the plain
+pipeline interfaces.
+
+## Extractor knobs
+
+Every configurable property on `DbExtractor<T>` has a matching builder setter:
+
+| Setter | Underlying property | Purpose |
+|---|---|---|
+| `CommandType(CommandType)` | `DbExtractor<T>.CommandType` | `Text` (default) or `StoredProcedure`. |
+| `ManageConnection(bool)` | `DbExtractor<T>.ManageConnection` | When `true`, extractor opens/closes the connection. |
+| `Parameters(DynamicParameters)` | `DbExtractor<T>.Parameters` | Dapper parameter bag; overrides constructor `Parameters`. |
+| `ServerOffset(long?)` | `DbExtractor<T>.ServerOffset` | Row offset for server-side paging. |
+| `ServerLimit(long?)` | `DbExtractor<T>.ServerLimit` | Page size in rows. |
+| `PagingClauseTemplate(string)` | `DbExtractor<T>.PagingClauseTemplate` | SQL appended when both offset+limit are set (default `LIMIT @PageLimit OFFSET @PageOffset`). |
+| `TotalCountQuery(Func<CancellationToken, Task<int>>)` | `DbExtractor<T>.TotalCountQuery` | Snapshot the total row count for progress reporting. |
+
+Server-side paging kicks in only when **both** `ServerOffset` and `ServerLimit`
+are set — matching the underlying `DbExtractor.ApplyServerPaging` semantics.
+
+## Loader knobs
+
+| Setter | Underlying property | Purpose |
+|---|---|---|
+| `CommandType(CommandType)` | `DbLoader<T>.CommandType` | `Text` (default) or `StoredProcedure`. |
+| `ManageConnection(bool)` | `DbLoader<T>.ManageConnection` | When `true`, loader opens/closes the connection. |
+| `ErrorHandling(RowErrorHandling)` | `DbLoader<T>.ErrorHandling` | `Abort` (default) or `Skip` (per-record path only). |
+
+Dry-run behaviour on `DbLoader<T>` flows through the shared `ISupportDryRun`
+pipeline hook — no builder-specific setter, consistent with the rest of the ETL
+family.
+
+## Connection ownership
+
+The pipeline never overrides ownership. When `ManageConnection` is `false` (the
+default) the caller owns the connection lifetime, so the caller is responsible
+for opening the connection before `RunAsync` and disposing it after. When
+`ManageConnection` is `true` the extractor / loader opens and closes it. There
+is no factory-created file handle here (unlike `JsonLineLoader<T>(this
+IEtlPipeline<T>, string path)`), so no `DisposingOwned`-style resource handoff
+applies.
+
+## Cross-package chains
+
+Any format package that ships EtlPipeline extensions composes with DbClient:
+
+```csharp
+// SQL query → JSONL file (needs Wolfgang.Etl.Json)
+await EtlPipeline
+    .Create()
+    .DbExtractor<Person>(conn, "SELECT * FROM People WHERE Active = 1")
+    .JsonLineLoader<Person>("people.jsonl")
+    .RunAsync();
+
+// JSONL file → database table
+await EtlPipeline
+    .Create()
+    .JsonLineExtractor<Order>("orders.jsonl")
+    .DbLoader<Order>(conn, "INSERT INTO Orders (Id, Total) VALUES (@Id, @Total)")
+    .RunAsync();
+```
+
+## Reusing a pre-configured extractor or loader
+
+Both `DbExtractor` and `DbLoader` extensions have overloads that accept an
+existing instance instead of connection + SQL. Setter calls on the returned
+builder mutate the caller's instance — useful when the extractor / loader is
+constructed elsewhere (e.g. dependency injection) and needs a chain-time
+override:
+
+```csharp
+var extractor = serviceProvider.GetRequiredService<DbExtractor<Person>>();
+
+await EtlPipeline
+    .Create()
+    .DbExtractor(extractor)           // reuse the DI-registered instance
+    .ServerOffset(0)                  // mutates `extractor.ServerOffset`
+    .ServerLimit(500)
+    .DbLoader<Person>(destConn, insertSql)
+    .RunAsync();
+```
+
+## Server-side paging
+
+```csharp
+await EtlPipeline
+    .Create()
+    .DbExtractor<Invoice>(conn, "SELECT * FROM Invoices WHERE Status = @Status")
+    .Parameters(new DynamicParameters(new { Status = "paid" }))
+    .ServerOffset(1000)
+    .ServerLimit(500)
+    .DbLoader<Invoice>(destConn, "INSERT INTO PaidInvoicesPage2 ...")
+    .RunAsync();
+```
+
+When both `ServerOffset` and `ServerLimit` are set, the extractor appends
+`PagingClauseTemplate` (default `LIMIT @PageLimit OFFSET @PageOffset`) to the
+command text and adds `@PageOffset` / `@PageLimit` to the parameter set. For
+databases that use a different paging dialect (e.g. SQL Server's
+`OFFSET n ROWS FETCH NEXT m ROWS ONLY`), override the template:
+
+```csharp
+await EtlPipeline
+    .Create()
+    .DbExtractor<Invoice>(conn, "SELECT * FROM Invoices ORDER BY Id")
+    .ServerOffset(0)
+    .ServerLimit(500)
+    .PagingClauseTemplate("OFFSET @PageOffset ROWS FETCH NEXT @PageLimit ROWS ONLY")
+    .DbLoader<Invoice>(destConn, "...")
+    .RunAsync();
+```
+
+## Error handling
+
+`RowErrorHandling.Skip` on the loader silently drops the failing row and
+continues (per-record path only, requires `InsertBatchSize = 1`). Useful for
+imports where a per-row PK conflict or check-constraint violation shouldn't
+tear down the whole run:
+
+```csharp
+var loader = new DbLoader<Widget>(destConn, insertSql) { InsertBatchSize = 1 };
+
+await EtlPipeline
+    .Create()
+    .DbExtractor<Widget>(srcConn, "SELECT * FROM StagingWidgets")
+    .DbLoader(loader)
+    .ErrorHandling(RowErrorHandling.Skip)
+    .RunAsync();
+```
+
+## Escape hatch: enumerate without a sink
+
+`AsAsyncEnumerable()` drops down to the raw stream, useful when the caller
+wants to apply `System.Linq.Async` operators the pipeline doesn't ship, or when
+the row processing is not a "load somewhere" pattern at all:
+
+```csharp
+using System.Linq;
+
+var totalPaid = await EtlPipeline
+    .Create()
+    .DbExtractor<Invoice>(conn, "SELECT * FROM Invoices WHERE Status = 'paid'")
+    .AsAsyncEnumerable()
+    .SumAsync(i => i.Total);
+```
+
+## Progress reporting
+
+`RunAsync` accepts an optional `IProgress<EtlPipelineProgress>`:
+
+```csharp
+var progress = new Progress<EtlPipelineProgress>(p =>
+    Console.WriteLine($"loaded {p.RecordsLoaded}"));
+
+await EtlPipeline
+    .Create()
+    .DbExtractor<Person>(conn, sql)
+    .DbLoader<Person>(destConn, insertSql)
+    .RunAsync(progress);
+```
+
+For extractor-side totals, wire
+[`TotalCountQuery`](xref:Wolfgang.Etl.DbClient.IDbExtractorBuilder`1.TotalCountQuery*)
+so the extractor can populate `EtlPipelineProgress.TotalRecords`.
+
+## See also
+
+- [`EtlPipeline`](xref:Wolfgang.Etl.Abstractions.EtlPipeline) — the framework
+  entry point in `Wolfgang.Etl.Abstractions`.
+- [`IEtlPipeline<T>`](xref:Wolfgang.Etl.Abstractions.IEtlPipeline`1) — the core
+  chain interface.
+- The [Example.EtlPipeline](https://github.com/Chris-Wolfgang/Etl-DbClient/tree/main/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline)
+  runnable project.

--- a/docfx_project/docs/toc.yml
+++ b/docfx_project/docs/toc.yml
@@ -4,5 +4,7 @@
   href: introduction.md
 - name: Getting Started
   href: getting-started.md
+- name: Fluent EtlPipeline chain
+  href: etl-pipeline.md
 - name: Project website
   href: 'https://github.com/Chris-Wolfgang/Etl-DbClient'

--- a/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Sqlite;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.DbClient;
+
+// ---------------------------------------------------------------
+// Example: fluent EtlPipeline chain over DbExtractor / DbLoader (#280)
+//
+// Demonstrates the v0.7.0+ EtlPipeline extension surface:
+//   * DbExtractor<T>(this EtlPipeline, DbConnection, string, DbTransaction?)
+//   * DbLoader<T>(this IEtlPipeline<T>, DbConnection, string, DbTransaction?)
+// plus the fluent builder setters that mirror the underlying extractor / loader.
+//
+// Everything runs against two in-memory SQLite databases so the example is
+// self-contained and byte-repeatable.
+// ---------------------------------------------------------------
+
+// Set up an in-memory source with 20 orders and an empty destination.
+using var src = new SqliteConnection("Data Source=:memory:");
+using var dest = new SqliteConnection("Data Source=:memory:");
+await src.OpenAsync().ConfigureAwait(false);
+await dest.OpenAsync().ConfigureAwait(false);
+
+using (var cmd = src.CreateCommand())
+{
+    cmd.CommandText = @"
+        CREATE TABLE Orders (
+            Id INTEGER PRIMARY KEY,
+            Customer TEXT NOT NULL,
+            Total REAL NOT NULL,
+            Status TEXT NOT NULL
+        );
+    ";
+    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+}
+
+for (var i = 1; i <= 20; i++)
+{
+    using var ins = src.CreateCommand();
+    ins.CommandText =
+        $"INSERT INTO Orders (Id, Customer, Total, Status) VALUES ({i}, 'c{i}', {i * 10.5}, '{(i % 3 == 0 ? "pending" : "paid")}');";
+    await ins.ExecuteNonQueryAsync().ConfigureAwait(false);
+}
+
+using (var cmd = dest.CreateCommand())
+{
+    cmd.CommandText = "CREATE TABLE PaidOrders (Id INTEGER PRIMARY KEY, Customer TEXT NOT NULL, Total REAL NOT NULL);";
+    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+}
+
+
+// -----------------------------------------------------------------
+// 1. End-to-end pipeline: SQL query on `src` → INSERT on `dest`
+// -----------------------------------------------------------------
+Console.WriteLine("== 1. round-trip via fluent chain ==");
+
+await EtlPipeline
+    .Create()
+    .DbExtractor<Order>(src, "SELECT Id, Customer, Total FROM Orders WHERE Status = 'paid' ORDER BY Id")
+    .DbLoader<Order>(dest, "INSERT INTO PaidOrders (Id, Customer, Total) VALUES (@Id, @Customer, @Total)")
+    .RunAsync()
+    .ConfigureAwait(false);
+
+Console.WriteLine($"   paid orders copied: {await CountAsync(dest, "PaidOrders").ConfigureAwait(false)}");
+
+
+// -----------------------------------------------------------------
+// 2. Server-side paging via the builder
+// -----------------------------------------------------------------
+Console.WriteLine();
+Console.WriteLine("== 2. server-side paging (skip 5, take 5) ==");
+
+using var page = new SqliteConnection("Data Source=:memory:");
+await page.OpenAsync().ConfigureAwait(false);
+using (var cmd = page.CreateCommand())
+{
+    cmd.CommandText = "CREATE TABLE OrdersPage (Id INTEGER PRIMARY KEY, Customer TEXT NOT NULL, Total REAL NOT NULL);";
+    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+}
+
+await EtlPipeline
+    .Create()
+    .DbExtractor<Order>(src, "SELECT Id, Customer, Total FROM Orders ORDER BY Id")
+    .ServerOffset(5)
+    .ServerLimit(5)
+    .DbLoader<Order>(page, "INSERT INTO OrdersPage (Id, Customer, Total) VALUES (@Id, @Customer, @Total)")
+    .RunAsync()
+    .ConfigureAwait(false);
+
+Console.WriteLine($"   rows on page: {await CountAsync(page, "OrdersPage").ConfigureAwait(false)}");
+
+
+// -----------------------------------------------------------------
+// 3. Escape hatch: AsAsyncEnumerable + LINQ aggregation, no sink
+// -----------------------------------------------------------------
+Console.WriteLine();
+Console.WriteLine("== 3. escape hatch: sum totals inline ==");
+
+double sum = 0;
+await foreach (var order in EtlPipeline
+    .Create()
+    .DbExtractor<Order>(src, "SELECT Id, Customer, Total FROM Orders WHERE Status = 'paid'")
+    .AsAsyncEnumerable()
+    .ConfigureAwait(false))
+{
+    sum += order.Total;
+}
+
+Console.WriteLine($"   sum of paid totals: {sum:F2}");
+
+
+// -----------------------------------------------------------------
+// 4. Error handling: RowErrorHandling.Skip on the loader builder
+// -----------------------------------------------------------------
+Console.WriteLine();
+Console.WriteLine("== 4. RowErrorHandling.Skip continues past PK conflict ==");
+
+// Pre-insert row Id=3 so the pipeline hits a PK conflict on it.
+using (var seed = dest.CreateCommand())
+{
+    seed.CommandText = "DELETE FROM PaidOrders; INSERT INTO PaidOrders (Id, Customer, Total) VALUES (3, 'preexisting', 0.0);";
+    await seed.ExecuteNonQueryAsync().ConfigureAwait(false);
+}
+
+var loader = new DbLoader<Order>
+(
+    dest,
+    "INSERT INTO PaidOrders (Id, Customer, Total) VALUES (@Id, @Customer, @Total)"
+)
+{
+    InsertBatchSize = 1,
+};
+
+await EtlPipeline
+    .Create()
+    .DbExtractor<Order>(src, "SELECT Id, Customer, Total FROM Orders WHERE Status = 'paid' ORDER BY Id")
+    .DbLoader(loader)
+    .ErrorHandling(RowErrorHandling.Skip)
+    .RunAsync()
+    .ConfigureAwait(false);
+
+Console.WriteLine($"   total rows in dest: {await CountAsync(dest, "PaidOrders").ConfigureAwait(false)} (row 3 was pre-existing; the rest landed)");
+
+
+// -----------------------------------------------------------------
+// 5. Progress reporting
+// -----------------------------------------------------------------
+Console.WriteLine();
+Console.WriteLine("== 5. progress reporting via IProgress<EtlPipelineProgress> ==");
+
+using var live = new SqliteConnection("Data Source=:memory:");
+await live.OpenAsync().ConfigureAwait(false);
+using (var cmd = live.CreateCommand())
+{
+    cmd.CommandText = "CREATE TABLE Live (Id INTEGER PRIMARY KEY, Customer TEXT NOT NULL, Total REAL NOT NULL);";
+    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+}
+
+var progress = new Progress<EtlPipelineProgress>(p =>
+    Console.WriteLine($"   ↪ loaded={p.RecordsLoaded}"));
+
+await EtlPipeline
+    .Create()
+    .DbExtractor<Order>(src, "SELECT Id, Customer, Total FROM Orders ORDER BY Id")
+    .DbLoader<Order>(live, "INSERT INTO Live (Id, Customer, Total) VALUES (@Id, @Customer, @Total)")
+    .RunAsync(progress)
+    .ConfigureAwait(false);
+
+
+Console.WriteLine();
+Console.WriteLine("Done.");
+
+
+// -----------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------
+
+static async Task<long> CountAsync(SqliteConnection conn, string table)
+{
+    using var cmd = conn.CreateCommand();
+    cmd.CommandText = $"SELECT COUNT(*) FROM {table};";
+    var raw = await cmd.ExecuteScalarAsync().ConfigureAwait(false);
+    return Convert.ToInt64(raw, System.Globalization.CultureInfo.InvariantCulture);
+}
+
+
+[UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+internal sealed class Order
+{
+    public int Id { get; set; }
+    public string Customer { get; set; } = "";
+    public double Total { get; set; }
+}

--- a/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dapper;
 using JetBrains.Annotations;
 using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.Abstractions;
@@ -65,7 +66,7 @@ await EtlPipeline
     .RunAsync()
     .ConfigureAwait(false);
 
-Console.WriteLine($"   paid orders copied: {await CountAsync(dest, "SELECT COUNT(*) FROM PaidOrders;").ConfigureAwait(false)}");
+Console.WriteLine($"   paid orders copied: {await dest.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM PaidOrders;").ConfigureAwait(false)}");
 
 
 // -----------------------------------------------------------------
@@ -91,7 +92,7 @@ await EtlPipeline
     .RunAsync()
     .ConfigureAwait(false);
 
-Console.WriteLine($"   rows on page: {await CountAsync(page, "SELECT COUNT(*) FROM OrdersPage;").ConfigureAwait(false)}");
+Console.WriteLine($"   rows on page: {await page.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM OrdersPage;").ConfigureAwait(false)}");
 
 
 // -----------------------------------------------------------------
@@ -143,7 +144,7 @@ await EtlPipeline
     .RunAsync()
     .ConfigureAwait(false);
 
-Console.WriteLine($"   total rows in dest: {await CountAsync(dest, "SELECT COUNT(*) FROM PaidOrders;").ConfigureAwait(false)} (row 3 was pre-existing; the rest landed)");
+Console.WriteLine($"   total rows in dest: {await dest.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM PaidOrders;").ConfigureAwait(false)} (row 3 was pre-existing; the rest landed)");
 
 
 // -----------------------------------------------------------------
@@ -176,21 +177,8 @@ Console.WriteLine("Done.");
 
 
 // -----------------------------------------------------------------
-// Helpers
+// Types
 // -----------------------------------------------------------------
-
-static async Task<long> CountAsync(SqliteConnection conn, string sql)
-{
-    // Callers pass a compile-time SQL literal, e.g.
-    // `CountAsync(conn, "SELECT COUNT(*) FROM PaidOrders;")`. No
-    // interpolation on a parameter, no user input — Semgrep sees this
-    // as a fixed string ExecuteScalar, not a formatted-SQL sink.
-    using var cmd = conn.CreateCommand();
-    cmd.CommandText = sql;
-    var raw = await cmd.ExecuteScalarAsync().ConfigureAwait(false);
-    return Convert.ToInt64(raw, System.Globalization.CultureInfo.InvariantCulture);
-}
-
 
 [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
 internal sealed class Order

--- a/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
@@ -181,7 +181,12 @@ Console.WriteLine("Done.");
 
 static async Task<long> CountAsync(SqliteConnection conn, string table)
 {
+    // `table` is only ever a hard-coded table name from this example's own
+    // Main body ("PaidOrders" / "OrdersPage"). No user input reaches this
+    // path — it's a two-line row-count helper for the example's console
+    // output, not a query builder.
     using var cmd = conn.CreateCommand();
+    // nosemgrep: csharp.lang.security.sqli.csharp-sqli.csharp-sqli
     cmd.CommandText = $"SELECT COUNT(*) FROM {table};";
     var raw = await cmd.ExecuteScalarAsync().ConfigureAwait(false);
     return Convert.ToInt64(raw, System.Globalization.CultureInfo.InvariantCulture);

--- a/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
@@ -65,7 +65,7 @@ await EtlPipeline
     .RunAsync()
     .ConfigureAwait(false);
 
-Console.WriteLine($"   paid orders copied: {await CountAsync(dest, "PaidOrders").ConfigureAwait(false)}");
+Console.WriteLine($"   paid orders copied: {await CountAsync(dest, "SELECT COUNT(*) FROM PaidOrders;").ConfigureAwait(false)}");
 
 
 // -----------------------------------------------------------------
@@ -91,7 +91,7 @@ await EtlPipeline
     .RunAsync()
     .ConfigureAwait(false);
 
-Console.WriteLine($"   rows on page: {await CountAsync(page, "OrdersPage").ConfigureAwait(false)}");
+Console.WriteLine($"   rows on page: {await CountAsync(page, "SELECT COUNT(*) FROM OrdersPage;").ConfigureAwait(false)}");
 
 
 // -----------------------------------------------------------------
@@ -143,7 +143,7 @@ await EtlPipeline
     .RunAsync()
     .ConfigureAwait(false);
 
-Console.WriteLine($"   total rows in dest: {await CountAsync(dest, "PaidOrders").ConfigureAwait(false)} (row 3 was pre-existing; the rest landed)");
+Console.WriteLine($"   total rows in dest: {await CountAsync(dest, "SELECT COUNT(*) FROM PaidOrders;").ConfigureAwait(false)} (row 3 was pre-existing; the rest landed)");
 
 
 // -----------------------------------------------------------------
@@ -179,15 +179,14 @@ Console.WriteLine("Done.");
 // Helpers
 // -----------------------------------------------------------------
 
-static async Task<long> CountAsync(SqliteConnection conn, string table)
+static async Task<long> CountAsync(SqliteConnection conn, string sql)
 {
-    // `table` is only ever a hard-coded table name from this example's own
-    // Main body ("PaidOrders" / "OrdersPage"). No user input reaches this
-    // path — it's a two-line row-count helper for the example's console
-    // output, not a query builder.
+    // Callers pass a compile-time SQL literal, e.g.
+    // `CountAsync(conn, "SELECT COUNT(*) FROM PaidOrders;")`. No
+    // interpolation on a parameter, no user input — Semgrep sees this
+    // as a fixed string ExecuteScalar, not a formatted-SQL sink.
     using var cmd = conn.CreateCommand();
-    // nosemgrep: csharp.lang.security.sqli.csharp-sqli.csharp-sqli
-    cmd.CommandText = $"SELECT COUNT(*) FROM {table};";
+    cmd.CommandText = sql;
     var raw = await cmd.ExecuteScalarAsync().ConfigureAwait(false);
     return Convert.ToInt64(raw, System.Globalization.CultureInfo.InvariantCulture);
 }

--- a/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Wolfgang.Etl.DbClient.Example.EtlPipeline.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Wolfgang.Etl.DbClient.Example.EtlPipeline.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 same treatment as sister examples. -->
+    <NoWarn>$(NoWarn);MA0002;MA0004;MA0048;VSTHRD200;S3903;NU1903</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.DbClient\Wolfgang.Etl.DbClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>

--- a/src/Wolfgang.Etl.DbClient/DbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorBuilder.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Default <see cref="IDbExtractorBuilder{T}"/> implementation. Configuration
+/// setters mutate the wrapped <see cref="DbExtractor{TRecord}"/>; pipeline
+/// operators materialize a fresh <see cref="IEtlPipeline{T}"/> from the
+/// configured extractor and delegate to it.
+/// </summary>
+/// <remarks>
+/// The <see cref="EtlPipelineSourceExtensions.From{T, TProgress}"/> materialization
+/// wraps <c>extractor.ExtractAsync(token)</c> in a delegate read at enumeration
+/// time, so setters called on this builder still take effect even after a
+/// pipeline operator has consumed the builder — the extractor instance is the
+/// single source of truth throughout.
+/// </remarks>
+internal sealed class DbExtractorBuilder<T> : IDbExtractorBuilder<T>
+    where T : notnull
+{
+    private readonly EtlPipeline _pipeline;
+    private readonly DbExtractor<T> _extractor;
+
+
+
+    internal DbExtractorBuilder(EtlPipeline pipeline, DbExtractor<T> extractor)
+    {
+        _pipeline = pipeline;
+        _extractor = extractor;
+    }
+
+
+
+    // -----------------------------------------------------------------
+    // Fluent setters
+    // -----------------------------------------------------------------
+
+    public IDbExtractorBuilder<T> CommandType(CommandType commandType)
+    {
+        _extractor.CommandType = commandType;
+        return this;
+    }
+
+
+
+    public IDbExtractorBuilder<T> ManageConnection(bool manage)
+    {
+        _extractor.ManageConnection = manage;
+        return this;
+    }
+
+
+
+    public IDbExtractorBuilder<T> Parameters(DynamicParameters parameters)
+    {
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        _extractor.Parameters = parameters;
+        return this;
+    }
+
+
+
+    public IDbExtractorBuilder<T> ServerOffset(long? offset)
+    {
+        _extractor.ServerOffset = offset;
+        return this;
+    }
+
+
+
+    public IDbExtractorBuilder<T> ServerLimit(long? limit)
+    {
+        _extractor.ServerLimit = limit;
+        return this;
+    }
+
+
+
+    public IDbExtractorBuilder<T> PagingClauseTemplate(string template)
+    {
+        if (template is null)
+        {
+            throw new ArgumentNullException(nameof(template));
+        }
+
+        _extractor.PagingClauseTemplate = template;
+        return this;
+    }
+
+
+
+    public IDbExtractorBuilder<T> TotalCountQuery(Func<CancellationToken, Task<int>> countQuery)
+    {
+        if (countQuery is null)
+        {
+            throw new ArgumentNullException(nameof(countQuery));
+        }
+
+        _extractor.TotalCountQuery = countQuery;
+        return this;
+    }
+
+
+
+    // -----------------------------------------------------------------
+    // IEtlPipeline<T> — delegate through a materialized pipeline. The
+    // extractor is passed by reference so any further setter calls on
+    // this builder still influence enumeration (see class remarks).
+    // -----------------------------------------------------------------
+
+    public IEtlPipeline<TOut> Through<TOut>(ITransformAsync<T, TOut> transformer)
+        where TOut : notnull
+        => Materialize().Through(transformer);
+
+
+
+    public IEtlPipeline<TOut> Through<TOut>(ITransformWithCancellationAsync<T, TOut> transformer)
+        where TOut : notnull
+        => Materialize().Through(transformer);
+
+
+
+    public IEtlPipeline<TOut> Through<TOut>(Func<IAsyncEnumerable<T>, IAsyncEnumerable<TOut>> stage)
+        where TOut : notnull
+        => Materialize().Through(stage);
+
+
+
+    public IEtlPipeline<TOut> Through<TOut>(Func<IAsyncEnumerable<T>, CancellationToken, IAsyncEnumerable<TOut>> stage)
+        where TOut : notnull
+        => Materialize().Through(stage);
+
+
+
+    public IEtlPipelineSink To<TProgress>(LoaderBase<T, TProgress> loader)
+        where TProgress : notnull
+        => Materialize().To(loader);
+
+
+
+    public IAsyncEnumerable<T> AsAsyncEnumerable(CancellationToken token = default)
+        => Materialize().AsAsyncEnumerable(token);
+
+
+
+    /// <summary>
+    /// The extractor being configured. Internal so the <c>DbLoader</c>
+    /// terminator extensions can materialize the pipeline through the same
+    /// extractor when a caller chains <c>DbExtractor(...).DbLoader(...)</c>
+    /// without an intermediate operator.
+    /// </summary>
+    internal DbExtractor<T> Extractor => _extractor;
+
+
+
+    private IEtlPipeline<T> Materialize()
+    {
+        return _pipeline.From(_extractor);
+    }
+}

--- a/src/Wolfgang.Etl.DbClient/DbLoaderBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoaderBuilder.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Default <see cref="IDbLoaderBuilder{T}"/> implementation. Configuration
+/// setters mutate the wrapped <see cref="DbLoader{TRecord}"/>;
+/// <see cref="IEtlPipelineSink.RunAsync"/> executes the pipeline via that
+/// loader.
+/// </summary>
+/// <remarks>
+/// Since the sink is materialized as <c>pipeline.To(loader)</c> when this
+/// builder is constructed, further setter calls still take effect: the
+/// underlying <see cref="EtlPipelineSink{T, TProgress}"/> reads the loader's
+/// properties at <see cref="IEtlPipelineSink.RunAsync"/> time, not at
+/// construction.
+/// </remarks>
+internal sealed class DbLoaderBuilder<T> : IDbLoaderBuilder<T>
+    where T : notnull
+{
+    private readonly IEtlPipelineSink _sink;
+    private readonly DbLoader<T> _loader;
+
+
+
+    internal DbLoaderBuilder(IEtlPipelineSink sink, DbLoader<T> loader)
+    {
+        _sink = sink;
+        _loader = loader;
+    }
+
+
+
+    // -----------------------------------------------------------------
+    // Fluent setters
+    // -----------------------------------------------------------------
+
+    public IDbLoaderBuilder<T> CommandType(CommandType commandType)
+    {
+        _loader.CommandType = commandType;
+        return this;
+    }
+
+
+
+    public IDbLoaderBuilder<T> ManageConnection(bool manage)
+    {
+        _loader.ManageConnection = manage;
+        return this;
+    }
+
+
+
+    public IDbLoaderBuilder<T> ErrorHandling(RowErrorHandling handling)
+    {
+        _loader.ErrorHandling = handling;
+        return this;
+    }
+
+
+
+    // -----------------------------------------------------------------
+    // IEtlPipelineSink
+    // -----------------------------------------------------------------
+
+    public Task RunAsync(IProgress<EtlPipelineProgress>? progress = null, CancellationToken token = default)
+    {
+        return _sink.RunAsync(progress, token);
+    }
+}

--- a/src/Wolfgang.Etl.DbClient/EtlPipelineDbClientExtensions.cs
+++ b/src/Wolfgang.Etl.DbClient/EtlPipelineDbClientExtensions.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Data.Common;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Class-named DbClient factories + terminators for the fluent
+/// <see cref="EtlPipeline"/> chain. Enables
+/// <c>EtlPipeline.Create().DbExtractor&lt;Order&gt;(conn, sql).DbLoader&lt;Order&gt;(destConn, insertSql).RunAsync()</c>
+/// alongside the sibling factories shipped by other format packages
+/// (<c>CsvExtractor</c>, <c>JsonLineLoader</c>, etc.).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Connection lifetime follows the existing
+/// <see cref="DbExtractor{TRecord}.ManageConnection"/> and
+/// <see cref="DbLoader{TRecord}.ManageConnection"/> semantics — the pipeline
+/// does <b>not</b> override ownership. When <c>ManageConnection</c> is
+/// <see langword="true"/> the extractor / loader opens and closes the
+/// connection; otherwise the caller owns it. There is no
+/// <c>DisposingOwned</c>-style resource handoff, because unlike file loaders
+/// there is no file handle created by the factory itself.
+/// </para>
+/// <para>
+/// Dry-run behaviour on the loader flows through the shared
+/// <see cref="ISupportDryRun"/> pipeline hook rather than a DbClient-specific
+/// setter, consistent with the other loaders.
+/// </para>
+/// </remarks>
+public static class EtlPipelineDbClientExtensions
+{
+    // -----------------------------------------------------------------
+    // Source factories
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Starts a pipeline that reads rows from a database query.
+    /// </summary>
+    /// <typeparam name="T">The record type produced by the extractor.</typeparam>
+    /// <param name="pipeline">The pipeline seed from <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="connection">
+    /// The <see cref="DbConnection"/> the extractor reads from. Caller retains
+    /// ownership unless <see cref="IDbExtractorBuilder{T}.ManageConnection"/>
+    /// is set to <see langword="true"/>.
+    /// </param>
+    /// <param name="commandText">The SQL query to execute.</param>
+    /// <param name="transaction">
+    /// An optional <see cref="DbTransaction"/> for isolation-level control.
+    /// The extractor never commits or rolls back the transaction.
+    /// </param>
+    /// <returns>An <see cref="IDbExtractorBuilder{T}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="pipeline"/>, <paramref name="connection"/>, or
+    /// <paramref name="commandText"/> is <see langword="null"/>.
+    /// </exception>
+    public static IDbExtractorBuilder<T> DbExtractor<T>
+    (
+        this EtlPipeline pipeline,
+        DbConnection connection,
+        string commandText,
+        DbTransaction? transaction = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        if (commandText is null)
+        {
+            throw new ArgumentNullException(nameof(commandText));
+        }
+
+        var extractor = new DbExtractor<T>(connection, commandText, transaction);
+        return new DbExtractorBuilder<T>(pipeline, extractor);
+    }
+
+
+
+    /// <summary>
+    /// Starts a pipeline from an existing <see cref="Wolfgang.Etl.DbClient.DbExtractor{TRecord}"/>
+    /// instance — for callers that already configured an extractor and want
+    /// to reuse it verbatim.
+    /// </summary>
+    /// <typeparam name="T">The record type produced by the extractor.</typeparam>
+    /// <param name="pipeline">The pipeline seed from <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="extractor">The pre-configured extractor.</param>
+    /// <returns>An <see cref="IDbExtractorBuilder{T}"/> for chaining. Setter
+    /// calls on the builder mutate <paramref name="extractor"/> in place.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="pipeline"/> or <paramref name="extractor"/> is <see langword="null"/>.
+    /// </exception>
+    public static IDbExtractorBuilder<T> DbExtractor<T>
+    (
+        this EtlPipeline pipeline,
+        DbExtractor<T> extractor
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (extractor is null)
+        {
+            throw new ArgumentNullException(nameof(extractor));
+        }
+
+        return new DbExtractorBuilder<T>(pipeline, extractor);
+    }
+
+
+
+    // -----------------------------------------------------------------
+    // Sink terminators
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Terminates the pipeline, writing each record to a database via an
+    /// <c>INSERT</c> / <c>UPDATE</c> command.
+    /// </summary>
+    /// <typeparam name="T">The record type consumed by the loader.</typeparam>
+    /// <param name="pipeline">The pipeline to terminate.</param>
+    /// <param name="connection">
+    /// The <see cref="DbConnection"/> the loader writes to. Caller retains
+    /// ownership unless <see cref="IDbLoaderBuilder{T}.ManageConnection"/>
+    /// is set to <see langword="true"/>.
+    /// </param>
+    /// <param name="commandText">The SQL command to execute per record.</param>
+    /// <param name="transaction">
+    /// An optional <see cref="DbTransaction"/>. If <see langword="null"/> the
+    /// loader creates and manages its own transaction (commit on success,
+    /// rollback on failure).
+    /// </param>
+    /// <returns>An <see cref="IDbLoaderBuilder{T}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="pipeline"/>, <paramref name="connection"/>, or
+    /// <paramref name="commandText"/> is <see langword="null"/>.
+    /// </exception>
+    public static IDbLoaderBuilder<T> DbLoader<T>
+    (
+        this IEtlPipeline<T> pipeline,
+        DbConnection connection,
+        string commandText,
+        DbTransaction? transaction = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        if (commandText is null)
+        {
+            throw new ArgumentNullException(nameof(commandText));
+        }
+
+        var loader = new DbLoader<T>(connection, commandText, transaction);
+        var sink = pipeline.To(loader);
+        return new DbLoaderBuilder<T>(sink, loader);
+    }
+
+
+
+    /// <summary>
+    /// Terminates the pipeline with a pre-configured
+    /// <see cref="Wolfgang.Etl.DbClient.DbLoader{TRecord}"/> instance — for callers that already
+    /// configured a loader (e.g. via a <c>WriteMode</c> ctor overload) and
+    /// want to reuse it verbatim.
+    /// </summary>
+    /// <typeparam name="T">The record type consumed by the loader.</typeparam>
+    /// <param name="pipeline">The pipeline to terminate.</param>
+    /// <param name="loader">The pre-configured loader.</param>
+    /// <returns>An <see cref="IDbLoaderBuilder{T}"/> for chaining. Setter
+    /// calls on the builder mutate <paramref name="loader"/> in place.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="pipeline"/> or <paramref name="loader"/> is <see langword="null"/>.
+    /// </exception>
+    public static IDbLoaderBuilder<T> DbLoader<T>
+    (
+        this IEtlPipeline<T> pipeline,
+        DbLoader<T> loader
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (loader is null)
+        {
+            throw new ArgumentNullException(nameof(loader));
+        }
+
+        var sink = pipeline.To(loader);
+        return new DbLoaderBuilder<T>(sink, loader);
+    }
+}

--- a/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Fluent builder for a <see cref="DbExtractor{TRecord}"/> hung off the generic
+/// <see cref="EtlPipeline"/> chain. Extends <see cref="IEtlPipeline{T}"/>, so a
+/// consumer transitions from configuring the extractor to appending pipeline
+/// operators simply by calling one — no explicit <c>Build()</c> step.
+/// </summary>
+/// <typeparam name="T">The record type produced by the extractor.</typeparam>
+/// <remarks>
+/// Each setter maps 1:1 to a public property on <see cref="DbExtractor{TRecord}"/>;
+/// no new configuration surface is introduced. Setters return the builder for
+/// chaining and take effect on the next enumeration of the pipeline.
+/// </remarks>
+public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
+    where T : notnull
+{
+    /// <summary>
+    /// Sets <see cref="DbExtractor{TRecord}.CommandType"/>. Default: <see cref="System.Data.CommandType.Text"/>.
+    /// </summary>
+    IDbExtractorBuilder<T> CommandType(CommandType commandType);
+
+
+    /// <summary>
+    /// Sets <see cref="DbExtractor{TRecord}.ManageConnection"/>. When <see langword="true"/>,
+    /// the extractor opens the connection before enumerating and closes it after
+    /// the enumeration finishes.
+    /// </summary>
+    IDbExtractorBuilder<T> ManageConnection(bool manage);
+
+
+    /// <summary>
+    /// Sets <see cref="DbExtractor{TRecord}.Parameters"/> — Dapper-style parameter
+    /// bag for the query. Overrides any parameters supplied via the constructor.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="parameters"/> is <see langword="null"/>.</exception>
+    IDbExtractorBuilder<T> Parameters(DynamicParameters parameters);
+
+
+    /// <summary>
+    /// Sets <see cref="DbExtractor{TRecord}.ServerOffset"/> for server-side paging.
+    /// Combined with <see cref="ServerLimit"/> and
+    /// <see cref="PagingClauseTemplate"/>, the extractor appends the paging clause
+    /// to the caller's SQL.
+    /// </summary>
+    IDbExtractorBuilder<T> ServerOffset(long? offset);
+
+
+    /// <summary>
+    /// Sets <see cref="DbExtractor{TRecord}.ServerLimit"/> for server-side paging.
+    /// </summary>
+    IDbExtractorBuilder<T> ServerLimit(long? limit);
+
+
+    /// <summary>
+    /// Sets <see cref="DbExtractor{TRecord}.PagingClauseTemplate"/> — the SQL
+    /// snippet appended when <see cref="ServerOffset"/> and/or
+    /// <see cref="ServerLimit"/> are set. Default:
+    /// <c>LIMIT @PageLimit OFFSET @PageOffset</c>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="template"/> is <see langword="null"/>.</exception>
+    IDbExtractorBuilder<T> PagingClauseTemplate(string template);
+
+
+    /// <summary>
+    /// Sets <see cref="DbExtractor{TRecord}.TotalCountQuery"/> — an optional
+    /// async delegate the extractor calls once at the start of enumeration to
+    /// snapshot the total row count for progress reporting.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="countQuery"/> is <see langword="null"/>.</exception>
+    IDbExtractorBuilder<T> TotalCountQuery(Func<CancellationToken, Task<int>> countQuery);
+}

--- a/src/Wolfgang.Etl.DbClient/IDbLoaderBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbLoaderBuilder.cs
@@ -1,0 +1,45 @@
+using System.Data;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Fluent builder for a <see cref="DbLoader{TRecord}"/> that terminates a
+/// generic <see cref="EtlPipeline"/> chain. Extends <see cref="IEtlPipelineSink"/>,
+/// so a consumer transitions from configuring the loader to running the
+/// pipeline simply by calling
+/// <see cref="IEtlPipelineSink.RunAsync(System.IProgress{EtlPipelineProgress}, System.Threading.CancellationToken)"/>
+/// — no explicit <c>Build()</c> step.
+/// </summary>
+/// <typeparam name="T">The record type consumed by the loader.</typeparam>
+/// <remarks>
+/// Each setter maps 1:1 to a public property on <see cref="DbLoader{TRecord}"/>;
+/// no new configuration surface is introduced. Setters return the builder for
+/// chaining and take effect on <see cref="IEtlPipelineSink.RunAsync"/>.
+/// </remarks>
+public interface IDbLoaderBuilder<T> : IEtlPipelineSink
+    where T : notnull
+{
+    /// <summary>
+    /// Sets <see cref="DbLoader{TRecord}.CommandType"/>. Default: <see cref="System.Data.CommandType.Text"/>.
+    /// </summary>
+    IDbLoaderBuilder<T> CommandType(CommandType commandType);
+
+
+    /// <summary>
+    /// Sets <see cref="DbLoader{TRecord}.ManageConnection"/>. When <see langword="true"/>,
+    /// the loader opens the connection before writing and closes it after the
+    /// run completes.
+    /// </summary>
+    IDbLoaderBuilder<T> ManageConnection(bool manage);
+
+
+    /// <summary>
+    /// Sets <see cref="DbLoader{TRecord}.ErrorHandling"/>. Controls per-row
+    /// error behaviour: <see cref="RowErrorHandling.Abort"/> stops the run at
+    /// the first failure (default); <see cref="RowErrorHandling.Skip"/>
+    /// silently drops the failing row and continues (per-record path only —
+    /// see the enum's remarks).
+    /// </summary>
+    IDbLoaderBuilder<T> ErrorHandling(RowErrorHandling handling);
+}

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -8,3 +8,20 @@ Wolfgang.Etl.DbClient.DbLoader<TRecord>.ValidateSchemaOnStart.get -> bool
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.ValidateSchemaOnStart.set -> void
 Wolfgang.Etl.DbClient.DbKeyAttribute
 Wolfgang.Etl.DbClient.DbKeyAttribute.DbKeyAttribute() -> void
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.CommandType(System.Data.CommandType commandType) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.ManageConnection(bool manage) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.Parameters(Dapper.DynamicParameters! parameters) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.ServerOffset(long? offset) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.ServerLimit(long? limit) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.PagingClauseTemplate(string! template) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.TotalCountQuery(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<int>!>! countQuery) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>
+Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>.CommandType(System.Data.CommandType commandType) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!
+Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>.ManageConnection(bool manage) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!
+Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>.ErrorHandling(Wolfgang.Etl.DbClient.RowErrorHandling handling) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!
+Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions
+static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline! pipeline, System.Data.Common.DbConnection! connection, string! commandText, System.Data.Common.DbTransaction? transaction = null) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline! pipeline, Wolfgang.Etl.DbClient.DbExtractor<T>! extractor) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Data.Common.DbConnection! connection, string! commandText, System.Data.Common.DbTransaction? transaction = null) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!
+static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, Wolfgang.Etl.DbClient.DbLoader<T>! loader) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -85,7 +85,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
   </ItemGroup>
 
   <!-- Source generator: built alongside the runtime, packed into the same

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs
@@ -1,0 +1,248 @@
+// End-to-end tests for the EtlPipeline DbClient extensions (#280).
+//
+// Coverage:
+//   1. Round-trip fixture: DbExtractor → DbLoader against the same
+//      SQLite :memory: connection via the fluent chain.
+//   2. Server-side paging (ServerLimit / ServerOffset / PagingClauseTemplate)
+//      applied through the builder still routes to the underlying
+//      DbExtractor and produces the expected page.
+//   3. AsAsyncEnumerable escape hatch works without a sink.
+//   4. Null-guard behaviour on every factory + terminator.
+//   5. Existing-instance overloads share state with the caller's own
+//      extractor / loader (setter calls on the builder mutate the
+//      caller's instance).
+//
+// The "Cross-format test: read CSV via CsvExtractor, write rows via
+// DbLoader" AC item is NOT covered here — ETL-Csv hasn't shipped the
+// CsvExtractor pipeline extension yet (sibling issue). Will land in
+// a follow-up once ETL-Csv catches up.
+
+using System.Data;
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Sqlite;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+public class EtlPipelineDbClientExtensionsTests
+{
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    public sealed class Widget
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+
+
+    private static SqliteConnection CreateSourceWithRows(int rowCount)
+    {
+        var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "CREATE TABLE source (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL);";
+        cmd.ExecuteNonQuery();
+
+        for (var i = 1; i <= rowCount; i++)
+        {
+            using var ins = conn.CreateCommand();
+            ins.CommandText = $"INSERT INTO source (Id, Name) VALUES ({i}, 'w-{i}');";
+            ins.ExecuteNonQuery();
+        }
+        return conn;
+    }
+
+
+
+    private static SqliteConnection CreateEmptyDestination()
+    {
+        var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "CREATE TABLE dest (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL);";
+        cmd.ExecuteNonQuery();
+        return conn;
+    }
+
+
+
+    private static long CountRows(DbConnection conn, string table)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM {table};";
+        return System.Convert.ToInt64(cmd.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+
+
+    [Fact]
+    public async Task Fluent_chain_roundtrips_rows_from_extractor_to_loader()
+    {
+        using var src = CreateSourceWithRows(3);
+        using var dest = CreateEmptyDestination();
+
+        await EtlPipeline
+            .Create()
+            .DbExtractor<Widget>(src, "SELECT Id, Name FROM source ORDER BY Id")
+            .DbLoader<Widget>(dest, "INSERT INTO dest (Id, Name) VALUES (@Id, @Name)")
+            .RunAsync()
+            .ConfigureAwait(false);
+
+        Assert.Equal(3L, CountRows(dest, "dest"));
+    }
+
+
+
+    [Fact]
+    public async Task Extractor_builder_setters_propagate_to_the_underlying_extractor()
+    {
+        // Server-side paging via the builder: ServerLimit=2, ServerOffset=1 →
+        // pipeline yields exactly rows 2 and 3.
+        using var src = CreateSourceWithRows(5);
+        using var dest = CreateEmptyDestination();
+
+        await EtlPipeline
+            .Create()
+            .DbExtractor<Widget>(src, "SELECT Id, Name FROM source ORDER BY Id")
+            .ServerOffset(1)
+            .ServerLimit(2)
+            .DbLoader<Widget>(dest, "INSERT INTO dest (Id, Name) VALUES (@Id, @Name)")
+            .RunAsync()
+            .ConfigureAwait(false);
+
+        Assert.Equal(2L, CountRows(dest, "dest"));
+
+        using var check = dest.CreateCommand();
+        check.CommandText = "SELECT Id FROM dest ORDER BY Id;";
+        using var reader = check.ExecuteReader();
+        Assert.True(reader.Read()); Assert.Equal(2L, reader.GetInt64(0));
+        Assert.True(reader.Read()); Assert.Equal(3L, reader.GetInt64(0));
+    }
+
+
+
+    [Fact]
+    public async Task AsAsyncEnumerable_escape_hatch_enumerates_without_a_sink()
+    {
+        using var src = CreateSourceWithRows(2);
+
+        var collected = new List<Widget>();
+        await foreach (var w in EtlPipeline
+            .Create()
+            .DbExtractor<Widget>(src, "SELECT Id, Name FROM source ORDER BY Id")
+            .AsAsyncEnumerable()
+            .ConfigureAwait(false))
+        {
+            collected.Add(w);
+        }
+
+        Assert.Equal(2, collected.Count);
+        Assert.Equal("w-1", collected[0].Name);
+        Assert.Equal("w-2", collected[1].Name);
+    }
+
+
+
+    [Fact]
+    public async Task Loader_builder_ErrorHandling_flows_through_to_the_underlying_loader()
+    {
+        using var src = CreateSourceWithRows(3);
+        using var dest = CreateEmptyDestination();
+
+        // Insert row 2 into dest first so the loader's second row hits a PK
+        // conflict. RowErrorHandling.Skip lets rows 1 and 3 land; row 2
+        // silently fails.
+        using (var seed = dest.CreateCommand())
+        {
+            seed.CommandText = "INSERT INTO dest (Id, Name) VALUES (2, 'pre-existing');";
+            seed.ExecuteNonQuery();
+        }
+
+        var extractor = new DbExtractor<Widget>(src, "SELECT Id, Name FROM source ORDER BY Id");
+        var loader = new DbLoader<Widget>(dest, "INSERT INTO dest (Id, Name) VALUES (@Id, @Name)")
+        {
+            InsertBatchSize = 1,
+        };
+
+        await EtlPipeline
+            .Create()
+            .DbExtractor(extractor)
+            .DbLoader(loader)
+            .ErrorHandling(RowErrorHandling.Skip)
+            .RunAsync()
+            .ConfigureAwait(false);
+
+        // 3 rows total: rows 1 and 3 succeeded, row 2 was the pre-existing one.
+        Assert.Equal(3L, CountRows(dest, "dest"));
+    }
+
+
+
+    [Fact]
+    public async Task Existing_extractor_overload_shares_state_with_the_caller()
+    {
+        using var src = CreateSourceWithRows(3);
+        using var dest = CreateEmptyDestination();
+
+        var extractor = new DbExtractor<Widget>(src, "SELECT Id, Name FROM source ORDER BY Id");
+        Assert.Null(extractor.ServerLimit);
+
+        // DbExtractor's paging is gated on BOTH ServerOffset AND ServerLimit
+        // being set (see DbExtractor.ApplyServerPaging), so setting both
+        // proves the setter path AND exercises paging end-to-end.
+        await EtlPipeline
+            .Create()
+            .DbExtractor(extractor)
+            .ServerOffset(0)
+            .ServerLimit(2)
+            .DbLoader<Widget>(dest, "INSERT INTO dest (Id, Name) VALUES (@Id, @Name)")
+            .RunAsync()
+            .ConfigureAwait(false);
+
+        // Setter on the builder mutated the caller's extractor.
+        Assert.Equal(0L, extractor.ServerOffset);
+        Assert.Equal(2L, extractor.ServerLimit);
+        Assert.Equal(2L, CountRows(dest, "dest"));
+    }
+
+
+
+    [Fact]
+    public void DbExtractor_factories_throw_ArgumentNullException_on_null_inputs()
+    {
+        using var src = CreateSourceWithRows(1);
+        var pipeline = EtlPipeline.Create();
+
+        Assert.Throws<System.ArgumentNullException>(() =>
+            ((EtlPipeline)null!).DbExtractor<Widget>(src, "SELECT 1"));
+        Assert.Throws<System.ArgumentNullException>(() =>
+            pipeline.DbExtractor<Widget>((DbConnection)null!, "SELECT 1"));
+        Assert.Throws<System.ArgumentNullException>(() =>
+            pipeline.DbExtractor<Widget>(src, (string)null!));
+        Assert.Throws<System.ArgumentNullException>(() =>
+            pipeline.DbExtractor<Widget>((DbExtractor<Widget>)null!));
+    }
+
+
+
+    [Fact]
+    public void DbLoader_factories_throw_ArgumentNullException_on_null_inputs()
+    {
+        using var src = CreateSourceWithRows(1);
+        using var dest = CreateEmptyDestination();
+        var stage = EtlPipeline
+            .Create()
+            .DbExtractor<Widget>(src, "SELECT Id, Name FROM source");
+
+        Assert.Throws<System.ArgumentNullException>(() =>
+            ((IEtlPipeline<Widget>)null!).DbLoader<Widget>(dest, "INSERT ..."));
+        Assert.Throws<System.ArgumentNullException>(() =>
+            stage.DbLoader<Widget>((DbConnection)null!, "INSERT ..."));
+        Assert.Throws<System.ArgumentNullException>(() =>
+            stage.DbLoader<Widget>(dest, (string)null!));
+        Assert.Throws<System.ArgumentNullException>(() =>
+            stage.DbLoader<Widget>((DbLoader<Widget>)null!));
+    }
+}


### PR DESCRIPTION
## Status: DRAFT — blocked on Abstractions 0.16.0 hitting public NuGet

This PR bumps \`Wolfgang.Etl.Abstractions\` PackageReference to **0.16.0**. That version currently lives only on the maintainer's local NuGet feed (\`C:\nuget-local\`); it has not shipped to nuget.org yet. **CI will fail restore** until Abstractions 0.16.0 is published.

Draft-open now so the code is reviewable; ready to un-draft the moment Abstractions 0.16.0 lands publicly.

---

## Summary

Ships the DbClient sibling of the pipeline-extension work already in \`Wolfgang.Etl.Json\`. Adds class-named source factories and sink terminators for the generic \`EtlPipeline\` chain:

\`\`\`csharp
await EtlPipeline
    .Create()
    .DbExtractor<Person>(conn, \"SELECT * FROM People\")
    .ServerOffset(0)
    .ServerLimit(1000)
    .DbLoader<Person>(destConn, \"INSERT INTO ...\")
    .ErrorHandling(RowErrorHandling.Skip)
    .RunAsync();
\`\`\`

## New public surface

- \`IDbExtractorBuilder<T> : IEtlPipeline<T>\` — 7 fluent setters mapping 1:1 to \`DbExtractor<T>\` properties (\`CommandType\`, \`ManageConnection\`, \`Parameters\`, \`ServerOffset\`, \`ServerLimit\`, \`PagingClauseTemplate\`, \`TotalCountQuery\`).
- \`IDbLoaderBuilder<T> : IEtlPipelineSink\` — 3 fluent setters mapping 1:1 to \`DbLoader<T>\` properties (\`CommandType\`, \`ManageConnection\`, \`ErrorHandling\`).
- \`EtlPipelineDbClientExtensions\` static class hosting 4 extensions: 2 source factories (\`DbExtractor<T>\` on \`EtlPipeline\`, connection-and-SQL + existing-instance overloads) + 2 sink terminators (\`DbLoader<T>\` on \`IEtlPipeline<T>\`, matching overloads).

## Design notes

- Builder setters mutate the wrapped extractor/loader instance. Existing-instance overloads (\`DbExtractor(EtlPipeline, DbExtractor<T>)\` etc.) share state with the caller.
- \`EtlPipeline.From\` wraps \`extractor.ExtractAsync(token)\` in a delegate read at enumeration time, so setter calls on the builder still take effect even after a pipeline operator has consumed it. Same pattern applies to the loader path.
- No new configuration surface — every setter is a 1:1 passthrough to an existing property.
- Connection ownership continues to honour \`ManageConnection\` on both types; the pipeline does **not** override ownership. Since there is no factory-created file handle here, no \`DisposingOwned\`-style resource handoff applies (contrast with \`JsonLineLoader<T>(this IEtlPipeline<T>, string path)\` which does own the file stream).
- \`ISupportDryRun\` on \`DbLoader<T>\` flows through the shared pipeline hook, not a builder-specific setter (consistent with \`Wolfgang.Etl.Json\`).

## Test plan

- [x] Build clean across all 11 TFMs.
- [x] 7 new end-to-end tests over SQLite \`:memory:\` fixtures cover:
  - Round-trip: extractor → loader through the fluent chain.
  - Server-side paging (\`ServerOffset\` + \`ServerLimit\`) via the builder produces the expected page.
  - \`AsAsyncEnumerable\` escape hatch works without a sink.
  - \`ErrorHandling(RowErrorHandling.Skip)\` via the loader builder lets rows land past a PK conflict.
  - State-sharing on existing-instance overloads (setter mutates caller's extractor).
  - Null-guard behaviour on every factory + terminator.
- [x] 277/277 total Tests.Unit pass on net10.0.
- [ ] CI multi-TFM — currently blocked (see status note above).

## Not in this PR

- **Cross-format test: CSV → \`DbLoader\`** — ETL-Csv hasn't shipped a \`CsvExtractor\` pipeline extension yet. Follow-up once the sibling issue lands.

Refs #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)