### PR TITLE
chore(release): prep v0.7.1 (docs/CI-only patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.7.1] - 2026-08-09
+
+Docs/CI-only patch — no source or public API changes.
+
+### Changed
+
+- CI: bumped the `github-actions` dependency group (checkout, setup-dotnet,
+  upload-artifact, paths-filter, attest-build-provenance,
+  action-gh-release, scorecard-action, zizmor-action) to their latest
+  pinned SHAs (#306).
+- README: corrected the Supported Frameworks TFM list to match the
+  csproj's actual multi-targeting (#288).
+- README: added the canonical publication badge set (nuget-version,
+  nuget-downloads, wf:pr, wf:release) (#286).
+
+### Fixed
+
+- CHANGELOG: corrected the v0.7.0 entry date to the actual NuGet
+  publish date (#308).
+- Fixed a stale comment describing the version-picker's auto-select
+  behavior in the docfx template (#291).
+
 ## [0.7.0] - 2026-08-08
 
 Additive release. New runtime schema-validation type, opt-in

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -25,7 +25,7 @@
                                   <Version>; set explicitly here so it's
                                   discoverable in a metadata dump.
          ===================================================================== -->
-    <Version>0.7.0</Version>
+    <Version>0.7.1</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>


### PR DESCRIPTION
## Summary
Prep for a PATCH release covering the five docs/CI-only PRs merged directly to `main` since v0.7.0 (#308, #306, #291, #288, #286) — no source or public API changes.

- Bumps `<Version>` 0.7.0 → 0.7.1 in `Wolfgang.Etl.DbClient.csproj`
- Seeds the `CHANGELOG.md` [0.7.1] entry

`AssemblyVersion` stays pinned at `1.0.0.0` per the binding-stability convention — this is a PATCH, no breaking change.

## Test plan
- [x] `dotnet build -c Release` clean, 0 warnings/errors
- [ ] CI green on this PR
- [ ] Merge, then tag `v0.7.1` and cut the GitHub Release to fire `release.yaml`