### PR TITLE
fix(dbloader): correct multi-row insert param-name prefix collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.1] - 2026-08-09
 
-Docs/CI-only patch — no source or public API changes.
+Patch release — one correctness fix, one packaging-safety addition, plus
+docs/CI cleanup. No public API changes.
 
 ### Changed
 
@@ -36,6 +37,14 @@ Docs/CI-only patch — no source or public API changes.
 
 ### Fixed
 
+- **`DbLoader<T>.InsertBatchSize > 1` corrupted SQL when one bound
+  parameter's name was a textual prefix of another** (e.g. `@Total` /
+  `@TotalTax`) — the per-parameter `String.Replace` rewrite matched the
+  shorter name inside the longer one, producing a parameter Dapper
+  never bound and throwing at execution time. The multi-row row
+  template is now rebuilt from pre-scanned parameter spans instead of
+  sequential substring replacement, which also removes the per-row
+  full-template rescans (#279).
 - CHANGELOG: corrected the v0.7.0 entry date to the actual NuGet
   publish date (#308).
 - Fixed a stale comment describing the version-picker's auto-select

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.1] - 2026-08-09
 
-Patch release — one correctness fix, one packaging-safety addition, plus
-docs/CI cleanup. No public API changes.
+Patch release — one correctness fix plus docs/CI cleanup. No public
+API changes.
 
 ### Changed
 

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -793,7 +793,9 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
     )
     {
         var prefix = ExtractInsertPrefix(_commandText, out var template);
-        var paramNames = ExtractTemplateParamNames(template, out var paramSpans);
+        var templateParams = ExtractTemplateParamNames(template);
+        var paramNames = templateParams.Names;
+        var paramSpans = templateParams.Spans;
         var properties = GetMappedProperties(paramNames);
 
         var buffer = new List<TRecord>(_insertBatchSize);
@@ -931,6 +933,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
     /// the leading <c>@</c>. Lets the multi-row flush copy the template by exact
     /// offset instead of substring-matching parameter names against it.
     /// </summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
     private readonly struct ParamSpan : IEquatable<ParamSpan>
     {
         internal ParamSpan(int start, int length)
@@ -972,7 +975,33 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
 
 
-    private static IReadOnlyList<string> ExtractTemplateParamNames(string template, out IReadOnlyList<ParamSpan> spans)
+    /// <summary>
+    /// The parameter names and their token spans scanned from an INSERT row
+    /// template. A class rather than a tuple — net462 doesn't ship
+    /// <c>System.ValueTuple</c> in the base targeting pack and we avoid the
+    /// extra package reference (same convention as <see cref="DbExtractor{TRecord}"/>'s
+    /// paging out-parameters).
+    /// </summary>
+    private sealed class TemplateParams
+    {
+        internal TemplateParams(IReadOnlyList<string> names, IReadOnlyList<ParamSpan> spans)
+        {
+            Names = names;
+            Spans = spans;
+        }
+
+
+
+        internal IReadOnlyList<string> Names { get; }
+
+
+
+        internal IReadOnlyList<ParamSpan> Spans { get; }
+    }
+
+
+
+    private static TemplateParams ExtractTemplateParamNames(string template)
     {
         // `while` rather than `for` — the loop intentionally jumps the cursor past
         // the matched parameter name in one step, which Sonar's S127 flags as
@@ -1001,8 +1030,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
             }
             i = end;
         }
-        spans = spanList;
-        return names;
+        return new TemplateParams(names, spanList);
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -793,7 +793,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
     )
     {
         var prefix = ExtractInsertPrefix(_commandText, out var template);
-        var paramNames = ExtractTemplateParamNames(template);
+        var paramNames = ExtractTemplateParamNames(template, out var paramSpans);
         var properties = GetMappedProperties(paramNames);
 
         var buffer = new List<TRecord>(_insertBatchSize);
@@ -818,14 +818,14 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
             if (buffer.Count >= _insertBatchSize)
             {
-                await FlushMultiRowInsertAsync(prefix, template, paramNames, properties, buffer, transaction, token).ConfigureAwait(false);
+                await FlushMultiRowInsertAsync(prefix, template, paramNames, paramSpans, properties, buffer, transaction, token).ConfigureAwait(false);
                 buffer.Clear();
             }
         }
 
         if (buffer.Count > 0)
         {
-            await FlushMultiRowInsertAsync(prefix, template, paramNames, properties, buffer, transaction, token).ConfigureAwait(false);
+            await FlushMultiRowInsertAsync(prefix, template, paramNames, paramSpans, properties, buffer, transaction, token).ConfigureAwait(false);
         }
     }
 
