### PR TITLE
fix(deps): patch SQLitePCLRaw GHSA-2m69-gcr7-jv3q across dev-only projects

### DIFF
--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/Wolfgang.Etl.DbClient.Benchmarks.csproj
@@ -8,17 +8,7 @@
     <!-- Analyzer-rule suppressions for BenchmarkDotNet compatibility now live
          in benchmarks/.editorconfig (curated, one-comment-per-rule). The
          Release-mode TreatWarningsAsErrors gate inherited from
-         Directory.Build.props stays on for every other rule.
-
-         NU1903 (NuGet vulnerability warning) is suppressed for the benchmarks
-         project only — the bundled SQLite native library (SQLitePCLRaw.lib.
-         e_sqlite3) is on GHSA-2m69-gcr7-jv3q and the upstream advisory has no
-         patched version yet (firstPatchedVersion: null at audit time). The
-         benchmark assembly is never published or distributed, so the impact
-         is limited to local + CI bench runs. Re-evaluate when the advisory
-         gets a fix. NU1903 is a NuGet warning, not an analyzer diagnostic,
-         so it must be suppressed here (not in editorconfig). -->
-    <NoWarn>$(NoWarn);NU1903</NoWarn>
+         Directory.Build.props stays on for every other rule. -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,6 +19,11 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- GHSA-2m69-gcr7-jv3q: Microsoft.Data.Sqlite pins a vulnerable
+         SQLitePCLRaw.lib.e_sqlite3 2.1.11 transitively. The 3.x
+         bundle_e_sqlite3/core line pulls patched native lib.e_sqlite3
+         3.50.3 and is API-compatible with the provider contract. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />

--- a/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.AotSmoke/Wolfgang.Etl.DbClient.Example.AotSmoke.csproj
@@ -22,12 +22,7 @@
          informational (see .github/workflows/aot-smoke.yaml comments). -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
 
-    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 (transitive via Microsoft.Data.Sqlite)
-         is on GHSA-2m69-gcr7-jv3q with no patched version. Same treatment as
-         the other example projects. This assembly is never published; impact
-         limited to local + CI runs.
-
-         The rest of this NoWarn list is analyzer noise scoped ONLY to this
+    <!-- This NoWarn list is analyzer noise scoped ONLY to this
          smoke-test example, not the library. The example is a single-file
          Program.cs whose sole purpose is to exercise the AOT publish path —
          the library-level style rules don't add value here and demanding
@@ -46,7 +41,7 @@
          VSTHRD200 — "Async" suffix on methods returning awaitable types.
                    A local helper inside Program.cs isn't part of a
                    consumer API surface. -->
-    <NoWarn>$(NoWarn);NU1903;MA0004;MA0048;MA0051;VSTHRD200</NoWarn>
+    <NoWarn>$(NoWarn);MA0004;MA0048;MA0051;VSTHRD200</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -58,6 +53,8 @@
     <!-- Microsoft.Data.Sqlite for a real DbConnection to hand to the
          extractor / loader — no external service needed. -->
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Wolfgang.Etl.DbClient.Example.AutoSql.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.AutoSql/Wolfgang.Etl.DbClient.Example.AutoSql.csproj
@@ -6,11 +6,6 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 (transitive from Microsoft.Data.Sqlite)
-         is on GHSA-2m69-gcr7-jv3q with no patched version available yet. Same
-         treatment as the test + benchmark projects. Example assembly is never
-         published; impact limited to local + CI runs. -->
-    <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,6 +15,12 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <!-- GHSA-2m69-gcr7-jv3q: Microsoft.Data.Sqlite pins a vulnerable
+         SQLitePCLRaw.lib.e_sqlite3 2.1.11 transitively. The 3.x
+         bundle_e_sqlite3/core line pulls patched native lib.e_sqlite3
+         3.50.3 and is API-compatible with the provider contract. Same
+         treatment across every project that references Microsoft.Data.Sqlite. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Wolfgang.Etl.DbClient.Example.EtlPipeline.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Wolfgang.Etl.DbClient.Example.EtlPipeline.csproj
@@ -6,8 +6,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 same treatment as sister examples. -->
-    <NoWarn>$(NoWarn);MA0002;MA0004;MA0048;VSTHRD200;S3903;NU1903</NoWarn>
+    <NoWarn>$(NoWarn);MA0002;MA0004;MA0048;VSTHRD200;S3903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction/Wolfgang.Etl.DbClient.Example.UpdateWithTransaction.csproj
@@ -6,8 +6,6 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <!-- NU1903: see sister-csproj note in Example.AutoSql. -->
-    <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +15,8 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/examples/Wolfgang.Etl.DbClient.Example/Wolfgang.Etl.DbClient.Example.csproj
+++ b/examples/Wolfgang.Etl.DbClient.Example/Wolfgang.Etl.DbClient.Example.csproj
@@ -6,8 +6,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <!-- NU1903: see sister-csproj note in Example.AutoSql. -->
-    <NoWarn>$(NoWarn);MA0002;MA0004;MA0048;VSTHRD200;S3903;NU1903</NoWarn>
+    <NoWarn>$(NoWarn);MA0002;MA0004;MA0048;VSTHRD200;S3903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/Wolfgang.Etl.DbClient.Tests.Concurrency.csproj
@@ -12,7 +12,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;CA1707;CA1062;CA2007</NoWarn>
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1062;CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,6 +29,8 @@
     <PackageReference Include="Microsoft.Coyote" Version="1.7.11" />
     <PackageReference Include="Microsoft.Coyote.Test" Version="1.7.11" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.DocExamples/Wolfgang.Etl.DbClient.Tests.DocExamples.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.DocExamples/Wolfgang.Etl.DbClient.Tests.DocExamples.csproj
