### PR TITLE
ci(packagevalidation): enable PackageValidation gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.1] - 2026-08-09
 
-Patch release — one correctness fix plus docs/CI cleanup. No public
-API changes.
+Patch release — one correctness fix, one packaging-safety addition,
+plus docs/CI cleanup. No public API changes.
+
+### Added
+
+- **`PackageValidation` gate**, enabled via `EnablePackageValidation` +
+  `PackageValidationBaselineVersion` (pinned to `0.7.0`, the last
+  published version) — now diffs the packed public API surface against
+  the previous release on every pack, catching unintentional
+  binary-breaking changes before they ship (#290).
 
 ### Changed
 

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -43,6 +43,12 @@
     <SignAssembly>False</SignAssembly>
     <PackageTags>ETL;Extract-Transform-Load;ADO.NET;Database;SQL;DbConnection</PackageTags>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <!-- Gate against unintentional binary-breaking changes. Baseline stays pinned
+         to the last version actually PUBLISHED on NuGet — bump it in its own PR
+         once the version being released here is live on the flatcontainer CDN,
+         never to the in-flight version (the pack step downloads the baseline). -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.7.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Fixes #290 — this repo had no `PackageValidation` gate, leaving consumers unprotected against unintentional binary-breaking changes at release time.

- Adds `EnablePackageValidation` + `PackageValidationBaselineVersion` (pinned to `0.7.0`, the last version actually published on NuGet — per fleet convention, bump this only in a post-release PR once the new version is live on the flatcontainer CDN, never before).
- Fleet exemplar: [ETL-Abstractions#302](https://github.com/Chris-Wolfgang/ETL-Abstractions/pull/302).

## Test plan
- [x] `dotnet pack -c Release` — succeeds cleanly, no `CP0002`/`CP0008` findings against the 0.7.0 baseline (confirms no breaking API changes have snuck in since 0.7.0)
- [ ] CI green on this PR

Note: this PR's `CHANGELOG.md` edit and #310's touch the same `[0.7.1]` section — expect a conflict on whichever merges second; trivial to resolve.