@@ -836,6 +836,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         string prefix,
         string template,
         IReadOnlyList<string> paramNames,
+        IReadOnlyList<ParamSpan> paramSpans,
         IReadOnlyList<System.Reflection.PropertyInfo> properties,
         List<TRecord> batch,
         DbTransaction? transaction,
@@ -863,15 +864,24 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
                 sb.Append(',');
             }
 
-            var rowTemplate = template;
-            for (var p = 0; p < paramNames.Count; p++)
+            // Rebuild the row directly from the pre-scanned parameter spans instead
+            // of String.Replace-ing "@name" -> "@name_<i>" against the whole template:
+            // Replace does a substring match, so a name that's a textual prefix of
+            // another (e.g. "@Order" inside "@OrderId") gets corrupted mid-rewrite.
+            // Copying by exact span never touches text outside the matched token.
+            var cursor = 0;
+            for (var p = 0; p < paramSpans.Count; p++)
             {
-                var original = "@" + paramNames[p];
-                var suffixed = original + "_" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                rowTemplate = rowTemplate.Replace(original, suffixed);
-                dp.Add(suffixed, properties[p].GetValue(batch[i]));
+                var span = paramSpans[p];
+                sb.Append(template, cursor, span.Start - cursor);
+
+                var paramKey = "@" + paramNames[p] + "_" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                sb.Append(paramKey);
+                dp.Add(paramKey, properties[p].GetValue(batch[i]));
+
+                cursor = span.Start + span.Length;
             }
-            sb.Append(rowTemplate);
+            sb.Append(template, cursor, template.Length - cursor);
         }
 
         await _connection.ExecuteAsync
@@ -916,12 +926,59 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
 
 
-    private static IReadOnlyList<string> ExtractTemplateParamNames(string template)
+    /// <summary>
+    /// A parameter token's <c>@name</c> extent within the row template, including
+    /// the leading <c>@</c>. Lets the multi-row flush copy the template by exact
+    /// offset instead of substring-matching parameter names against it.
+    /// </summary>
+    private readonly struct ParamSpan : IEquatable<ParamSpan>
+    {
+        internal ParamSpan(int start, int length)
+        {
+            Start = start;
+            Length = length;
+        }
+
+
+
+        internal int Start { get; }
+
+
+
+        internal int Length { get; }
+
+
+
+        public bool Equals(ParamSpan other) => Start == other.Start && Length == other.Length;
+
+
+
+        public override bool Equals(object? obj) => obj is ParamSpan other && Equals(other);
+
+
+
+        public override int GetHashCode()
+        {
+#if NETCOREAPP2_1_OR_GREATER || NET5_0_OR_GREATER
+            return HashCode.Combine(Start, Length);
+#else
+            unchecked
+            {
+                return (Start * 397) ^ Length;
+            }
+#endif
+        }
+    }
+
+
+
+    private static IReadOnlyList<string> ExtractTemplateParamNames(string template, out IReadOnlyList<ParamSpan> spans)
     {
         // `while` rather than `for` — the loop intentionally jumps the cursor past
         // the matched parameter name in one step, which Sonar's S127 flags as
         // "loop counter mutated in body" when the cursor is a for-loop variable.
         var names = new List<string>();
+        var spanList = new List<ParamSpan>();
         var i = 0;
         while (i < template.Length)
         {
@@ -930,6 +987,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
                 i++;
                 continue;
             }
+            var tokenStart = i;
             var start = i + 1;
             var end = start;
             while (end < template.Length && (char.IsLetterOrDigit(template[end]) || template[end] == '_'))
@@ -939,9 +997,11 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
             if (end > start)
             {
                 names.Add(template.Substring(start, end - start));
+                spanList.Add(new ParamSpan(tokenStart, end - tokenStart));
             }
             i = end;
         }
