### PR TITLE
tests(shadow): sample-consumer scaffold for shadow-testing gate (#130)

### DIFF
--- a/Wolfgang.Etl.DbClient.slnx
+++ b/Wolfgang.Etl.DbClient.slnx
@@ -44,6 +44,9 @@
   <Folder Name="/tools/">
     <Project Path="tools/GcProfileWorkload/GcProfileWorkload.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj" />
+  </Folder>
   <Folder Name="/examples/">
     <Project Path="examples/Wolfgang.Etl.DbClient.Example/Wolfgang.Etl.DbClient.Example.csproj" />
     <Project Path="examples/Wolfgang.Etl.DbClient.Example.AutoSql/Wolfgang.Etl.DbClient.Example.AutoSql.csproj" />

--- a/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Program.cs
+++ b/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Program.cs
@@ -1,0 +1,193 @@
+// Shadow-testing consumer — realistic DbClient workload for #130.
+//
+// Scenario: a paged extract-transform-load loop. 100k rows in a source
+// SQLite table, paged out 1k at a time via server-side paging on the
+// extractor, projected through a lightweight transform, and re-inserted
+// into a destination table in batches of 100 via the loader's InsertBatchSize.
+//
+// The workload runs against SQLite in-memory so behaviour is deterministic
+// across CI runners — the shadow-testing gate compares metrics, not
+// wall-clock absolute values, so the SQLite path is fine as a stand-in for
+// realistic ETL shapes even though production consumers hit SQL Server /
+// Postgres / etc.
+//
+// Metrics printed to stdout as one JSON line at the end. shadow.yaml
+// (follow-up PR) parses that line, diffs against a baseline recorded on
+// gh-pages, and fails the run if latency or allocation regresses beyond a
+// documented threshold.
+//
+// Refs #130.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Sqlite;
+using Wolfgang.Etl.DbClient;
+using Wolfgang.Etl.DbClient.Samples.ShadowConsumer;
+
+const int totalRows = 100_000;
+const int pageSize = 1_000;
+const int batchSize = 100;
+
+Console.Error.WriteLine($"[shadow] .NET {Environment.Version}  ServerGC={System.Runtime.GCSettings.IsServerGC}");
+Console.Error.WriteLine($"[shadow] rows={totalRows} page={pageSize} batch={batchSize}");
+
+using var src = new SqliteConnection("Data Source=:memory:");
+using var dest = new SqliteConnection("Data Source=:memory:");
+await src.OpenAsync();
+await dest.OpenAsync();
+
+await Ddl(src, "CREATE TABLE widget (id INTEGER PRIMARY KEY, name TEXT NOT NULL, price REAL NOT NULL);");
+await Ddl(dest, "CREATE TABLE widget_projected (id INTEGER PRIMARY KEY, upper_name TEXT NOT NULL, price REAL NOT NULL);");
+await SeedSourceAsync(src, totalRows);
+
+// Baseline GC counters — everything after this point is measured.
+GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+GC.WaitForPendingFinalizers();
+GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+var startAllocated = GC.GetTotalAllocatedBytes(precise: true);
+var startGen0 = GC.CollectionCount(0);
+var startGen1 = GC.CollectionCount(1);
+var startGen2 = GC.CollectionCount(2);
+var sw = Stopwatch.StartNew();
+
+long extracted = 0;
+long loaded = 0;
+
+for (long offset = 0; offset < totalRows; offset += pageSize)
+{
+    var extractor = new DbExtractor<SourceWidget>
+    (
+        src,
+        "SELECT id AS Id, name AS Name, price AS Price FROM widget ORDER BY id"
+    )
+    {
+        ServerOffset = offset,
+        ServerLimit = pageSize,
+    };
+
+    var page = new List<DestWidget>(pageSize);
+    await foreach (var s in extractor.ExtractAsync())
+    {
+        page.Add(new DestWidget { Id = s.Id, UpperName = s.Name.ToUpperInvariant(), Price = s.Price });
+        extracted++;
+    }
+
+    var loader = new DbLoader<DestWidget>
+    (
+        dest,
+        "INSERT INTO widget_projected (id, upper_name, price) VALUES (@Id, @UpperName, @Price)"
+    )
+    {
+        InsertBatchSize = batchSize,
+    };
+    await loader.LoadAsync(AsAsync(page));
+    loaded += page.Count;
+}
+
+sw.Stop();
+
+var endAllocated = GC.GetTotalAllocatedBytes(precise: true);
+var endGen0 = GC.CollectionCount(0);
+var endGen1 = GC.CollectionCount(1);
+var endGen2 = GC.CollectionCount(2);
+var peakWs = Environment.WorkingSet;
+
+var metrics = new
+{
+    schemaVersion = 1,
+    runtime = Environment.Version.ToString(),
+    serverGc = System.Runtime.GCSettings.IsServerGC,
+    scenario = "paged-etl",
+    rows = extracted,
+    loaded,
+    elapsedMs = sw.ElapsedMilliseconds,
+    rowsPerSecond = extracted * 1000L / Math.Max(1L, sw.ElapsedMilliseconds),
+    allocatedBytes = endAllocated - startAllocated,
+    bytesPerRow = (endAllocated - startAllocated) / Math.Max(1L, extracted),
+    gen0Collections = endGen0 - startGen0,
+    gen1Collections = endGen1 - startGen1,
+    gen2Collections = endGen2 - startGen2,
+    peakWorkingSetBytes = peakWs,
+};
+
+// Human-readable summary to stderr; machine-readable JSON to stdout.
+Console.Error.WriteLine($"[shadow] elapsed={sw.ElapsedMilliseconds}ms " +
+    $"rows/s={metrics.rowsPerSecond:N0} " +
+    $"alloc={metrics.allocatedBytes / 1024 / 1024}MB " +
+    $"bytes/row={metrics.bytesPerRow:N0} " +
+    $"gc={endGen0 - startGen0}/{endGen1 - startGen1}/{endGen2 - startGen2}");
+Console.WriteLine(JsonSerializer.Serialize(metrics));
+
+
+// -----------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------
+
+static async Task Ddl(SqliteConnection conn, string sql)
+{
+    using var cmd = conn.CreateCommand();
+    // nosemgrep: csharp.lang.security.sqli.csharp-sqli.csharp-sqli
+    cmd.CommandText = sql;
+    await cmd.ExecuteNonQueryAsync();
+}
+
+static async Task SeedSourceAsync(SqliteConnection conn, int rowCount)
+{
+    using var tx = (SqliteTransaction)await conn.BeginTransactionAsync();
+    using var cmd = conn.CreateCommand();
+    cmd.Transaction = tx;
+    cmd.CommandText = "INSERT INTO widget (id, name, price) VALUES ($id, $name, $price)";
+    var pId = cmd.CreateParameter(); pId.ParameterName = "$id"; cmd.Parameters.Add(pId);
+    var pName = cmd.CreateParameter(); pName.ParameterName = "$name"; cmd.Parameters.Add(pName);
+    var pPrice = cmd.CreateParameter(); pPrice.ParameterName = "$price"; cmd.Parameters.Add(pPrice);
+    for (var i = 1; i <= rowCount; i++)
+    {
+        pId.Value = i;
+        pName.Value = "widget-" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        pPrice.Value = (i * 0.01) % 10.0;
+        await cmd.ExecuteNonQueryAsync();
+    }
+    await tx.CommitAsync();
+}
+
+static async IAsyncEnumerable<T> AsAsync<T>(IEnumerable<T> source)
+{
+    foreach (var item in source)
+    {
+        yield return item;
+        if ((item is DestWidget dw) && (dw.Id & 0xFF) == 0)
+        {
+            await Task.Yield();
+        }
+    }
+}
+
+
+// -----------------------------------------------------------------
+// Types (namespaced to satisfy MA0047)
+// -----------------------------------------------------------------
+
+namespace Wolfgang.Etl.DbClient.Samples.ShadowConsumer
+{
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    internal sealed class SourceWidget
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public double Price { get; set; }
+    }
+
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    internal sealed class DestWidget
+    {
+        public int Id { get; set; }
+        public string UpperName { get; set; } = "";
+        public double Price { get; set; }
+    }
+}

