### PR TITLE
ci(shadow): shadow.yaml — nightly + workflow_dispatch capture of consumer metrics (#130)

### DIFF
--- a/.github/workflows/shadow.yaml
+++ b/.github/workflows/shadow.yaml
@@ -1,0 +1,141 @@
+# Shadow-testing gate for realistic consumer workloads.
+#
+# Runs the sample under `samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/`
+# on a weekly cron + workflow_dispatch, parses the JSON metrics line it
+# writes to stdout, and uploads the raw output as an artifact for
+# post-mortem. Baseline capture on gh-pages + regression gate + auto-issue
+# arrive in follow-up PRs so this workflow can land ahead of the metric
+# thresholds being settled.
+#
+# The Shadow Consumer's scenario is a paged ETL loop against SQLite
+# in-memory — deterministic across runners so the metric deltas rather
+# than the absolute values are what matter. See
+# samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/README.md.
+#
+# Refs #130.
+
+name: Shadow-testing
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "Row count for the paged ETL loop (default = the sample's built-in 100000)"
+        required: false
+        default: ""
+        type: string
+  schedule:
+    # Weekly Sunday 08:00 UTC — outside the Stryker (Sunday 06:00) +
+    # gc-profile (Sunday 07:00) window so the three heavy scheduled
+    # jobs don't pile up on the runner pool.
+    - cron: '0 8 * * 0'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shadow-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shadow:
+    name: Shadow consumer (${{ matrix.os }} / net10.0)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # Multi-OS from the start so the baseline captured later has
+        # per-OS numbers. Linux/Windows are the two OSes reproducible-
+        # build already exercises; adding macOS would triple runtime for
+        # marginal signal — deferred to a follow-up if a Mac-specific
+        # regression class emerges.
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Guard so the scheduled Sunday 08:00 UTC run on main no-ops when
+      # the sample project isn't on the checked-out ref. The sample
+      # lives on vNext and hasn't merged to main yet; once it has, this
+      # guard becomes a no-op and the block can be dropped.
+      - name: Detect Shadow Consumer sample
+        id: check
+        shell: bash
+        run: |
+          if [ -f samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Shadow Consumer sample not present on this ref — skipping. Merge vNext to main to enable."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore + Build sample (Release)
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          dotnet restore samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj
+          dotnet build samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj \
+            --no-restore \
+            --configuration Release
+
+      - name: Run shadow consumer + capture metrics
+        # The sample writes human-readable progress to stderr and one
+        # JSON line to stdout at the end. Redirect them separately so we
+        # can persist the metrics line as a first-class artifact (that
+        # the regression-gate follow-up PR consumes) AND the human log
+        # for post-mortem.
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p reports
+          dotnet run --project samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj \
+            --configuration Release \
+            --no-build \
+            1> reports/metrics.json \
+            2> reports/shadow.log
+
+          # Tag the metrics with runner metadata so the follow-up
+          # regression gate can pick the right baseline record.
+          jq --arg os "${{ matrix.os }}" \
+             --arg sha "${{ github.sha }}" \
+             --arg ref "${{ github.ref }}" \
+             --arg run_id "${{ github.run_id }}" \
+             '. + {os: $os, sha: $sha, ref: $ref, runId: $run_id}' \
+             reports/metrics.json > reports/metrics.tagged.json
+          mv reports/metrics.tagged.json reports/metrics.json
+
+          echo "=== shadow.log ==="
+          cat reports/shadow.log
+          echo
+          echo "=== metrics.json ==="
+          cat reports/metrics.json
+
+      - name: Emit metrics to Step Summary
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          {
+            echo "### Shadow consumer — \`${{ matrix.os }}\` / net10.0"
+            echo ""
+            echo '```json'
+            cat reports/metrics.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload shadow artifacts
+        if: always() && steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: shadow-${{ matrix.os }}
+          path: reports/
+          retention-days: 60


### PR DESCRIPTION
## Summary

Second stacked PR of the #130 series. Adds \`.github/workflows/shadow.yaml\` which runs the sample from #294 on a weekly cron + \`workflow_dispatch\`, splits stdout (JSON metrics) and stderr (human log) into separate artifacts, and mirrors the metrics to the Step Summary for at-a-glance triage.

Stacked on [#294](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/294) (which is stacked on [#292](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/292)).

## What runs

- **Matrix:** ubuntu-latest + windows-latest. macOS deferred.
- **Cron:** Sunday 08:00 UTC — outside Stryker (06:00) + gc-profile (07:00) so the three heavy scheduled jobs don't stack.
- **Guard:** no-ops when the sample project isn't on the checked-out ref (same pattern as concurrency/fuzz/gc-profile guards during the v0.7.0 split).
- **Metrics tagging:** each leg tags its \`metrics.json\` with runner metadata (\`os\`, \`sha\`, \`ref\`, \`runId\`) via \`jq\` so the follow-up regression-gate PR can look up the right baseline record.
- **Actions SHA-pinned** per \`feedback_actions_sha_pin\` (v7.0.0 checkout, v5 setup-dotnet, v7 upload-artifact — all with commit SHAs).

## Not yet in this PR (follow-ups)

1. **Baseline capture on \`gh-pages\`** — one JSON per runner+TFM, updated on push to main.
2. **Regression gate** — per-metric thresholds, fails the run when a metric regresses beyond threshold.
3. **Auto-issue on regression** — same shape as the fuzz-failure workflow (#275).

Landing this workflow first (without the gate) lets the metrics start accumulating on scheduled runs before we commit to specific thresholds.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)