+        spans = spanList;
         return names;
     }
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -945,6 +945,61 @@ public class DbLoaderTests
 
 
 
+    [Fact]
+    public async Task LoadAsync_with_InsertBatchSize_when_a_parameter_name_is_a_textual_prefix_of_another_binds_correct_values()
+    {
+        using var conn = TestDb.CreateConnection();
+
+        using (var create = conn.CreateCommand())
+        {
+            create.CommandText = @"
+                CREATE TABLE Orders (
+                    total_amount REAL NOT NULL,
+                    total_tax REAL NOT NULL
+                )";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        // "@Total" is a textual prefix of "@TotalTax" — regression guard for #279,
+        // where per-parameter String.Replace corrupted the row template because
+        // the shorter name's replace pass matched inside the longer one too.
+        var loader = new DbLoader<OrderRecord>
+        (
+            conn,
+            "INSERT INTO Orders (total_amount, total_tax) VALUES (@Total, @TotalTax)"
+        )
+        {
+            InsertBatchSize = 2
+        };
+
+        var records = new[]
+        {
+            new OrderRecord { Total = 100m, TotalTax = 8m },
+            new OrderRecord { Total = 250m, TotalTax = 20m },
+            new OrderRecord { Total = 75m, TotalTax = 6m }
+        };
+
+        await loader.LoadAsync(records.ToAsyncEnumerable());
+
+        using var select = conn.CreateCommand();
+        select.CommandText = "SELECT total_amount, total_tax FROM Orders ORDER BY rowid";
+        using var reader = await select.ExecuteReaderAsync();
+
+        var actual = new List<(decimal Total, decimal Tax)>();
+        while (await reader.ReadAsync())
+        {
+            actual.Add((reader.GetDecimal(0), reader.GetDecimal(1)));
+        }
+
+        Assert.Equal
+        (
+            new[] { (100m, 8m), (250m, 20m), (75m, 6m) },
+            actual
+        );
+    }
+
+
+
     // ------------------------------------------------------------------
     // ManageConnection (#31)
     // ------------------------------------------------------------------

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/OrderRecord.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/OrderRecord.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+// "Total" is a textual prefix of "TotalTax" — used to regression-test the
+// multi-row InsertBatchSize path against param-name collisions (#279).
+[ExcludeFromCodeCoverage]
+public class OrderRecord
+{
+    public decimal Total { get; set; }
+
+
+
+    public decimal TotalTax { get; set; }
+}


### PR DESCRIPTION
## Summary
Fixes #279 — `DbLoader<T>.InsertBatchSize > 1` corrupted the emitted SQL whenever one bound parameter's name was a textual prefix of another (e.g. `@Total` / `@TotalTax`). `FlushMultiRowInsertAsync` suffixed each parameter with a per-name `String.Replace` against the whole row template; `Replace` is a substring match, so the shorter name's replace pass also rewrote it inside the longer name, producing a parameter Dapper never bound. Execution-breaking (`ExecuteAsync` throws), not silent.

- Parameter positions are now pre-scanned once into `ParamSpan`s (start/length) alongside the existing `paramNames` extraction.
- Each row is rebuilt by copying the template by exact offset and splicing in `@name_<i>` at each span — correct by construction, no substring matching against the template at all.
- Also removes the O(rows × cols × templateLength) `Replace`-and-rescan cost that was on the same hot path (the allocation angle #279 also called out).

## Test plan
- [x] New regression test: `LoadAsync_with_InsertBatchSize_when_a_parameter_name_is_a_textual_prefix_of_another_binds_correct_values` (`@Total`/`@TotalTax`, verifies correct per-row values land in the correct columns)
- [x] `dotnet test` — all 94 unit tests pass (net10.0)
- [x] `dotnet build -c Release` — clean across all TFMs, 0 warnings/errors
- [ ] CI green on this PR

Note: this PR's `CHANGELOG.md` edit and #290's touch the same `[0.7.1]` section — expect a conflict on whichever merges second; trivial to resolve.