### PR TITLE
release: v0.7.0 workflow updates (admin-bypass)

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -1,0 +1,157 @@
+# AOT / trim publish smoke test.
+#
+# Publishes examples/Wolfgang.Etl.DbClient.Example.AotSmoke with
+# <PublishAot>true</PublishAot> + <PublishTrimmed>true</PublishTrimmed>
+# and runs the resulting native binary. Surfaces IL2xxx / AOT0xxx /
+# IL3xxx warnings so we know which library surfaces the trimmer /
+# AOT compiler can't see through.
+#
+# Status: INFORMATIONAL / NON-BLOCKING today.
+#
+# Rationale: DbClient's runtime path is built on Dapper 2.1.66,
+# which currently has known trim/AOT gaps that no consumer can
+# annotate around from outside the library. Failing the PR gate
+# would block every merge on issues we can't fix without either
+# (a) a Dapper upgrade that lands its own AOT annotations, or
+# (b) rewriting the reflection paths in DbClient to something
+# trim-friendly (source-generator-driven — partially in progress
+# via #23). Until then, this workflow captures the warning-list
+# and surfaces it as a PR annotation so we can track direction of
+# travel without blocking merges.
+#
+# Blocking-mode plan:
+#   1. Land the source-generator (#23) UPDATE/DELETE/SELECT + Bind
+#      wire-up so reflection is optional at consumer opt-in.
+#   2. Consume Dapper release that ships trim annotations.
+#   3. Flip `continue-on-error` to false and enforce a max IL2xxx
+#      warning count via `--verbosity minimal` grep, as a
+#      regression gate.
+#
+# Refs #143.
+
+name: AOT + trim smoke
+
+on:
+  # pull_request (not pull_request_target): this job runs PR code
+  # (`dotnet publish` on the AotSmoke example, then executes the
+  # published binary). Running PR code in the elevated
+  # pull_request_target context is the exact anti-pattern the
+  # Semgrep pull-request-target-code-checkout rule flags. This
+  # workflow is a build-and-run job: a PR that disables it would be
+  # visible in the PR diff, and the branch-protection rule requires
+  # this check by name before merge, so a PR can't silently drop it.
+  # pull_request is the correct trigger here.
+  pull_request:
+    paths:
+      - "src/**"
+      - "examples/Wolfgang.Etl.DbClient.Example.AotSmoke/**"
+      - ".github/workflows/aot-smoke.yaml"
+  push:
+    branches: [main, vNext]
+    paths:
+      - "src/**"
+      - "examples/Wolfgang.Etl.DbClient.Example.AotSmoke/**"
+      - ".github/workflows/aot-smoke.yaml"
+  workflow_dispatch:
+
+jobs:
+  aot-smoke:
+    name: PublishAot + PublishTrimmed
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # pull_request already checks out the PR HEAD by default;
+          # persist-credentials stays false to keep the token off disk.
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj
+
+      # Non-blocking (see file header). Captures full trim/AOT
+      # warning output so we can trend and eventually gate.
+      - name: Publish (PublishAot + PublishTrimmed)
+        id: publish
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          mkdir -p publish
+          dotnet publish \
+            examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj \
+            --configuration Release \
+            --runtime linux-x64 \
+            --self-contained true \
+            --output publish \
+            -p:PublishAot=true \
+            -p:PublishTrimmed=true \
+            -p:TrimmerSingleWarn=false \
+            2>&1 | tee publish.log
+
+      - name: Summarize trim / AOT warnings
+        if: always()
+        run: |
+          {
+            echo "## AOT + trim smoke — warning summary"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ ! -f publish.log ]; then
+            echo "publish step produced no log — likely errored before running dotnet." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          il2_count=$(grep -c "warning IL2" publish.log || true)
+          il3_count=$(grep -c "warning IL3" publish.log || true)
+          aot_count=$(grep -c "warning AOT" publish.log || true)
+          {
+            echo "| Category | Count |"
+            echo "|---|---|"
+            echo "| Trim (IL2xxx) | $il2_count |"
+            echo "| Single-file (IL3xxx) | $il3_count |"
+            echo "| AOT (AOT0xxx) | $aot_count |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$il2_count" -gt 0 ] || [ "$il3_count" -gt 0 ] || [ "$aot_count" -gt 0 ]; then
+            {
+              echo "<details><summary>First 20 warnings</summary>"
+              echo ""
+              echo '```'
+              grep -E "warning (IL[23]|AOT)" publish.log | head -20
+              echo '```'
+              echo ""
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          {
+            echo ""
+            echo "**Gate mode**: non-blocking (informational). See workflow header for the plan to move to blocking."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Only meaningful if publish actually succeeded — otherwise
+      # skip cleanly instead of failing.
+      - name: Run the AOT-published binary
+        if: steps.publish.outcome == 'success'
+        run: |
+          bin=publish/Wolfgang.Etl.DbClient.Example.AotSmoke
+          if [ ! -x "$bin" ]; then
+            echo "::warning::AOT-published binary not found at $bin — publish output layout may have changed."
+            exit 0
+          fi
+          "$bin"
+
+      - name: Upload publish log
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: aot-smoke-publish-log
+          path: publish.log
+          retention-days: 30

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -37,10 +37,10 @@ jobs:
     name: "Benchmarks / sqlite"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 
@@ -87,10 +87,10 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 
@@ -138,10 +138,10 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 
@@ -189,10 +189,10 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 
@@ -242,10 +242,10 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
@@ -192,7 +192,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
@@ -245,7 +245,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-dotnet@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository (full history + all tags)
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # Full history so all tags are reachable
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
 
@@ -77,13 +77,13 @@ jobs:
 
     - name: Initialize CodeQL
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Setup .NET
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
       with:
         dotnet-version: '10.0.x'
 
@@ -128,7 +128,7 @@ jobs:
     - name: Perform CodeQL Analysis
       id: perform-codeql-analysis
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
       with:
         category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Setup .NET
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: actions/setup-dotnet@v6
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
 

--- a/.github/workflows/concurrency.yaml
+++ b/.github/workflows/concurrency.yaml
@@ -38,30 +38,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # Guard so this workflow (present on main so workflow_dispatch works)
-      # doesn't fail its scheduled run when the checked-out ref pre-dates
-      # the Tests.Concurrency project — that project lives on vNext and
-      # hasn't merged to main yet. Once vNext → main, the guard is a
-      # no-op (the directory always exists) and this comment can go.
-      - name: Detect Tests.Concurrency
-        id: check
-        shell: bash
-        run: |
-          if [ -f tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Tests.Concurrency project not present on this ref — skipping Coyote suite. Merge vNext to main to enable."
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup .NET
-        if: steps.check.outputs.found == 'true'
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
         with:
           dotnet-version: 10.0.x
 
       - name: Restore + Build (Release)
-        if: steps.check.outputs.found == 'true'
         run: |
           dotnet restore tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj
           dotnet build tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj \
@@ -69,7 +51,6 @@ jobs:
             --configuration Release
 
       - name: Run Coyote concurrency suite
-        if: steps.check.outputs.found == 'true'
         # Iteration count is read from an env var at test time; runtime-
         # configurable without a rebuild.
         env:

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -10,8 +10,12 @@
 #
 # Failing cases: CsCheck auto-shrinks and prints the counter-example
 # to test output. The workflow logs are captured as an artifact for
-# post-mortem. Automated issue-filing on failure is a follow-up
-# (needs a strategy for duplicate-detection so a rerun doesn't spam).
+# post-mortem, and on failure the workflow files (or comments on) a
+# tracking issue labelled `fuzz-failure`. Duplicate detection: if an
+# open `fuzz-failure` issue already exists, the workflow appends a
+# comment linking the new run instead of opening a second issue.
+# Once the underlying property is fixed, close the issue by hand —
+# the next scheduled run then starts a fresh one on the next regression.
 #
 # Refs #129.
 
@@ -33,6 +37,11 @@ on:
 
 permissions:
   contents: read
+  # `issues: write` is required for the auto-file / auto-comment step
+  # at the bottom of the job. Job-level scope (rather than
+  # workflow-level) so the earlier fuzz-execution steps run with
+  # least-privilege.
+  issues: write
 
 jobs:
   fuzz:
@@ -45,29 +54,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # Guard so the scheduled Saturday 04:00 UTC run on main no-ops when
-      # Tests.Fuzz isn't yet on the checked-out ref. Tests.Fuzz lives on
-      # vNext and hasn't merged to main; the guard becomes a no-op once
-      # it has and this block can be dropped.
-      - name: Detect Tests.Fuzz
-        id: check
-        shell: bash
-        run: |
-          if [ -f tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Tests.Fuzz project not present on this ref — skipping fuzz suite. Merge vNext to main to enable."
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup .NET
-        if: steps.check.outputs.found == 'true'
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
         with:
           dotnet-version: 10.0.x
 
       - name: Restore + Build Tests.Fuzz (Release)
-        if: steps.check.outputs.found == 'true'
         run: |
           dotnet restore tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj
           dotnet build tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj \
@@ -75,12 +67,19 @@ jobs:
             --configuration Release
 
       - name: Run fuzz suite
-        if: steps.check.outputs.found == 'true'
         # CsCheck reads its iteration budget from CsCheck_Iterations at
         # runtime (the alternative — hardcoding in the source — would
         # require rebuilding to change the case count). The scheduled
         # value lives here so a maintainer can bump it without touching
         # C#.
+        #
+        # continue-on-error: the subsequent "File / comment fuzz-failure
+        # issue" step needs this step's `outcome` to distinguish a real
+        # fuzz counter-example from a random build/restore failure. The
+        # final "Fail workflow" step below re-fails the job so overall
+        # status still reflects the failure.
+        id: fuzz-run
+        continue-on-error: true
         env:
           CsCheck_Iterations: ${{ inputs.iterations || '100000' }}
           CsCheck_Timeout: "1800000"    # 30 min per property
@@ -102,3 +101,94 @@ jobs:
           name: fuzz-reports
           path: reports/
           retention-days: 60
+
+      - name: File / comment fuzz-failure issue
+        # Only fires when the fuzz-run step failed (a real counter-
+        # example or unhandled test crash). Duplicate detection: if an
+        # open `fuzz-failure` labelled issue exists we comment on it
+        # rather than opening a second; the human closes it once the
+        # underlying property is fixed and the next regression opens a
+        # fresh one.
+        if: steps.fuzz-run.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ITERATIONS: ${{ inputs.iterations || '100000' }}
+        run: |
+          set -euo pipefail
+
+          # Grab a bounded excerpt of the CsCheck output for the issue
+          # body. The full log lives on the fuzz-reports artifact — the
+          # embedded excerpt is just for at-a-glance triage.
+          excerpt=""
+          if [ -f reports/fuzz.log ]; then
+            excerpt=$(tail -c 8000 reports/fuzz.log)
+          fi
+
+          existing=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --label fuzz-failure \
+            --json number,url \
+            --limit 1 \
+            --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            echo "Existing fuzz-failure issue #$existing — appending comment."
+            {
+              echo "Additional failure on scheduled fuzz run."
+              echo ""
+              echo "- Run: $RUN_URL"
+              echo "- Iterations budget: $ITERATIONS"
+              echo "- Artifact: \`fuzz-reports\` on the run above (retention 60 days)"
+              echo ""
+              echo "<details><summary>Tail of fuzz.log</summary>"
+              echo ""
+              echo '```'
+              printf '%s\n' "$excerpt"
+              echo '```'
+              echo ""
+              echo "</details>"
+            } > /tmp/fuzz-comment.md
+            gh issue comment "$existing" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/fuzz-comment.md
+          else
+            echo "No open fuzz-failure issue — filing a new one."
+            {
+              echo "The weekly fuzz workflow surfaced a failing property."
+              echo ""
+              echo "- Run: $RUN_URL"
+              echo "- Iterations budget: $ITERATIONS"
+              echo "- Artifact: \`fuzz-reports\` on the run above (retention 60 days)"
+              echo ""
+              echo "CsCheck auto-shrinks failing cases. The counter-example should be visible near the end of the log below. Reproduce locally with:"
+              echo ""
+              echo '```'
+              echo 'CsCheck_Iterations=100000 CsCheck_Timeout=1800000 dotnet test tests/Wolfgang.Etl.DbClient.Tests.Fuzz --configuration Release --filter Category=Fuzz'
+              echo '```'
+              echo ""
+              echo "Close this issue once the property is fixed — the next scheduled failure re-opens a new one automatically."
+              echo ""
+              echo "<details><summary>Tail of fuzz.log</summary>"
+              echo ""
+              echo '```'
+              printf '%s\n' "$excerpt"
+              echo '```'
+              echo ""
+              echo "</details>"
+            } > /tmp/fuzz-issue.md
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Fuzz failure: weekly cron surfaced a counter-example" \
+              --label fuzz-failure \
+              --body-file /tmp/fuzz-issue.md
+          fi
+
+      - name: Fail workflow if fuzz failed
+        # Re-fails the job so scheduled-run status reflects reality even
+        # though the fuzz step had continue-on-error: true.
+        if: steps.fuzz-run.outcome == 'failure'
+        run: |
+          echo "::error::Fuzz run failed — see filed issue for triage."
+          exit 1

--- a/.github/workflows/gc-profile.yaml
+++ b/.github/workflows/gc-profile.yaml
@@ -45,35 +45,17 @@ jobs:
         with:
           persist-credentials: false
 
-      # Guard so the scheduled Sunday 07:00 UTC run on main no-ops when
-      # the workload project isn't on the checked-out ref. GcProfileWorkload
-      # lives on vNext and hasn't merged to main; the guard becomes a
-      # no-op once it has and this block can be dropped.
-      - name: Detect GcProfileWorkload
-        id: check
-        shell: bash
-        run: |
-          if [ -f tools/GcProfileWorkload/GcProfileWorkload.csproj ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::GcProfileWorkload project not present on this ref — skipping GC profile. Merge vNext to main to enable."
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup .NET
-        if: steps.check.outputs.found == 'true'
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
         with:
           dotnet-version: 10.0.x
 
       - name: Install dotnet-counters + dotnet-trace
-        if: steps.check.outputs.found == 'true'
         run: |
           dotnet tool install --global dotnet-counters
           dotnet tool install --global dotnet-trace
 
       - name: Restore + Build workload (Release)
-        if: steps.check.outputs.found == 'true'
         run: |
           dotnet restore tools/GcProfileWorkload/GcProfileWorkload.csproj
           dotnet build tools/GcProfileWorkload/GcProfileWorkload.csproj \
@@ -82,7 +64,6 @@ jobs:
 
       - name: Run workload + capture counters
         id: profile
-        if: steps.check.outputs.found == 'true'
         env:
           GC_WORKLOAD_SECONDS: ${{ inputs.duration_seconds || '600' }}
         run: |
@@ -120,7 +101,7 @@ jobs:
           echo "workload_log=reports/workload.log" >> "$GITHUB_OUTPUT"
 
       - name: Summarise into Step Summary
-        if: always() && steps.check.outputs.found == 'true'
+        if: always()
         # Pass the duration through env (not inline expansion) so a
         # workflow_dispatch input with shell metacharacters can't inject
         # into this script. Zizmor flags the inline form as
@@ -149,7 +130,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload reports
-        if: always() && steps.check.outputs.found == 'true'
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: gc-profile-reports

--- a/.github/workflows/integration-status.yaml
+++ b/.github/workflows/integration-status.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v5
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             8.0.x
@@ -162,9 +162,9 @@ jobs:
           for rdbms in sqlserver postgres mysql mariadb cockroachdb sqlite; do
             aggregate="passing"
             color="brightgreen"
-            for file in _status/${rdbms}__*.txt; do
+            for file in "_status/${rdbms}"__*.txt; do
               [ -f "$file" ] || continue
-              outcome=$(cat "$file" | tr -d '[:space:]')
+              outcome=$(tr -d '[:space:]' < "$file")
               echo "  ${rdbms} → $(basename "$file" .txt): $outcome"
               case "$outcome" in
                 success)   ;;

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -1,0 +1,98 @@
+name: License audit
+
+# Audits the licenses of the shipped packages' transitive dependencies against
+# an allowlist, and generates THIRD-PARTY-NOTICES.md attribution. Dev-only
+# tooling (analyzers / SourceLink / framework shims — all PrivateAssets, never
+# shipped) is filtered out via .github/license/packages-filter.json. Fails the
+# run if a runtime dependency carries a license outside the allowlist.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.csproj'
+      - 'Directory.Build.props'
+      - '.github/license/**'
+      - '.github/workflows/license-audit.yaml'
+  push:
+    branches: [ main, vNext ]
+  schedule:
+    - cron: '15 6 * * 1'   # Mondays 06:15 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  license-audit:
+    name: Audit dependency licenses
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up .NET
+        # 7.0.x (EOL) is installed only because the dotnet-project-licenses tool
+        # targets net7.0; the runner image no longer ships it, so the tool fails
+        # to launch without an explicit install. Do not remove.
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: |
+            7.0.x
+            8.0.x
+            10.0.x
+
+      - name: Install dotnet-project-licenses
+        run: dotnet tool install --global dotnet-project-licenses --version 2.7.1
+
+      - name: Restore (populates project.assets.json)
+        run: dotnet restore
+
+      - name: Audit licenses + generate notices
+        shell: bash
+        run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          projects=(
+            src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+          )
+          {
+            echo "# Third-party notices"
+            echo
+            echo "Licenses of the transitive runtime dependencies of the shipped"
+            echo "\`Wolfgang.Etl.DbClient\` package. Dev-only tooling (analyzers,"
+            echo "SourceLink, framework shims) is excluded — it is never distributed."
+            echo
+          } > THIRD-PARTY-NOTICES.md
+
+          fail=0
+          for proj in "${projects[@]}"; do
+            name=$(basename "$proj" .csproj)
+            echo "::group::License audit — $name"
+            if ! dotnet-project-licenses \
+                --input "$proj" \
+                --use-project-assets-json -t \
+                --packages-filter .github/license/packages-filter.json \
+                --licenseurl-to-license-mappings .github/license/licenseurl-mappings.json \
+                --allowed-license-types .github/license/allowed-licenses.json \
+                --outfile "notices-$name.md" --md
+            then
+              echo "::error::Disallowed license in $name — see the log above."
+              fail=1
+            fi
+            echo "::endgroup::"
+            {
+              echo "## $name"
+              echo
+              cat "notices-$name.md" 2>/dev/null || true
+              echo
+            } >> THIRD-PARTY-NOTICES.md
+          done
+          exit $fail
+
+      - name: Upload notices
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: third-party-notices
+          path: THIRD-PARTY-NOTICES.md
+          retention-days: 30

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -94,7 +94,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -329,7 +329,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -391,7 +391,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -441,7 +441,7 @@ jobs:
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             8.0.x
@@ -480,7 +480,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@fb4bfd79bfa826ce96c90727ff8833835ba8aad0 # v3
         with:
           sarif_file: inspect.sarif
 
@@ -513,7 +513,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -632,7 +632,7 @@ jobs:
           sudo rm /etc/apt/sources.list.d/focal-security.list
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -889,7 +889,7 @@ jobs:
 
       - name: Upload Linux coverage results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-linux
           path: |
@@ -897,7 +897,7 @@ jobs:
             CoverageReport/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-output
           path: |
@@ -937,13 +937,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             8.0.x
@@ -985,7 +985,7 @@ jobs:
 
       - name: Upload integration test results
         if: always() && steps.locate.outputs.found == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: integration-${{ matrix.rdbms }}-${{ matrix.tfm }}-trx
           path: TestResults-Integration/
@@ -1055,7 +1055,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1151,7 +1151,7 @@ jobs:
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -1339,7 +1339,7 @@ jobs:
 
       - name: Upload Windows coverage results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-windows
           path: |
@@ -1361,7 +1361,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1465,7 +1465,7 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             6.0.x
@@ -1704,7 +1704,7 @@ jobs:
 
       - name: Upload macOS coverage results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-macos
           path: |
@@ -1754,7 +1754,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1891,7 +1891,7 @@ jobs:
 
       - name: Upload security scan results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: devskim-results
           path: devskim-results.txt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,18 +4,27 @@
 # Stage 3: macOS tests (only if Stage 2 passes)
 #
 # SECURITY NOTE:
-# - Uses pull_request_target to run workflow from the trusted main branch, not from the PR branch
-# - This prevents malicious workflow YAML changes in untrusted PR branches from taking effect
-# - All checkout steps use PR refs (refs/pull/*/head) to check out PR code from the base repo
-# - After checkout, configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched from
-#   the main branch to prevent malicious PRs from disabling analyzers or bypassing code quality checks
-# - If a PR changes any of these protected configuration files, CI explicitly fails with instructions
-#   for a maintainer to manually review and verify the changes before merging
-# - persist-credentials: false prevents the checkout token from being written to git config for subsequent git commands
-#   (it does NOT, by itself, prevent steps from accessing github.token / GITHUB_TOKEN if you explicitly expose it)
-# - After checkout, configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched from
-#   the main branch to prevent malicious PRs from disabling analyzers or bypassing code quality checks
-# - Default GITHUB_TOKEN permissions are restricted to read-only repository contents to limit impact if exposed
+# - Trigger is `pull_request` (not `pull_request_target`). The workflow YAML
+#   that runs comes from the PR itself. A PR that modifies pr.yaml to remove
+#   or rename a required check does not silently pass — the branch-protection
+#   ruleset requires specific check names before merge, so a missing check is
+#   an unmet requirement and blocks merge.
+# - The old `pull_request_target` model traded "PR can't modify the workflow"
+#   for "PR-authored code runs in the elevated pull_request_target context"
+#   (Semgrep flagged this as `pull-request-target-code-checkout`). Migrating
+#   to `pull_request` runs PR code in the standard read-only-token PR context,
+#   which is what the Actions security guidance recommends. Refs #131 / #257.
+# - Configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched
+#   from the main branch before build so a PR can't relax analyzer rules and
+#   get a clean CI run. Combined with the "Detect protected configuration
+#   file changes" guard (which fails the PR if any protected file differs),
+#   this catches both accidental and deliberate weakening.
+# - persist-credentials: false prevents the checkout token from being written
+#   to git config for subsequent git commands (it does NOT, by itself, prevent
+#   steps from accessing github.token / GITHUB_TOKEN if you explicitly expose
+#   it).
+# - Default GITHUB_TOKEN permissions are restricted to read-only repository
+#   contents to limit impact if exposed.
 
 name: PR Checks v3 (Gated)
 
@@ -24,9 +33,9 @@ permissions:
 
 env:
   CODECOV_MINIMUM: 90
-  
+
 on:
-  pull_request_target:  # Runs from the main branch, not from PR branch
+  pull_request:
     branches:
       - main
 
@@ -208,138 +217,95 @@ jobs:
             echo "has-projects=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
           fi
-  # ============================================================================
-  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
-  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
-  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
-  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
-  # annotations). `error`-severity findings fail the job; `warning`-severity
-  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
-  # filter). Tune the noise floor via .DotSettings at the repo root.
-  # ============================================================================
-  # DbClient-specific: runs on windows-latest (not the canonical
-  # ubuntu-latest) because the repo targets net4x TFMs (net462/net472/
-  # net48/net481) which are Windows-only — a solution-level `dotnet
-  # build` on Linux would fail before InspectCode had a chance to run.
-  inspectcode:
-    name: "ReSharper InspectCode"
-    runs-on: windows-latest
-    needs: detect-projects
-    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      security-events: write   # required for upload-sarif
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7.0.0
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
-
-      # Rehydrate trusted config from main so a PR can't loosen
-      # analyzer rules and then get a clean InspectCode pass. Same
-      # threat model + Dependabot exemption as the test jobs above.
-      - name: Fetch trusted configuration files from main branch
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        shell: pwsh
+      - name: Verify src/ csprojs are in the solution
+        # Guards against the class of drift that hit v0.5.0's release: a new
+        # csproj was added under src/ (the source generator) but never added
+        # to the .slnx / .sln file. Per-project `dotnet test` invocations
+        # still triggered its ProjectReference chain, so PR CI never noticed;
+        # but the release pipeline's solution-level `dotnet build` didn't
+        # include it, and the runtime csproj's `PackSourceGenerator` target
+        # failed to find its bin/Release/ output — blocking the release.
+        #
+        # Detection: for every src/**/*.csproj, verify the .slnx or .sln
+        # (if present) references it by path. If a solution file exists and
+        # a src csproj isn't listed, fail with the specific missing entry.
+        # Repos without a solution file (or with everything already listed)
+        # pass unconditionally.
+        shell: bash
         run: |
-          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
+          shopt -s nullglob
+          slns=( *.slnx *.sln )
+          if [ ${#slns[@]} -eq 0 ]; then
+            echo "ℹ️  No solution file at repo root - skipping solution-consistency check."
+            exit 0
+          fi
+          echo "Checking solution files: ${slns[*]}"
 
-          git fetch origin main:main-branch
+          missing=()
+          # `git ls-files 'src/**/*.csproj'` returns forward-slashed paths on
+          # all platforms.
+          #
+          # Match semantics matter: solution-level `dotnet build` follows only
+          # <Project Path="…"/> entries in .slnx (or GUID lines in classic .sln).
+          # A csproj referenced as <File Path="…"/> (a solution item) is NOT
+          # built by the solution. So for .slnx we must match on the Project
+          # element specifically — a bare grep on the path would let a
+          # solution-items-only reference pass this guardrail while
+          # release.yaml's Pack step still skips the project.
+          while IFS= read -r csproj; do
+            # git ls-files always emits forward-slashed paths. Classic .sln
+            # GUID lines often use backslashes (`src\Foo\Foo.csproj`) — the
+            # generic check below handles both encodings for .sln.
+            csproj_bs="${csproj//\//\\}"
+            found=0
+            for sln in "${slns[@]}"; do
+              case "$sln" in
+                *.slnx)
+                  # .slnx: require the specific <Project Path="…"/> element.
+                  # Match either quoted attribute style; ignore whitespace
+                  # variance around the equals sign.
+                  if grep -qE "<Project[[:space:]]+Path[[:space:]]*=[[:space:]]*[\"']${csproj//\//\\/}[\"']" "$sln"; then
+                    found=1
+                    break
+                  fi
+                  ;;
+                *.sln)
+                  # Classic .sln: GUID `Project(...) = "Name", "path", "{GUID}"`
+                  # lines carry the path. Substring match is safe because .sln
+                  # doesn't have a "solution items" analogue of <File Path=…>.
+                  if grep -qF "$csproj" "$sln" || grep -qF "$csproj_bs" "$sln"; then
+                    found=1
+                    break
+                  fi
+                  ;;
+              esac
+            done
+            if [ "$found" -eq 0 ]; then
+              missing+=("$csproj")
+            fi
+          done < <(git ls-files 'src/**/*.csproj' 'src/*.csproj')
 
-          $configFiles = @(
-            ".editorconfig",
-            "Directory.Build.props",
-            "Directory.Build.targets",
-            "BannedSymbols.txt"
-          )
-
-          foreach ($configFile in $configFiles) {
-            git cat-file -e "main-branch:$configFile" 2>&1 | Out-Null
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
-            } else {
-              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
-            }
-          }
-
-          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
-          foreach ($pattern in $globPatterns) {
-            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
-            foreach ($file in $files) {
-              if ($file) {
-                Write-Host "  ✓ Copying $file from main branch"
-                $dir = Split-Path -Parent $file
-                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
-              }
-            }
-          }
-
-          Write-Host ""
-          Write-Host "✅ Configuration files secured - using versions from main branch"
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
-
-      - name: Restore + Build (Release)
-        run: |
-          dotnet restore
-          dotnet build -c Release --no-restore
-
-      - name: Install JetBrains.ReSharper.GlobalTools
-        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
-
-      # Everything below stays in pwsh so `jb` (a dotnet global tool)
-      # is on PATH via the pwsh session that installed it, and we
-      # avoid depending on `jq` being present in Git Bash on
-      # windows-latest.
-      - name: Run InspectCode
-        shell: pwsh
-        run: |
-          # Prefer .slnx (new format), fall back to .sln. Fail loudly if neither.
-          $sln = (Get-ChildItem -Filter '*.slnx' -File | Select-Object -First 1).Name
-          if (-not $sln) {
-            $sln = (Get-ChildItem -Filter '*.sln' -File | Select-Object -First 1).Name
-          }
-          if (-not $sln) {
-            Write-Host "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo ""
+            echo "❌ SOLUTION CONSISTENCY FAILURE"
+            echo ""
+            echo "The following src/**/*.csproj files are NOT referenced by any solution file:"
+            for m in "${missing[@]}"; do
+              echo "  - $m"
+            done
+            echo ""
+            echo "This breaks solution-level \`dotnet build\` (which release.yaml relies on"
+            echo "for Pack & Validate), even though per-project \`dotnet test\` still works."
+            echo ""
+            echo "Fix: add the missing project(s) to the solution:"
+            for sln in "${slns[@]}"; do
+              echo "  dotnet sln $sln add ${missing[*]}"
+              break  # only suggest the first sln
+            done
             exit 1
-          }
-          Write-Host "Inspecting: $sln"
-          jb inspectcode $sln `
-            --output=inspect.sarif `
-            --format=sarif `
-            --severity=WARNING `
-            --no-build
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: inspect.sarif
-
-      - name: Gate on error-severity findings
-        shell: pwsh
-        run: |
-          # SARIF level=error fails the job; warnings still upload (visible in
-          # Security → Code scanning) but don't gate merge.
-          $sarif = Get-Content -Raw -Path inspect.sarif | ConvertFrom-Json
-          $errors = @($sarif.runs | ForEach-Object { $_.results } | Where-Object { $_.level -eq 'error' })
-          $count = $errors.Count
-          if ($count -gt 0) {
-            Write-Host "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
-            exit 1
-          }
-          Write-Host "✅ No error-severity InspectCode findings."
-
+          fi
+          echo "✅ All src csprojs are referenced by a solution file - solution-level builds will include them."
 
   # ============================================================================
   # DETECTION: Classify changed paths (code vs workflows vs docs-only)
@@ -398,6 +364,139 @@ jobs:
               - 'nuget.config'
             workflows:
               - '.github/workflows/**'
+
+  # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter).
+  #
+  # DbClient-specific: runs on `windows-latest` (not `ubuntu-latest` like the
+  # canonical repo-template version) because DbClient targets .NET Framework
+  # TFMs (net462/net472/net48/net481) which are Windows-only. Building on
+  # Linux would fail before inspectcode gets a chance to run.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: windows-latest
+    needs: detect-projects
+    if: needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      # Rehydrate trusted config from main so a PR can't loosen
+      # analyzer rules and then get a clean InspectCode pass. Same
+      # threat model + Dependabot exemption as the test jobs above.
+      - name: Fetch trusted configuration files from main branch
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        shell: pwsh
+        run: |
+          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
+
+          git fetch origin main:main-branch
+
+          $configFiles = @(
+            ".editorconfig",
+            "Directory.Build.props",
+            "Directory.Build.targets",
+            "BannedSymbols.txt"
+          )
+
+          foreach ($configFile in $configFiles) {
+            git cat-file -e "main-branch:$configFile" 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "  ✓ Copying $configFile from main branch"
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
+            } else {
+              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
+            }
+          }
+
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
+          foreach ($pattern in $globPatterns) {
+            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
+            foreach ($file in $files) {
+              if ($file) {
+                Write-Host "  ✓ Copying $file from main branch"
+                $dir = Split-Path -Parent $file
+                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
+              }
+            }
+          }
+
+          Write-Host ""
+          Write-Host "✅ Configuration files secured - using versions from main branch"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      # Everything below stays in pwsh so `jb` (dotnet global tool)
+      # is on PATH via the pwsh session that installed it, and we
+      # avoid depending on `jq` being present in Git Bash on
+      # windows-latest.
+      - name: Run InspectCode
+        shell: pwsh
+        run: |
+          # Prefer .slnx (new format), fall back to .sln. Fail loudly if neither.
+          $sln = (Get-ChildItem -Filter '*.slnx' -File | Select-Object -First 1).Name
+          if (-not $sln) {
+            $sln = (Get-ChildItem -Filter '*.sln' -File | Select-Object -First 1).Name
+          }
+          if (-not $sln) {
+            Write-Host "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          }
+          Write-Host "Inspecting: $sln"
+          jb inspectcode $sln `
+            --output=inspect.sarif `
+            --format=sarif `
+            --severity=WARNING `
+            --no-build
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        shell: pwsh
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge.
+          $sarif = Get-Content -Raw -Path inspect.sarif | ConvertFrom-Json
+          $errors = @($sarif.runs | ForEach-Object { $_.results } | Where-Object { $_.level -eq 'error' })
+          $count = $errors.Count
+          if ($count -gt 0) {
+            Write-Host "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          }
+          Write-Host "✅ No error-severity InspectCode findings."
 
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
@@ -533,7 +632,7 @@ jobs:
           sudo rm /etc/apt/sources.list.d/focal-security.list
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             3.1.x
@@ -844,7 +943,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -1052,7 +1151,7 @@ jobs:
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             3.1.x
@@ -1366,7 +1465,7 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             6.0.x

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,7 +85,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             3.1.x
@@ -366,7 +366,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             3.1.x
@@ -600,7 +600,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -668,10 +668,200 @@ jobs:
           echo "❌ Integration aggregator FAILS — release gate blocks the publish."
           exit 1
 
-  # Publish to NuGet (only if validation + integration passed)
+  # ABI compatibility gate: for a PATCH/MINOR release, break the build
+  # if the new package's public surface is binary-incompatible with the
+  # last version on nuget.org. MAJOR releases record intentional breaks
+  # in compat-suppressions.txt (checked in) so they don't recur silently.
+  # Refs #136.
+  api-compat:
+    name: ApiCompat vs last NuGet
+    needs: pack-and-validate
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Download packed artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nuget-packages
+          path: ./packages
+
+      - name: Install ApiCompat tool
+        run: dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
+
+      - name: Run ApiCompat
+        id: apicompat
+        shell: bash
+        env:
+          PKG_ID: Wolfgang.Etl.DbClient
+        run: |
+          set -euo pipefail
+
+          # Determine package id + version from the freshly-packed .nupkg.
+          # Use find (not `ls <glob>`) so an empty match returns cleanly
+          # instead of tripping `set -e` before the friendly diagnostic.
+          new_nupkg=$(find packages -maxdepth 1 -name "${PKG_ID}.*.nupkg" ! -name '*.symbols.nupkg' | head -1)
+          if [ -z "$new_nupkg" ]; then
+            echo "❌ No runtime .nupkg in ./packages"
+            ls -la packages/ || true
+            exit 1
+          fi
+          fname=$(basename "$new_nupkg" .nupkg)
+          # <PKG_ID>.<major>.<minor>.<patch>[-suffix] → strip the id prefix.
+          # Quote the pattern expansion inside ${var#...} so shellcheck's
+          # SC2295 is satisfied (unquoted, it would be treated as a glob).
+          new_version=${fname#"${PKG_ID}."}
+          echo "New package: ${PKG_ID}@$new_version"
+
+          # Look up the previous stable version from nuget.org (excludes the
+          # version we're about to publish + any pre-release tags). Parse
+          # with python3 — guaranteed on ubuntu-latest and doesn't depend
+          # on `jq` staying on the runner image.
+          pkg_lc=$(printf '%s' "$PKG_ID" | tr '[:upper:]' '[:lower:]')
+          # One-liner python so the YAML block scalar isn't broken by the
+          # embedded newlines a multi-line `python3 -c '...'` needs.
+          # actionlint's YAML parser is strict about outdented lines
+          # inside `run: |` blocks.
+          prev_version=$(
+            curl -sSf "https://api.nuget.org/v3-flatcontainer/${pkg_lc}/index.json" \
+              | NEW_VERSION="$new_version" python3 -c 'import json, os, sys; d=json.load(sys.stdin); n=os.environ["NEW_VERSION"]; s=[v for v in d.get("versions", []) if "-" not in v and v!=n]; print(s[-1] if s else "")'
+          )
+
+          if [ -z "$prev_version" ]; then
+            echo "ℹ️  No prior stable version on nuget.org — first release or first stable. Skipping compat check."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Previous stable: Wolfgang.Etl.DbClient@$prev_version"
+          echo "prev-version=$prev_version" >> "$GITHUB_OUTPUT"
+
+          # Download previous nupkg
+          mkdir -p prev
+          curl -sSfL \
+            "https://api.nuget.org/v3-flatcontainer/${pkg_lc}/$prev_version/${pkg_lc}.$prev_version.nupkg" \
+            -o "prev/prev.nupkg"
+
+          # Extract both nupkgs
+          unzip -q "$new_nupkg" -d new
+          unzip -q "prev/prev.nupkg" -d prev/pkg
+
+          # Compare per TFM. All TFMs the package declares must be
+          # binary-compatible with the same TFM in the previous version
+          # (unless suppressed in compat-suppressions.txt or this is a
+          # MAJOR bump — the workflow doesn't distinguish; suppressions
+          # are the escape hatch).
+          # Array so the individual flag + path stay as separate arguments
+          # when expanded (shellcheck SC2086 — string interpolation would
+          # word-split incorrectly if either token ever contained whitespace).
+          suppression_args=()
+          if [ -f compat-suppressions.txt ]; then
+            suppression_args=(--suppression-file compat-suppressions.txt)
+          fi
+
+          # `while read` (not `for x in $(find ...)`) so filenames with
+          # spaces or newlines don't wordsplit (shellcheck SC2044).
+          exit_code=0
+          while IFS= read -r -d '' new_dll; do
+            tfm=$(basename "$(dirname "$new_dll")")
+            prev_dll="prev/pkg/lib/$tfm/Wolfgang.Etl.DbClient.dll"
+            if [ ! -f "$prev_dll" ]; then
+              echo "ℹ️  TFM $tfm is new in this release (no previous DLL) — skipping."
+              continue
+            fi
+            echo ""
+            echo "🔍 ApiCompat: $tfm"
+            if ! apicompat --left "$prev_dll" --right "$new_dll" "${suppression_args[@]}"; then
+              echo "❌ ApiCompat FAILED for $tfm"
+              exit_code=1
+            fi
+          done < <(find new/lib -name Wolfgang.Etl.DbClient.dll -print0)
+          exit $exit_code
+
+  # SourceLink structural gate — verifies the freshly-packed .snupkg carries
+  # a portable PDB for every runtime TFM so consumers get F11-into-source
+  # after publish. Full-format (Windows-only) PDBs are an immediate fail —
+  # SourceLink is portable-PDB only. Refs #144.
+  sourcelink-snupkg:
+    name: SourceLink structural verify (.snupkg)
+    needs: pack-and-validate
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download packed artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nuget-packages
+          path: ./packages
+
+      - name: Verify .snupkg carries portable PDBs
+        shell: bash
+        run: |
+          set -euo pipefail
+          snupkgs=$(find packages -maxdepth 1 -name 'Wolfgang.Etl.DbClient.*.snupkg' || true)
+          if [ -z "$snupkgs" ]; then
+            echo "❌ No .snupkg in ./packages — SourceLink verification cannot run."
+            ls -la packages/ || true
+            exit 1
+          fi
+
+          fail=0
+          for snupkg in $snupkgs; do
+            echo "::group::$snupkg"
+            work=$(mktemp -d)
+            unzip -q "$snupkg" -d "$work"
+
+            # Every runtime TFM MUST have a PDB under lib/<tfm>/. Missing
+            # entries mean SymbolPackageFormat/IncludeSymbols got misconfigured
+            # somewhere upstream — consumers on that TFM would fall back to
+            # decompiled placeholders in the debugger.
+            pdbs=$(find "$work/lib" -name 'Wolfgang.Etl.DbClient.pdb' | sort)
+            if [ -z "$pdbs" ]; then
+              echo "::error::No PDBs found under $snupkg / lib/*/"
+              fail=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            for pdb in $pdbs; do
+              tfm=$(basename "$(dirname "$pdb")")
+              # Portable-PDB magic = 'B','S','J','B' (0x42 0x53 0x4A 0x42)
+              # in the first 4 bytes. Full-format Windows PDBs start with
+              # "Microsoft C/C++ MSF 7.00" — an immediate fail.
+              magic=$(head -c 4 "$pdb" | od -An -tx1 | tr -d ' \n')
+              if [ "$magic" != "42534a42" ]; then
+                echo "::error::PDB is NOT portable (magic=0x$magic, expected 42534A42) — TFM $tfm"
+                fail=1
+              else
+                echo "✅ $tfm — portable PDB (magic BSJB)"
+              fi
+            done
+
+            echo "::endgroup::"
+            rm -rf "$work"
+          done
+
+          exit $fail
+
+  # Publish to NuGet (only if validation + integration + api-compat + sourcelink passed)
   publish-nuget:
     name: Publish to NuGet.org
-    needs: [pack-and-validate, test-integration-all]
+    needs: [pack-and-validate, test-integration-all, api-compat, sourcelink-snupkg]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     permissions:
@@ -679,7 +869,7 @@ jobs:
       contents: read
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             3.1.x
@@ -736,6 +926,84 @@ jobs:
           Write-Host "✅ All packages published to NuGet.org" -ForegroundColor Green
           Write-Host "==========================================" -ForegroundColor Green
 
+  # SourceLink post-publish smoke — after publish-nuget succeeds, poll the
+  # NuGet symbol server for the just-uploaded PDB. Uses dotnet-symbol which
+  # implements the SSQP protocol + follows the debug-directory signature
+  # in the DLL to compute the correct URL. Retries with backoff — the
+  # NuGet symbol server ingests .snupkg content on a delay measured in
+  # minutes (typical 5–30). Refs #144.
+  sourcelink-symbol-server-smoke:
+    name: SourceLink symbol-server smoke (post-publish)
+    needs: publish-nuget
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download packed artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nuget-packages
+          path: ./packages
+
+      - name: Install dotnet-symbol
+        run: dotnet tool install --global dotnet-symbol
+
+      - name: Extract a representative DLL from the packed .nupkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          nupkg=$(find packages -maxdepth 1 -name 'Wolfgang.Etl.DbClient.*.nupkg' ! -name '*.symbols.nupkg' | head -1)
+          if [ -z "$nupkg" ]; then
+            echo "::error::No runtime .nupkg to probe."
+            exit 1
+          fi
+          mkdir -p probe
+          unzip -q "$nupkg" -d probe
+          # Grab the net10.0 DLL if present, otherwise any TFM.
+          dll=$(find probe/lib -name 'Wolfgang.Etl.DbClient.dll' | sort | tail -1)
+          if [ -z "$dll" ]; then
+            echo "::error::No runtime DLL in the packed .nupkg."
+            find probe/lib -type f | head
+            exit 1
+          fi
+          echo "PROBE_DLL=$dll" >> "$GITHUB_ENV"
+          echo "Probing symbols for: $dll"
+
+      - name: Poll symbol server for published PDB (retry with backoff)
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="$PATH:$HOME/.dotnet/tools"
+
+          # nuget.org's symbol server URL (SSQP endpoint). dotnet-symbol
+          # defaults to msdl.microsoft.com — override to hit nuget.org.
+          server='https://symbols.nuget.org/download/symbols/'
+
+          # Retry loop: NuGet symbol ingestion is typically 5–30 min. Poll
+          # every 60s for up to 30 min, then fail.
+          out=$(mktemp -d)
+          attempts=30
+          for i in $(seq 1 "$attempts"); do
+            echo "Attempt $i/$attempts — dotnet-symbol from $server"
+            if dotnet-symbol --symbols --server-path "$server" --output "$out" "$PROBE_DLL"; then
+              # Success if a PDB actually landed in the output dir.
+              if find "$out" -name '*.pdb' | grep -q .; then
+                echo "✅ Symbol server served the PDB on attempt $i."
+                exit 0
+              fi
+            fi
+            echo "  not-yet — sleeping 60s"
+            sleep 60
+          done
+
+          echo "::error::Symbol server did not serve the published PDB after $((attempts*60))s of polling."
+          exit 1
+
   # Build and deploy versioned documentation via the shared docfx workflow
   # Note: reusable workflow jobs called via `uses:` do not require `runs-on` in the caller
   trigger-docs:
@@ -746,6 +1014,35 @@ jobs:
     uses: ./.github/workflows/docfx.yaml
     with:
       version: ${{ github.event.release.tag_name }}
+
+  # SLSA build provenance attestation — proves the .nupkg / .snupkg
+  # attached to the Release were built by THIS workflow at THIS commit,
+  # signed via GitHub's OIDC identity with Sigstore's keyless CA.
+  # Consumers can verify with `gh attestation verify <.nupkg> --owner
+  # Chris-Wolfgang --repo Etl-DbClient` (see SECURITY.md).
+  # Refs #138.
+  attest-build-provenance:
+    name: Attest build provenance (SLSA)
+    needs: [pack-and-validate, publish-nuget]
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # OIDC token for Sigstore keyless signing
+      contents: read
+      attestations: write   # required to write attestation to the repo
+    steps:
+      - name: Download packed artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nuget-packages
+          path: ./packages
+
+      - name: Attest .nupkg / .snupkg provenance
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v3.0.0
+        with:
+          subject-path: |
+            packages/*.nupkg
+            packages/*.snupkg
 
   # Attach NuGet packages and coverage report to the GitHub Release page
   update-release-artifacts:
@@ -772,7 +1069,7 @@ jobs:
         run: zip -r release-coverage.zip ./release-coverage
 
       - name: Attach artifacts to release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -85,7 +85,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -347,7 +347,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-coverage
           path: CoverageReport/
@@ -361,12 +361,12 @@ jobs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -569,7 +569,7 @@ jobs:
 
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nuget-packages
           path: ./nuget-packages/
@@ -595,12 +595,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             8.0.x
@@ -639,7 +639,7 @@ jobs:
 
       - name: Upload integration test results
         if: always() && steps.locate.outputs.found == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-integration-${{ matrix.rdbms }}-${{ matrix.tfm }}-trx
           path: TestResults-Integration/
@@ -869,7 +869,7 @@ jobs:
       contents: read
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             3.1.x
@@ -881,7 +881,7 @@ jobs:
             10.0.x
 
       - name: Download packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./packages
@@ -1054,13 +1054,13 @@ jobs:
       contents: write  # Required to upload assets to the GitHub Release
     steps:
       - name: Download NuGet packages artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./nuget-packages
 
       - name: Download coverage report artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-coverage
           path: ./release-coverage

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,72 @@
+# OSSF Scorecard — automated security-posture scoring.
+#
+# Scores the *repo configuration* (branch protection, signed commits,
+# pinned dependencies, dangerous-workflow patterns, ...) not the code.
+# Complementary to CodeQL (which scans source code) and zizmor
+# (workflow-YAML security).
+#
+# Publishes SARIF to the GitHub Security tab so findings appear
+# alongside CodeQL alerts. Also publishes to the public OpenSSF
+# dashboard once the scan runs on main and enables the badge in
+# README.md.
+#
+# Refs #152. Canonical form from https://github.com/ossf/scorecard-action.
+
+name: OSSF Scorecard
+
+on:
+  # Weekly schedule catches drift when nothing else has changed.
+  schedule:
+    - cron: "38 5 * * 2"  # Tuesday 05:38 UTC — arbitrary off-peak slot
+  # Score every merge into the default branch.
+  push:
+    branches: [main]
+  # Manual trigger for one-off score checks / debugging.
+  workflow_dispatch:
+
+# Least-privilege default: read-only for everything, per-job elevation below.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to the code-scanning API.
+      security-events: write
+      # Required for OIDC-based publishing to the OpenSSF dashboard.
+      id-token: write
+      # Required to read repository content and settings for scoring.
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes results to the OpenSSF public dashboard so the badge
+          # in README.md resolves. Requires the repo to be public (this repo is).
+          publish_results: true
+
+      # Upload as an artifact so the SARIF is retrievable even if the
+      # code-scanning upload later fails (e.g. quota, transient API).
+      - name: Upload SARIF as artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      # Publish SARIF to the Security tab. Failures here are non-blocking —
+      # the artifact upload above is the fallback for retrieval.
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -58,17 +58,14 @@ jobs:
         #   p/security-audit     — cross-language security-audit set
         #   p/secrets            — hard-coded credentials / API keys
         #
-        # Temporary exclusion of
-        # `yaml.github-actions.security.pull-request-target-code-checkout`.
-        # vNext already migrated pr.yaml, workflow-security.yaml, and
-        # aot-smoke.yaml off `pull_request_target` — but that migration
-        # hasn't reached main yet (this PR ships the vNext workflows to
-        # main so workflow_dispatch works; the pr.yaml migration itself
-        # is a separate main-facing PR). Without the exclusion, this
-        # workflow would fail on main's still-existing `pull_request_target`
-        # sites and block every PR until the migration lands. Drop the
-        # `--exclude-rule` line when main's pr.yaml + workflow-security.yaml
-        # + aot-smoke.yaml carry the migration too.
+        # No rule exclusions today. The previous rule-wide exclusion of
+        # yaml.github-actions.security.pull-request-target-code-checkout
+        # was removed after migrating pr.yaml, workflow-security.yaml,
+        # and aot-smoke.yaml from `pull_request_target` to `pull_request`
+        # (refs #131 / #257). If a future workflow needs
+        # `pull_request_target`, the rule should re-fire and force the
+        # author to think through mitigations rather than being silently
+        # ignored.
         #
         # Gate: `--severity=ERROR --error` fails the run on error-severity
         # findings only. Warning + info findings still upload to Code
@@ -80,7 +77,6 @@ jobs:
             --config=p/owasp-top-ten \
             --config=p/security-audit \
             --config=p/secrets \
-            --exclude-rule=yaml.github-actions.security.pull-request-target-code-checkout.pull-request-target-code-checkout \
             --sarif \
             --output=semgrep.sarif \
             --severity=ERROR \

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check.outputs.found == 'true'
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,87 @@
+# Workflow YAML security audit — zizmor + actionlint.
+#
+# CodeQL scans source code. This workflow scans the GitHub Actions
+# YAML *itself* for security defects that source-code SAST can't see:
+#   - untrusted-input injection into run: blocks
+#   - missing / overly-permissive permissions: blocks
+#   - secrets leaking via expression-context expansion
+#   - third-party actions not pinned by SHA
+#
+# zizmor: security-focused static analysis (rules focus on threat model).
+# actionlint: syntax + typing + common-mistake linting (broader, less deep).
+# The two are complementary — running both covers rule sets neither
+# tool covers alone.
+#
+# Refs #153.
+
+name: Workflow security audit
+
+on:
+  # pull_request (not pull_request_target). Neither zizmor nor actionlint
+  # execute PR-authored code — they parse YAML and emit findings. A PR
+  # that modifies this workflow to disable itself is caught by the
+  # branch-protection ruleset: both jobs' check names ("zizmor",
+  # "actionlint") are required, so their absence blocks merge.
+  # Matches the pr.yaml + aot-smoke.yaml migration off the
+  # pull-request-target-code-checkout anti-pattern (refs #131 / #257).
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".zizmor.yml"
+      - ".github/actionlint.yaml"
+  push:
+    branches: [main, vNext]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".zizmor.yml"
+      - ".github/actionlint.yaml"
+  # Manual trigger for full re-scan (e.g. after tightening the config).
+  workflow_dispatch:
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to code-scanning.
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          # Gate on high-severity findings; medium / low surface in
+          # Code Scanning but don't block the PR.
+          min-severity: high
+          # Config lives in .zizmor.yml at the repo root (see below).
+          # The zizmor action uploads SARIF to Code Scanning internally
+          # — no separate upload step needed. An earlier version of this
+          # workflow duplicated the upload and failed because it looked
+          # for a `results.sarif` path the action doesn't produce.
+
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        with:
+          # PR annotations (::error / ::warning file=…) are emitted by
+          # actionlint's default GitHub Actions matcher.
+          fail-on-error: true
+          # actionlint config lives in .github/actionlint.yaml (see below).


### PR DESCRIPTION
## Summary

**Protected half** of the v0.7.0 vNext → main split. Companion to [#284](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/284) (code, full CI). Ships only the \`.github/workflows/\` changes accumulated on vNext this cycle.

## Files

16 workflow files:
- **Modified (12):** benchmarks.yaml, build-all-versions.yaml, codeql.yaml, concurrency.yaml, docfx.yaml, fuzz.yaml, gc-profile.yaml, integration-status.yaml, pr.yaml, release.yaml, semgrep.yaml, stryker.yaml
- **Net-new (4):** aot-smoke.yaml, license-audit.yaml, scorecard.yaml, workflow-security.yaml

**Not touching \`sourcelink.yaml\`:** main has it (from #274) but vNext doesn't; explicitly preserving main's copy. Post-release \`vNext\` will be deleted per \`feedback_vnext_per_release_cycle\` and the next cycle's fresh vNext will inherit sourcelink.yaml from main automatically.

## Why admin-bypass

pr.yaml's \`Detect .NET Projects\` protected-file guard fires on any diff that touches \`.github/workflows/\` — by design, per \`feedback_protected_config_files_guard\`. Admin-bypass is the standard workaround per \`feedback_admin_bypass_all_or_nothing\` + \`feedback_protected_nonprotected_release_split\`.

## Merge order

1. [#284](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/284) (code, full CI) — merge first.
2. This PR — admin-bypass merge after #284.
3. YOU tag \`v0.7.0\` and create the GitHub Release; release.yaml (OIDC) publishes to NuGet.
4. Post-release: delete \`vNext\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)