--- a/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/README.md
+++ b/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/README.md
@@ -1,0 +1,83 @@
+# Shadow-testing consumer
+
+Realistic workload for [#130](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/130).
+Represents a consumer that uses the library the way production code does —
+paged extract + transform + batched load — so a nightly shadow run can
+detect regressions the synthetic BDN suite misses.
+
+## Scenario
+
+Seeds a 100,000-row SQLite source table, then extracts it in 100 pages of
+1,000 rows via `DbExtractor<T>`'s `ServerOffset` / `ServerLimit`, projects
+each row through a small transform, and reloads the projection into a
+destination table via `DbLoader<T>` with `InsertBatchSize = 100`.
+
+Every knob a production consumer would touch is exercised: server-side
+paging, per-page extractor instantiation, batched inserts, transaction
+management, per-row Dapper materialization, `IAsyncEnumerable<T>` streaming.
+
+## Metrics
+
+One JSON line is written to **stdout** at the end of the run; human-readable
+progress goes to **stderr**. The shadow-testing workflow (follow-up PR)
+parses the stdout line and compares against a baseline recorded on
+gh-pages.
+
+```json
+{
+  "schemaVersion": 1,
+  "runtime": "10.0.10",
+  "serverGc": true,
+  "scenario": "paged-etl",
+  "rows": 100000,
+  "loaded": 100000,
+  "elapsedMs": 3297,
+  "rowsPerSecond": 30330,
+  "allocatedBytes": 307479216,
+  "bytesPerRow": 3074,
+  "gen0Collections": 89,
+  "gen1Collections": 1,
+  "gen2Collections": 0,
+  "peakWorkingSetBytes": 58466304
+}
+```
+
+Fields tracked by the regression gate (thresholds set by the follow-up PR
+that adds the gate):
+- `elapsedMs` — total wall-clock time.
+- `rowsPerSecond` — throughput.
+- `allocatedBytes` — cumulative GC allocations for the whole ETL loop.
+- `bytesPerRow` — normalised allocation cost.
+- `gen0Collections` / `gen1Collections` / `gen2Collections` — GC pressure
+  by generation. gen2 is the most sensitive to allocation regressions.
+
+Not tracked: `peakWorkingSetBytes`. Useful eyeballing but too noisy
+across CI runners for a threshold gate — reported for context only.
+
+## Why SQLite in-memory
+
+Deterministic across runners. The gate compares **metric deltas**, not
+absolute values, so the SQLite path is a valid stand-in for real ETL
+shapes even though production consumers hit SQL Server / Postgres / etc.
+A real-DB replay against Testcontainers would add ~30s of container
+warmup per matrix leg for no additional signal — the code paths inside
+DbClient are the same regardless of driver.
+
+## Running locally
+
+```bash
+dotnet run --project samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer -c Release
+```
+
+Typical local run: 3-5 seconds wall-clock on a warm .NET 10 runtime,
+~30k rows/second, ~3 KB allocated per row, ~90 gen0 collections.
+
+## Follow-up work (separate PRs)
+
+- **`shadow.yaml` workflow** — nightly + `workflow_dispatch`, matrix
+  across the shipping TFMs, runs this project + parses JSON.
+- **Baseline capture on gh-pages** — one JSON per runner+TFM combo,
+  updated on `push` to main.
+- **Regression gate + auto-issue** — fails the shadow run when a metric
+  regresses beyond a per-metric threshold. Same auto-issue pattern as
+  the fuzz-failure workflow (#275).

--- a/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj
+++ b/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+
+    <!-- Server GC + concurrent tuning — matches a production ETL workload
+         the library would run under. Same reasoning as tools/GcProfileWorkload. -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+
+    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 same treatment as sibling
+         samples. CA2007 / MA0004 / MA0048 / S3903 / VSTHRD200 — top-level
+         statements in a .exe workload, not library code. -->
+    <NoWarn>$(NoWarn);NU1903;CA2007;CA1849;MA0004;MA0048;S3903;VSTHRD200</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.DbClient\Wolfgang.Etl.DbClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -85,7 +85,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.20.0" />
   </ItemGroup>
 
   <!-- Source generator: built alongside the runtime, packed into the same

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/CultureInvarianceTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/CultureInvarianceTests.cs
@@ -89,8 +89,8 @@ public class CultureInvarianceTests
     public async Task Extract_roundtrips_decimal_and_datetime_under_hostile_culture(string cultureName)
     {
         using var _ = new CultureScope(cultureName);
-        await using var conn = TestDb.CreateConnection();
-        await using (var seed = conn.CreateCommand())
+        using var conn = TestDb.CreateConnection();
+        using (var seed = conn.CreateCommand())
         {
             seed.CommandText = @"
                 CREATE TABLE Widget (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL, Price REAL NOT NULL, CreatedUtc TEXT NOT NULL);
@@ -127,8 +127,8 @@ public class CultureInvarianceTests
     public async Task Load_persists_decimal_and_datetime_under_hostile_culture(string cultureName)
     {
         using var _ = new CultureScope(cultureName);
-        await using var conn = TestDb.CreateConnection();
-        await using (var create = conn.CreateCommand())
+        using var conn = TestDb.CreateConnection();
+        using (var create = conn.CreateCommand())
         {
             create.CommandText = "CREATE TABLE Widget (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL, Price REAL NOT NULL, CreatedUtc TEXT NOT NULL);";
             await create.ExecuteNonQueryAsync();
@@ -152,9 +152,9 @@ public class CultureInvarianceTests
         // extractor so any culture-injected error the LOAD path introduces
         // is caught here rather than being masked by a matching bug in
         // the read side.
-        await using var readBack = conn.CreateCommand();
+        using var readBack = conn.CreateCommand();
         readBack.CommandText = "SELECT Price FROM Widget ORDER BY Id";
-        await using var reader = await readBack.ExecuteReaderAsync();
+        using var reader = await readBack.ExecuteReaderAsync();
         Assert.True(await reader.ReadAsync());
         Assert.Equal(1.25m, Convert.ToDecimal(reader.GetValue(0), CultureInfo.InvariantCulture));
         Assert.True(await reader.ReadAsync());

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbSchemaValidatorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbSchemaValidatorTests.cs
@@ -157,14 +157,14 @@ public class DbSchemaValidatorTests
     [Fact]
     public async Task ValidateAsync_when_all_mapped_columns_exist_returns_normally()
     {
-        await using var conn = CreateSeededConnection();
+        using var conn = CreateSeededConnection();
         await DbSchemaValidator.ValidateAsync<Widget>(conn);
     }
 
     [Fact]
     public async Task ValidateAsync_when_column_missing_throws()
     {
-        await using var conn = CreateSeededConnection();
+        using var conn = CreateSeededConnection();
         await Assert.ThrowsAsync<InvalidOperationException>
         (
             () => DbSchemaValidator.ValidateAsync<WidgetWithExtraColumn>(conn)
@@ -174,7 +174,7 @@ public class DbSchemaValidatorTests
     [Fact]
     public async Task ValidateAsync_honours_cancellation()
     {
-        await using var conn = CreateSeededConnection();
+        using var conn = CreateSeededConnection();
         using var cts = new CancellationTokenSource();
         cts.Cancel();
         await Assert.ThrowsAsync<OperationCanceledException>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -117,13 +117,13 @@
   <!-- Shared dependencies (all TFMs) -->
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.10" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.9.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.13.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.13.0" />
   </ItemGroup>
 
   <!-- Copy native SQLite DLL to output for .NET Framework (no RID-based probing) -->


### PR DESCRIPTION
## Summary

First stacked PR of the #130 series. Introduces \`samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/\`, a realistic paged-ETL workload that a shadow-testing workflow can replay nightly to detect perf/allocation regressions the synthetic BDN suite misses.

Stacked on [#292](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/292) (Abstractions 0.20 + TestKit 0.13 bump).

## Scenario

100k rows in a SQLite source table → extracted in 100 pages of 1k via \`DbExtractor<T>.ServerOffset\`/\`ServerLimit\` → projected through a small transform → reloaded into a destination table via \`DbLoader<T>.InsertBatchSize = 100\`. Exercises every knob a production consumer would touch: paged extraction, per-page extractor instantiation, batched inserts, transaction management, per-row Dapper materialization, \`IAsyncEnumerable<T>\` streaming.

## Output

One JSON metrics line to **stdout** (parsed by the follow-up shadow workflow); human-readable progress to **stderr**.

\`\`\`json
{
  \"schemaVersion\": 1,
  \"runtime\": \"10.0.10\",
  \"serverGc\": true,
  \"scenario\": \"paged-etl\",
  \"rows\": 100000,
  \"loaded\": 100000,
  \"elapsedMs\": 3297,
  \"rowsPerSecond\": 30330,
  \"allocatedBytes\": 307479216,
  \"bytesPerRow\": 3074,
  \"gen0Collections\": 89,
  \"gen1Collections\": 1,
  \"gen2Collections\": 0,
  \"peakWorkingSetBytes\": 58466304
}
\`\`\`

Verified locally on .NET 10 ServerGC.

## Follow-up PRs (this stack)

1. **This PR** — sample-consumer scaffold.
2. \`shadow.yaml\` workflow — nightly + \`workflow_dispatch\`, runs the sample per TFM+RID.
3. Baseline capture on \`gh-pages\` — one JSON per runner+TFM combo, updated on push to main.
4. Regression gate + auto-issue — per-metric thresholds, same auto-issue pattern as fuzz-failure (#275).

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)