### PR TITLE
docs(changelog): correct v0.7.0 release date to actual publish date (2026-08-08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.7.0] - 2026-07-20
+## [0.7.0] - 2026-08-08
 
 Additive release. New runtime schema-validation type, opt-in
 extractor/loader property that wires it in, `[DbKey]` attribute + full


### PR DESCRIPTION
## Summary

The CHANGELOG entry for v0.7.0 was placeholder-dated \`2026-07-20\` (when the version-bump PR was drafted) but the actual NuGet publish landed **2026-08-08 12:36 UTC** after a bumpy release-day sequence:

1. Initial \`release.yaml\` run failed on ApiCompat's XML parser (\`compat-suppressions.txt\` was still plain-text format).
2. Hotfix [#307](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/307) converted the suppressions file to valid XML.
3. Re-fired \`release.yaml\` on the moved \`v0.7.0\` tag — successful publish at 12:36Z.

## Change

One-line edit — \`## [0.7.0] - 2026-07-20\` → \`## [0.7.0] - 2026-08-08\`.

## Why it matters

The CHANGELOG is the machine-readable release history other tooling (NuGet consumers, docfx version pages, drafters of release notes for downstream libs) reads. Wrong dates degrade it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)