### PR TITLE
tests: adopt SupportsDryRunContractTests + prune 2 subsumed property tests

### DIFF
--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -85,7 +85,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.20.0" />
   </ItemGroup>
 
   <!-- Source generator: built alongside the runtime, packed into the same

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/CultureInvarianceTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/CultureInvarianceTests.cs
@@ -89,8 +89,8 @@ public class CultureInvarianceTests
     public async Task Extract_roundtrips_decimal_and_datetime_under_hostile_culture(string cultureName)
     {
         using var _ = new CultureScope(cultureName);
-        await using var conn = TestDb.CreateConnection();
-        await using (var seed = conn.CreateCommand())
+        using var conn = TestDb.CreateConnection();
+        using (var seed = conn.CreateCommand())
         {
             seed.CommandText = @"
                 CREATE TABLE Widget (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL, Price REAL NOT NULL, CreatedUtc TEXT NOT NULL);
@@ -127,8 +127,8 @@ public class CultureInvarianceTests
     public async Task Load_persists_decimal_and_datetime_under_hostile_culture(string cultureName)
     {
         using var _ = new CultureScope(cultureName);
-        await using var conn = TestDb.CreateConnection();
-        await using (var create = conn.CreateCommand())
+        using var conn = TestDb.CreateConnection();
+        using (var create = conn.CreateCommand())
         {
             create.CommandText = "CREATE TABLE Widget (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL, Price REAL NOT NULL, CreatedUtc TEXT NOT NULL);";
             await create.ExecuteNonQueryAsync();
@@ -152,9 +152,9 @@ public class CultureInvarianceTests
         // extractor so any culture-injected error the LOAD path introduces
         // is caught here rather than being masked by a matching bug in
         // the read side.
-        await using var readBack = conn.CreateCommand();
+        using var readBack = conn.CreateCommand();
         readBack.CommandText = "SELECT Price FROM Widget ORDER BY Id";
-        await using var reader = await readBack.ExecuteReaderAsync();
+        using var reader = await readBack.ExecuteReaderAsync();
         Assert.True(await reader.ReadAsync());
         Assert.Equal(1.25m, Convert.ToDecimal(reader.GetValue(0), CultureInfo.InvariantCulture));
         Assert.True(await reader.ReadAsync());

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderSupportsDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderSupportsDryRunContractTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+/// <summary>
+/// Adopts <see cref="SupportsDryRunContractTests{TSut}"/> for
+/// <see cref="DbLoader{TRecord}"/>'s <c>ISupportDryRun</c> implementation.
+/// Adds the property-contract tests + the two behavioural tests
+/// (side effect suppressed on dry-run, side effect performed when off)
+/// without duplicating what <see cref="DbLoaderTests"/> already covers.
+/// </summary>
+/// <remarks>
+/// The pre-existing <c>DbLoaderTests.LoadAsync_when_IsDryRun_is_true_does_not_write_to_database</c>
+/// is retained deliberately — it exercises the batched
+/// <see cref="DbLoader{TRecord}.InsertBatchSize"/> code path, which the
+/// contract tests don't reach (the contract's default per-row path goes
+/// through the loader base's <c>LoadWorkerAsync</c>). Property tests
+/// <c>IsDryRun_defaults_to_false</c> + <c>IsDryRun_set_and_get_roundtrips</c>
+/// in DbLoaderTests ARE subsumed — see the follow-up commit that
+/// prunes them.
+/// </remarks>
+public sealed class DbLoaderSupportsDryRunContractTests
+    : SupportsDryRunContractTests<DbLoader<DryRunContractRecord>>
+{
+    protected override DbLoader<DryRunContractRecord> CreateSut()
+    {
+        var conn = OpenSeededConnection();
+        return new DbLoader<DryRunContractRecord>
+        (
+            conn,
+            "INSERT INTO contract_dryrun (id, name) VALUES (@Id, @Name)"
+        );
+    }
+
+
+
+    protected override async Task<bool> RunAndReportSideEffectAsync(bool isDryRun)
+    {
+        // Each call gets its own SUT + connection so the "IsDryRun=false → rows
+        // land" and "IsDryRun=true → rows don't land" scenarios can't leak
+        // state through a shared in-memory database.
+        using var conn = OpenSeededConnection();
+
+        var sut = new DbLoader<DryRunContractRecord>
+        (
+            conn,
+            "INSERT INTO contract_dryrun (id, name) VALUES (@Id, @Name)"
+        )
+        {
+            IsDryRun = isDryRun,
+        };
+
+        await sut.LoadAsync(GenerateAsync(rowCount: 3));
+
+        // Side effect = at least one row landed in the destination table.
+        using var count = conn.CreateCommand();
+        count.CommandText = "SELECT COUNT(*) FROM contract_dryrun;";
+        var landed = Convert.ToInt64(await count.ExecuteScalarAsync(), System.Globalization.CultureInfo.InvariantCulture);
+        return landed > 0;
+    }
+
+
+
+    private static SqliteConnection OpenSeededConnection()
+    {
+        var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using var create = conn.CreateCommand();
+        create.CommandText = "CREATE TABLE contract_dryrun (id INTEGER PRIMARY KEY, name TEXT NOT NULL);";
+        create.ExecuteNonQuery();
+        return conn;
+    }
+
+
+
+    private static async IAsyncEnumerable<DryRunContractRecord> GenerateAsync(int rowCount)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            yield return new DryRunContractRecord { Id = i, Name = "contract-" + i };
+            await Task.Yield();
+        }
+    }
+}
+
+
+// Test fixture for the SupportsDryRun contract. Kept alongside the test
+// class rather than in a shared file since nothing else in the project
+// needs a dry-run POCO.
+public sealed class DryRunContractRecord
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -681,31 +681,13 @@ public class DbLoaderTests
 
     // ------------------------------------------------------------------
     // IsDryRun (#21)
+    //
+    // Property-contract coverage (defaults, roundtrip, set-back-to-false)
+    // is provided by SupportsDryRunContractTests<DbLoader<T>> — see
+    // DbLoaderSupportsDryRunContractTests. Only the batched behavioural
+    // scenario remains here because the contract's default per-row path
+    // doesn't reach the InsertBatchSize code path.
     // ------------------------------------------------------------------
-
-    [Fact]
-    public void IsDryRun_defaults_to_false()
-    {
-        using var conn = TestDb.CreateConnection();
-        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
-
-        Assert.False(loader.IsDryRun);
-    }
-
-
-
-    [Fact]
-    public void IsDryRun_set_and_get_roundtrips()
-    {
-        using var conn = TestDb.CreateConnection();
-        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
-
-        loader.IsDryRun = true;
-
-        Assert.True(loader.IsDryRun);
-    }
-
-
 
     [Fact]
     public async Task LoadAsync_when_IsDryRun_is_true_does_not_write_to_database()

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbSchemaValidatorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbSchemaValidatorTests.cs
@@ -157,14 +157,14 @@ public class DbSchemaValidatorTests
     [Fact]
     public async Task ValidateAsync_when_all_mapped_columns_exist_returns_normally()
     {
-        await using var conn = CreateSeededConnection();
+        using var conn = CreateSeededConnection();
         await DbSchemaValidator.ValidateAsync<Widget>(conn);
     }
 
     [Fact]
     public async Task ValidateAsync_when_column_missing_throws()
     {
-        await using var conn = CreateSeededConnection();
+        using var conn = CreateSeededConnection();
         await Assert.ThrowsAsync<InvalidOperationException>
         (
             () => DbSchemaValidator.ValidateAsync<WidgetWithExtraColumn>(conn)
@@ -174,7 +174,7 @@ public class DbSchemaValidatorTests
     [Fact]
     public async Task ValidateAsync_honours_cancellation()
     {
-        await using var conn = CreateSeededConnection();
+        using var conn = CreateSeededConnection();
         using var cts = new CancellationTokenSource();
         cts.Cancel();
         await Assert.ThrowsAsync<OperationCanceledException>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -117,13 +117,13 @@
   <!-- Shared dependencies (all TFMs) -->
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.10" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.9.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.13.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.13.0" />
   </ItemGroup>
 
   <!-- Copy native SQLite DLL to output for .NET Framework (no RID-based probing) -->


### PR DESCRIPTION
## Summary

First (and only) round of the duplicate-test enumeration against TestKit.Xunit 0.13's 25 contract-test bases. Enumeration covered all 20 repo test files; committing only the changes that survived case-by-case verification.

Stacked on [#292](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/292) (bump — needed for TestKit 0.13's contract classes).

## What changed

- **Added** `DbLoaderSupportsDryRunContractTests` adopting `SupportsDryRunContractTests<DbLoader<T>>` — 5 new contract-level tests all pass:
  - `IsDryRun_defaults_to_false`
  - `IsDryRun_can_be_set_to_true`
  - `IsDryRun_can_be_set_back_to_false`
  - `When_IsDryRun_is_false_side_effect_occurs_Async`
  - `When_IsDryRun_is_true_side_effect_is_skipped_Async`
- **Removed** `DbLoaderTests.IsDryRun_defaults_to_false` + `DbLoaderTests.IsDryRun_set_and_get_roundtrips` — property-level duplicates of the new contract.
- **Retained** `DbLoaderTests.LoadAsync_when_IsDryRun_is_true_does_not_write_to_database` — exercises the batched `InsertBatchSize` path, which the contract's default per-row path doesn't reach.

## Not adopted (case-by-case verification)

- **`ErrorHandlingContractTests<T>`** — DbLoader uses its own `RowErrorHandling` enum (`Skip`/`Abort`), not Abstractions' `ItemErrorAction`. Adopting requires migrating DbLoader's public API — breaking change out of scope for a tests-cleanup PR. Follow-up idea, not blocking.
- **`EtlPipelineContractTests<TExtractor, TLoader>`** — only 2 methods, complementary rather than duplicative. Can be added later without deleting anything.
- **`AllocationBudgetContractTests`, `DisposableStageContractTests`, `Idempotent*ContractTests`, `RetryContractTests`, `CancellationContractTests`** — all opt-in for capabilities DbClient doesn't implement or that are already covered by the base classes' contract tests.

## Base-class \"duplicates\" that survived verification

Initial punch list flagged `DbExtractorTests.ExtractAsync_returns_all_rows`, `DbLoaderTests.LoadAsync_inserts_all_records`, etc as base-contract duplicates. Deeper look showed the base contracts (`ExtractorBaseContractTests` / `LoaderBaseContractTests`) validate the async-enumerable contract but do NOT check end-to-end SQL side effects. Repo tests that assert `SELECT COUNT(*)`/row values after a load/extract cover a strictly different aspect (Dapper column-attribute mapping, real SQL execution) and stay.

## Test plan

- [x] `dotnet build -c Release` clean across all 13 TFMs (net462…net10).
- [x] 294/294 tests pass on net10.0.
- [ ] CI multi-TFM matrix — needs #292 to be non-draft (waiting on Abstractions 0.20 + TestKit 0.13 hitting public NuGet 2026-07-29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)