### PR TITLE
ci(repro-build): explicit <PathMap> to normalise cross-OS paths (#255)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -118,8 +118,14 @@
       the source path — this makes the explicit intent match the
       implicit behaviour and covers the intermediates the implicit
       normalisation misses.
+
+      Scoped to CI only (matching ContinuousIntegrationBuild's own
+      $(CI) condition above) so local dev builds keep real source
+      paths — rewriting them locally would break IDE step-into/
+      breakpoint source mapping for no reproducibility benefit, since
+      only CI-built artifacts get compared/published.
     -->
-    <PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>
+    <PathMap Condition="'$(CI)' == 'true'">$(MSBuildThisFileDirectory)=/_/</PathMap>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -101,6 +101,25 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+
+    <!--
+      Cross-OS reproducibility (#255):
+      Microsoft.SourceLink.GitHub maps source paths under the repo root to
+      GitHub raw URLs, but doesn't touch OTHER absolute paths the compiler
+      bakes into PDB records — most notably MSBuild-computed obj/bin
+      intermediates. Those paths differ per-OS (`D:\a\Etl-DbClient\…` on
+      Windows vs `/home/runner/work/Etl-DbClient/…` on Linux), so the two
+      OSes emit byte-different PDBs (and therefore byte-different DLLs
+      when the debug directory is embedded).
+
+      `<PathMap>` rewrites the leading source root uniformly to `/_/`
+      across every OS. The `/_/` sentinel is the same one dotnet SDK
+      uses when `ContinuousIntegrationBuild=true` implicitly normalises
+      the source path — this makes the explicit intent match the
+      implicit behaviour and covers the intermediates the implicit
+      normalisation misses.
+    -->
+    <PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
First-hypothesis fix for #255 — the reproducible-build workflow (#252) shows the tree isn't byte-identical across OSes. `Microsoft.SourceLink.GitHub` maps source paths under the repo root but doesn't touch MSBuild-computed obj/bin intermediate paths, which differ per-OS and leak into PDB records.

`<PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>` in `Directory.Build.props` rewrites the source root uniformly across OSes — the same `/_/` sentinel dotnet SDK uses implicitly under `ContinuousIntegrationBuild=true`.

Independent of the Abstractions/TestKit/ErrorPolicies 0.22 stack (#292 and friends) — this is pure build config, no package version dependency.

## Test plan
- [x] `dotnet build -c Release` — clean across all TFMs, 0 warnings/errors
- [ ] Watch `reproducible-build.yaml`'s next run — if cross-OS hashes now match, flip its Compare step from informational to blocking and unblock #155