### PR TITLE
chore(deps): bump Abstractions to 0.21.0 + TestKit(.Xunit) to 0.14.0

### DIFF
--- a/docfx_project/docs/etl-pipeline.md
+++ b/docfx_project/docs/etl-pipeline.md
@@ -183,7 +183,7 @@ var totalPaid = await EtlPipeline
 
 ```csharp
 var progress = new Progress<EtlPipelineProgress>(p =>
-    Console.WriteLine($"loaded {p.RecordsLoaded}"));
+    Console.WriteLine($"loaded {p.LoadedItemCount}"));
 
 await EtlPipeline
     .Create()

--- a/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
@@ -163,7 +163,7 @@ using (var cmd = live.CreateCommand())
 }
 
 var progress = new Progress<EtlPipelineProgress>(p =>
-    Console.WriteLine($"   ↪ loaded={p.RecordsLoaded}"));
+    Console.WriteLine($"   ↪ loaded={p.LoadedItemCount}"));
 
 await EtlPipeline
     .Create()

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -80,18 +80,18 @@
     prevent NuGet from resolving an older transitive version — no runtime assembly is copied.
   -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.21.0" />
   </ItemGroup>
 
   <!-- Source generator: built alongside the runtime, packed into the same

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Npgsql" Version="9.0.3" />

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -120,16 +120,16 @@
   <!-- Shared dependencies (all TFMs) -->
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql.
          The bundle_e_sqlite3/core line pulls patched native lib.e_sqlite3
          3.50.3 transitively — don't pin lib.e_sqlite3 directly, that
          package line never reached 3.50.x itself. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.9.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.14.0" />
   </ItemGroup>
 
   <!-- Copy native SQLite DLL to output for .NET Framework (no RID-based probing) -->


### PR DESCRIPTION
## Summary
Bumps to the currently-published lines — no Abstractions/TestKit 0.22 exists yet (that stack stays parked on the old #292 branch, blocked). Base for #299/#303/#304's rework, which turned out to need nothing beyond what's already published:

- `Wolfgang.Etl.Abstractions` 0.16.0 → 0.21.0
- `Wolfgang.Etl.TestKit`(.Xunit) 0.9.0 → 0.14.0
- `Microsoft.Extensions.Logging.Abstractions` 10.0.0 → 10.0.10 (cascade, `Wolfgang.Etl.ErrorPolicies` 0.21.0's dependency)
- `Microsoft.Bcl.AsyncInterfaces` 10.0.9 → 10.0.10 (cascade, TestKit 0.14.0's dependency)

Fixes one example-only break: `EtlPipelineProgress.RecordsLoaded` was renamed to `LoadedItemCount` between 0.16.0 and 0.21.0 — updated `Example.EtlPipeline/Program.cs`'s progress-reporting sample.

## Test plan
- [x] `dotnet restore` — clean, no cascade conflicts
- [x] `dotnet build -c Release` — clean across all TFMs, 0 warnings/errors
- [x] `dotnet test` (net10.0) — 311/311 pass
- [ ] CI green on this PR