### PR TITLE
ci(repro-build): explicit <PathMap> to normalise cross-OS paths (#255)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -101,6 +101,25 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+
+    <!--
+      Cross-OS reproducibility (#255):
+      Microsoft.SourceLink.GitHub maps source paths under the repo root to
+      GitHub raw URLs, but doesn't touch OTHER absolute paths the compiler
+      bakes into PDB records — most notably MSBuild-computed obj/bin
+      intermediates. Those paths differ per-OS (`D:\a\Etl-DbClient\…` on
+      Windows vs `/home/runner/work/Etl-DbClient/…` on Linux), so the two
+      OSes emit byte-different PDBs (and therefore byte-different DLLs
+      when the debug directory is embedded).
+
+      `<PathMap>` rewrites the leading source root uniformly to `/_/`
+      across every OS. The `/_/` sentinel is the same one dotnet SDK
+      uses when `ContinuousIntegrationBuild=true` implicitly normalises
+      the source path — this makes the explicit intent match the
+      implicit behaviour and covers the intermediates the implicit
+      normalisation misses.
+    -->
+    <PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -85,7 +85,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.20.0" />
   </ItemGroup>
 
   <!-- Source generator: built alongside the runtime, packed into the same

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/CultureInvarianceTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/CultureInvarianceTests.cs
@@ -89,8 +89,8 @@ public class CultureInvarianceTests
     public async Task Extract_roundtrips_decimal_and_datetime_under_hostile_culture(string cultureName)
     {
         using var _ = new CultureScope(cultureName);
-        await using var conn = TestDb.CreateConnection();
-        await using (var seed = conn.CreateCommand())
+        using var conn = TestDb.CreateConnection();
+        using (var seed = conn.CreateCommand())
         {
             seed.CommandText = @"
                 CREATE TABLE Widget (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL, Price REAL NOT NULL, CreatedUtc TEXT NOT NULL);
@@ -127,8 +127,8 @@ public class CultureInvarianceTests
     public async Task Load_persists_decimal_and_datetime_under_hostile_culture(string cultureName)
     {
         using var _ = new CultureScope(cultureName);
-        await using var conn = TestDb.CreateConnection();
-        await using (var create = conn.CreateCommand())
+        using var conn = TestDb.CreateConnection();
+        using (var create = conn.CreateCommand())
         {
             create.CommandText = "CREATE TABLE Widget (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL, Price REAL NOT NULL, CreatedUtc TEXT NOT NULL);";
             await create.ExecuteNonQueryAsync();
@@ -152,9 +152,9 @@ public class CultureInvarianceTests
         // extractor so any culture-injected error the LOAD path introduces
         // is caught here rather than being masked by a matching bug in
         // the read side.
-        await using var readBack = conn.CreateCommand();
+        using var readBack = conn.CreateCommand();
         readBack.CommandText = "SELECT Price FROM Widget ORDER BY Id";
-        await using var reader = await readBack.ExecuteReaderAsync();
+        using var reader = await readBack.ExecuteReaderAsync();
         Assert.True(await reader.ReadAsync());
         Assert.Equal(1.25m, Convert.ToDecimal(reader.GetValue(0), CultureInfo.InvariantCulture));
         Assert.True(await reader.ReadAsync());

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbSchemaValidatorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbSchemaValidatorTests.cs
@@ -157,14 +157,14 @@ public class DbSchemaValidatorTests
     [Fact]
     public async Task ValidateAsync_when_all_mapped_columns_exist_returns_normally()
     {
-        await using var conn = CreateSeededConnection();
+        using var conn = CreateSeededConnection();
         await DbSchemaValidator.ValidateAsync<Widget>(conn);
     }
 
     [Fact]
     public async Task ValidateAsync_when_column_missing_throws()
     {
-        await using var conn = CreateSeededConnection();
+        using var conn = CreateSeededConnection();
         await Assert.ThrowsAsync<InvalidOperationException>
         (
             () => DbSchemaValidator.ValidateAsync<WidgetWithExtraColumn>(conn)
@@ -174,7 +174,7 @@ public class DbSchemaValidatorTests
     [Fact]
     public async Task ValidateAsync_honours_cancellation()
     {
-        await using var conn = CreateSeededConnection();
+        using var conn = CreateSeededConnection();
         using var cts = new CancellationTokenSource();
         cts.Cancel();
         await Assert.ThrowsAsync<OperationCanceledException>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -117,13 +117,13 @@
   <!-- Shared dependencies (all TFMs) -->
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.10" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.9.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.13.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.13.0" />
   </ItemGroup>
 
   <!-- Copy native SQLite DLL to output for .NET Framework (no RID-based probing) -->


### PR DESCRIPTION
## Summary

First stacked PR on top of [#292](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/292) (Abstractions 0.20 + TestKit 0.13 bump). Takes the highest-signal hypothesis from #255's ordered fix list: explicit \`<PathMap>\` in Directory.Build.props.

## What & why

#255 diagnosed that even scoped to the shipping DLL + PDB, ubuntu-latest and windows-latest emit byte-different outputs per TFM despite \`<Deterministic>\`, \`<ContinuousIntegrationBuild>\`, and \`<EmbedUntrackedSources>\` all being set + SourceLink being wired.

The gap: SourceLink only rewrites source paths under the repo root. Absolute paths from other origins (MSBuild-computed \`obj/\`/\`bin/\` intermediates, the debug directory) end up in PDB records with per-OS forms (\`D:\a\Etl-DbClient\...\` vs \`/home/runner/work/Etl-DbClient/...\`), diverging the debug streams and therefore the DLLs.

\`<PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>\` rewrites every absolute path anchored at the repo root to \`/_/\` uniformly across OSes. Same sentinel dotnet SDK uses when \`ContinuousIntegrationBuild=true\` implicitly normalises source paths — explicit intent matches implicit behaviour, extends the rewrite to intermediates the implicit normalisation misses.

## Test plan

- [x] Local Release build clean.
- [ ] CI's \`reproducible-build.yaml\` runs the ubuntu-latest + windows-latest matrix; watch for the sha256 diff step to report same-hash across OSes for at least the \`Wolfgang.Etl.DbClient.dll\` line.
- [ ] If hashes match: next stacked PR flips the workflow's Compare step from informational to blocking (per #255 AC) + unblocks #155.
- [ ] If hashes still differ: file follow-up with the specific bytes that still diverge (probably PDB-embedded roslyn intermediate paths, would need per-file investigation).

Not addressed here (deferred if this alone doesn't close the gap):
* \`<GenerateAssemblyMetadataAttributes>false</GenerateAssemblyMetadataAttributes>\` — bumps public API surface (attribute is analyzer-visible), separate PR.
* Source-generator file order — \`ForAttributeWithMetadataName\` is deterministic in the incremental generator API, shouldn't be a factor.
* .nupkg/.snupkg zip-container determinism — outer-container concern, separate from this .dll/.pdb comparison.

Refs #255. Unblocks #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)