@@ -15,7 +15,7 @@
          (unused-usings on the imports we pre-declare, etc.). Silence the
          analyser-noise class of warnings — this project is purely a
          doc-rot gate and never packaged. -->
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;CA1707;CA1062</NoWarn>
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1062</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Fuzz/Wolfgang.Etl.DbClient.Tests.Fuzz.csproj
@@ -15,7 +15,7 @@
 
     <!-- Fuzz-property assemblies are permitted broader shapes than the
          library-code analyzer stack. -->
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;CA1707;CA1062;CA2007</NoWarn>
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1062;CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -8,14 +8,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 (transitive from Microsoft.Data.Sqlite)
-         is on GHSA-2m69-gcr7-jv3q with no patched version available yet (the
-         upstream advisory has firstPatchedVersion=null). The integration test
-         assembly is never published; impact is limited to local + CI bench
-         runs. Re-evaluate when the advisory has a fix. NU1903 is a NuGet
-         warning, not an analyzer diagnostic, so it must be suppressed in
-         <NoWarn> (not editorconfig). Same treatment as benchmarks/.../*.csproj. -->
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1812;CA2007;NU1903</NoWarn>
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1812;CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -48,7 +41,8 @@
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
+    <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <!-- Explicit Testcontainers base — CockroachDbFixture uses the generic
          ContainerBuilder directly (no dedicated Testcontainers.CockroachDb
          module exists at this version). -->

--- a/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Wolfgang.Etl.DbClient.Tests.Snapshots.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/Wolfgang.Etl.DbClient.Tests.Snapshots.csproj
@@ -11,7 +11,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;CA1707;CA1062</NoWarn>
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1062</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.DbClient.Tests.SourceLink/Wolfgang.Etl.DbClient.Tests.SourceLink.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.SourceLink/Wolfgang.Etl.DbClient.Tests.SourceLink.csproj
@@ -11,7 +11,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;CA1707;CA1062</NoWarn>
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;CA1707;CA1062</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -8,17 +8,20 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 (transitive from Microsoft.Data.Sqlite)
-         is on GHSA-2m69-gcr7-jv3q with no patched version available yet. Same
-         treatment as benchmarks/.../*.csproj and Tests.Integration. Test
-         assembly is never published; impact limited to local + CI runs. -->
+    <!-- SQLitePCLRaw.bundle_e_sqlite3 3.0.3's native SourceGear.sqlite3
+         dependency refuses AnyCPU builds on net471+ (net462/net47 aren't
+         affected — its buildTransitive assets only apply from net471 up).
+         These TFMs only ever build on the Windows CI stage anyway, so a
+         fixed win-x64 RID is safe here. -->
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net471' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481'">win-x64</RuntimeIdentifier>
+    <SelfContained Condition="'$(RuntimeIdentifier)' != ''">false</SelfContained>
     <!-- RS0016 / RS0037: PublicApiAnalyzers fires on members emitted by the
          DbTableGenerator source generator into this test project (the
          [DbTable]-decorated fixtures GeneratedPerson / GeneratedOrder gain
          a public `Insert` const + `Bind` helper). This assembly is never
          packaged — PublicAPI.txt contract doesn't apply. Same justification
          as the SourceGenerator project's local .editorconfig. -->
-    <NoWarn>$(NoWarn);MA0004;S1144;S6966;NU1903;RS0016;RS0037</NoWarn>
+    <NoWarn>$(NoWarn);MA0004;S1144;S6966;RS0016;RS0037</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -120,8 +123,11 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
-    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.10" />
+    <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql.
+         The bundle_e_sqlite3/core line pulls patched native lib.e_sqlite3
+         3.50.3 transitively — don't pin lib.e_sqlite3 directly, that
+         package line never reached 3.50.x itself. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
     <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.9.0" />
   </ItemGroup>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -14,7 +14,7 @@
          These TFMs only ever build on the Windows CI stage anyway, so a
          fixed win-x64 RID is safe here. -->
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net471' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481'">win-x64</RuntimeIdentifier>
-    <SelfContained Condition="'$(RuntimeIdentifier)' != ''">false</SelfContained>
+    <SelfContained Condition="'$(RuntimeIdentifier)' != '' AND '$(TargetFrameworkIdentifier)' == '.NETFramework'">false</SelfContained>
     <!-- RS0016 / RS0037: PublicApiAnalyzers fires on members emitted by the
          DbTableGenerator source generator into this test project (the
          [DbTable]-decorated fixtures GeneratedPerson / GeneratedOrder gain

--- a/tools/GcProfileWorkload/GcProfileWorkload.csproj
+++ b/tools/GcProfileWorkload/GcProfileWorkload.csproj
@@ -13,12 +13,10 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
 
-    <!-- NU1903: SQLitePCLRaw.lib.e_sqlite3 — same treatment as
-         benchmarks / examples.
-         CA2007: This is an .exe workload, not library code — the
+    <!-- CA2007: This is an .exe workload, not library code — the
          ConfigureAwait(false) discipline aimed at avoiding
          deadlocks in sync-over-async callers doesn't apply. -->
-    <NoWarn>$(NoWarn);NU1903;CA2007;MA0004;MA0048;S3903;VSTHRD200</NoWarn>
+    <NoWarn>$(NoWarn);CA2007;MA0004;MA0048;S3903;VSTHRD200</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,6 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
Fixes Dependabot alert #1 — `SQLitePCLRaw.lib.e_sqlite3` (transitive via `Microsoft.Data.Sqlite`) is on GHSA-2m69-gcr7-jv3q (high). No patched 2.1.x exists, so this was previously just `NoWarn`-suppressed per project rather than actually fixed — the alert stayed open.

- Adds `SQLitePCLRaw.bundle_e_sqlite3` **3.0.3** to all 10 projects that reference `Microsoft.Data.Sqlite` (benchmarks, 5 examples, `Tests.Concurrency`, `Tests.Integration`, `Tests.Unit`, `GcProfileWorkload`). The 3.x bundle/core line pulls patched native `lib.e_sqlite3 3.50.3`. None of these ship in the published package — dev/test/tooling only, no consumer-facing change.
- Removed the now-stale `NU1903` suppressions everywhere, including on 4 projects (`Tests.DocExamples`, `Tests.Fuzz`, `Tests.Snapshots`, `Tests.SourceLink`) that only reference the src project transitively and never actually restored the vulnerable package — dead copy-paste suppression.
- `Tests.Unit` needed one more fix: the new native `SourceGear.sqlite3` dependency refuses AnyCPU builds on net471+ (`net462`/`net47` unaffected). Pinned an explicit `win-x64` RuntimeIdentifier for `net471`/`net472`/`net48`/`net481` — safe since .NET Framework TFMs only ever build on the Windows CI stage.

Independent of the Abstractions/TestKit/ErrorPolicies 0.22 stack — dependency-hygiene fix, no package version dependency on that line.

## Test plan
- [x] Full solution `dotnet build -c Release -p:TreatWarningsAsErrors=true` — clean, 0 warnings/errors
- [x] `dotnet test` on `net462`, `net47`, `net472`, `net481`, `net10.0` — all 294 (297 on net10.0) tests pass at runtime, confirming the native SQLite DLL actually loads on every TFM (RID change relocates it from `runtimes/win-x64/native/` to the output root; .NET Framework's native probing finds it fine either way)
- [ ] CI green