### PR TITLE
feat(dbextractor): wire ErrorPolicy through per-row extraction

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -620,28 +620,82 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
             long rowIndex = 0;
 
-            await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
+            // The Dapper stream is enumerated with a manual MoveNextAsync loop so
+            // per-row failures (a mapper throw on a bad column, an unexpected null
+            // hitting a non-nullable property) can be routed through the base
+            // class's ErrorPolicy pipeline. `await foreach` would let the loop's
+            // try/catch scope only cover the body, not the enumerator's own
+            // MoveNextAsync — a bad-row exception thrown by Dapper's materialiser
+            // would then bypass the policy entirely.
+            //
+            // On ItemErrorAction.Skip, HandleItemError already increments the
+            // skipped-items counter and returns false to indicate "swallow and
+            // continue"; on Abort it returns true and we rethrow with the
+            // original stack via ExceptionDispatchInfo.
+            var enumerator = _connection
+                .QueryUnbufferedAsync<TRecord>(commandText, param, _transaction, CommandTimeoutSeconds, CommandType)
+                .GetAsyncEnumerator(token);
+            try
             {
-                token.ThrowIfCancellationRequested();
-                rowIndex++;
-
-                if (rowIndex <= SkipItemCount)
+                while (true)
                 {
-                    IncrementCurrentSkippedItemCount();
-                    LogDebugRowSkipped(rowIndex);
-                    continue;
-                }
+                    token.ThrowIfCancellationRequested();
 
-                if (CurrentItemCount >= MaximumItemCount)
-                {
-                    LogDebugMaxReached();
-                    LogExtractionCompleted();
-                    yield break;
-                }
+                    TRecord record;
+                    try
+                    {
+                        if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                        {
+                            break;
+                        }
+                        record = enumerator.Current;
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        rowIndex++;
+                        var action = HandleItemError
+                        (
+                            new ItemErrorContext
+                            (
+                                rowIndex,
+                                ex,
+                                rawContent: null
+                            )
+                        );
+                        if (action == ItemErrorAction.Abort)
+                        {
+                            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+                        }
+                        // ItemErrorAction.Skip — HandleItemError already incremented
+                        // the error-item counter on the base. Log and continue.
+                        LogDebugRowErrorSkipped(rowIndex, ex);
+                        continue;
+                    }
 
-                LogDebugRowExtracted(rowIndex);
-                IncrementCurrentItemCount();
-                yield return record;
+                    rowIndex++;
+
+                    if (rowIndex <= SkipItemCount)
+                    {
+                        IncrementCurrentSkippedItemCount();
+                        LogDebugRowSkipped(rowIndex);
+                        continue;
+                    }
+
+                    if (CurrentItemCount >= MaximumItemCount)
+                    {
+                        LogDebugMaxReached();
+                        LogExtractionCompleted();
+                        yield break;
+                    }
+
+                    LogDebugRowExtracted(rowIndex);
+                    IncrementCurrentItemCount();
+                    yield return record;
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
             }
 
             LogExtractionCompleted();
@@ -848,6 +902,22 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 "Extracted row {RowIndex} (item #{ItemCount})",
                 rowIndex,
                 CurrentItemCount + 1
+            );
+        }
+    }
+
+
+
+    private void LogDebugRowErrorSkipped(long rowIndex, Exception exception)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug
+            (
+                exception,
+                "Row {RowIndex} skipped by ErrorPolicy: {ExceptionMessage}",
+                rowIndex,
+                exception.Message
             );
         }
     }


### PR DESCRIPTION
## Summary

Stacked on **#292** (Abstractions/TestKit 0.22 bump). Wires the new init-only `ErrorPolicy` property into `DbExtractor<TRecord>.ExtractWorkerAsync` so a consumer can now do:

\`\`\`csharp
using Wolfgang.Etl.ErrorPolicies;

var extractor = new DbExtractor<Order>(conn, sql)
{
    ErrorPolicy = ItemErrorPolicy.SkipAndLog(logger)
    // or .Skip / .Abort / .SkipAndDeadLetter(deadLetters) / .SkipDeadLetterAndLog(...)
};
var good = await extractor.ExtractAsync().ToListAsync();
\`\`\`

## What changed

`ExtractWorkerAsync` — retired the \`await foreach\` sugar over Dapper's stream in favour of a manual \`GetAsyncEnumerator\` + \`while (true)\` loop. Reason: \`await foreach\`'s try/catch would only scope the body, but the failure mode we care about (Dapper's mapper throwing on a bad column, or a null hitting a non-nullable prop) is raised **inside MoveNextAsync itself**. Sugar would bypass ErrorPolicy entirely.

The catch:
- **`ItemErrorAction.Abort`** *(default when no policy)*: rethrow via `ExceptionDispatchInfo.Capture(ex).Throw()` — preserves the original stack.
- **`ItemErrorAction.Skip`**: base already ticked the error-item counter; we log at Debug and continue.
- **`OperationCanceledException`** is exempted via a \`when\` guard — cancellation must never be swallowed by a policy.

## Deferred / follow-ups

- **DbLoader wire-up** — the batching + auto-transaction paths make Skip-vs-Abort non-trivial (does Skip drop the item and continue the batch? split the batch? roll back the chunk?). Split into its own PR + design discussion.

## Test plan

- [x] Local: \`dotnet build -c Release -f net10.0\` — 0 warnings, 0 errors.
- [x] Local: \`dotnet test -c Release -f net10.0\` — 291 passed / 0 failed. (Happy path unchanged; ErrorPolicy defaults to Abort so pre-existing behavior is preserved bit-for-bit.)
- [ ] **Skip-path coverage** — drafted below, needs review before commit per project's test-code-change rule.

## Drafted test — needs approval before commit

Would append this near the end of \`tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs\`. Uses a Dapper mapper throw (unmapped required column) to force a per-row failure.

\`\`\`csharp
[Fact]
public async Task ExtractAsync_when_ErrorPolicy_is_Skip_swallows_bad_row_and_continues()
{
    // Arrange: two rows where the second one throws a mapper exception because
    // FirstName is null but the record type declares it non-nullable.
    await using var conn = new SqliteConnection(\"DataSource=:memory:\");
    await conn.OpenAsync();
    await using (var seed = conn.CreateCommand())
    {
        seed.CommandText = \"CREATE TABLE People (FirstName TEXT); \" +
                           \"INSERT INTO People VALUES ('Ada'), (NULL);\";
        await seed.ExecuteNonQueryAsync();
    }

    var sut = new DbExtractor<PersonRequired>(conn, \"SELECT FirstName FROM People\")
    {
        ErrorPolicy = ItemErrorPolicy.Skip
    };

    // Act
    var results = await sut.ExtractAsync().ToListAsync();

    // Assert: only the good row survives; the bad row bumped the error-item counter.
    Assert.Single(results);
    Assert.Equal(\"Ada\", results[0].FirstName);
    Assert.Equal(1, sut.GetProgressReport().CurrentSkippedItemCount);
}

private sealed record PersonRequired
{
    public string FirstName { get; init; } = string.Empty;
}
\`\`\`

**Approve** with a \"yes\" reply on the PR and I'll add it in a second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)