### PR TITLE
tests: adopt SupportsDryRunContractTests + prune 2 subsumed property tests

### DIFF
--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderSupportsDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderSupportsDryRunContractTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+/// <summary>
+/// Adopts <see cref="SupportsDryRunContractTests{TSut}"/> for
+/// <see cref="DbLoader{TRecord}"/>'s <c>ISupportDryRun</c> implementation.
+/// Adds the property-contract tests + the two behavioural tests
+/// (side effect suppressed on dry-run, side effect performed when off)
+/// without duplicating what <see cref="DbLoaderTests"/> already covers.
+/// </summary>
+/// <remarks>
+/// The pre-existing <c>DbLoaderTests.LoadAsync_when_IsDryRun_is_true_does_not_write_to_database</c>
+/// is retained deliberately — it exercises the batched
+/// <see cref="DbLoader{TRecord}.InsertBatchSize"/> code path, which the
+/// contract tests don't reach (the contract's default per-row path goes
+/// through the loader base's <c>LoadWorkerAsync</c>). Property tests
+/// <c>IsDryRun_defaults_to_false</c> + <c>IsDryRun_set_and_get_roundtrips</c>
+/// in DbLoaderTests ARE subsumed — see the follow-up commit that
+/// prunes them.
+/// </remarks>
+public sealed class DbLoaderSupportsDryRunContractTests
+    : SupportsDryRunContractTests<DbLoader<DryRunContractRecord>>
+{
+    protected override DbLoader<DryRunContractRecord> CreateSut()
+    {
+        var conn = OpenSeededConnection();
+        return new DbLoader<DryRunContractRecord>
+        (
+            conn,
+            "INSERT INTO contract_dryrun (id, name) VALUES (@Id, @Name)"
+        );
+    }
+
+
+
+    protected override async Task<bool> RunAndReportSideEffectAsync(bool isDryRun)
+    {
+        // Each call gets its own SUT + connection so the "IsDryRun=false → rows
+        // land" and "IsDryRun=true → rows don't land" scenarios can't leak
+        // state through a shared in-memory database.
+        using var conn = OpenSeededConnection();
+
+        var sut = new DbLoader<DryRunContractRecord>
+        (
+            conn,
+            "INSERT INTO contract_dryrun (id, name) VALUES (@Id, @Name)"
+        )
+        {
+            IsDryRun = isDryRun,
+        };
+
+        await sut.LoadAsync(GenerateAsync(rowCount: 3));
+
+        // Side effect = at least one row landed in the destination table.
+        using var count = conn.CreateCommand();
+        count.CommandText = "SELECT COUNT(*) FROM contract_dryrun;";
+        var landed = Convert.ToInt64(await count.ExecuteScalarAsync(), System.Globalization.CultureInfo.InvariantCulture);
+        return landed > 0;
+    }
+
+
+
+    private static SqliteConnection OpenSeededConnection()
+    {
+        var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using var create = conn.CreateCommand();
+        create.CommandText = "CREATE TABLE contract_dryrun (id INTEGER PRIMARY KEY, name TEXT NOT NULL);";
+        create.ExecuteNonQuery();
+        return conn;
+    }
+
+
+
+    private static async IAsyncEnumerable<DryRunContractRecord> GenerateAsync(int rowCount)
+    {
+        for (var i = 1; i <= rowCount; i++)
+        {
+            yield return new DryRunContractRecord { Id = i, Name = "contract-" + i };
+            await Task.Yield();
+        }
+    }
+}
+
+
+// Test fixture for the SupportsDryRun contract. Kept alongside the test
+// class rather than in a shared file since nothing else in the project
+// needs a dry-run POCO.
+public sealed class DryRunContractRecord
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderSupportsDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderSupportsDryRunContractTests.cs
@@ -20,8 +20,7 @@ namespace Wolfgang.Etl.DbClient.Tests.Unit;
 /// contract tests don't reach (the contract's default per-row path goes
 /// through the loader base's <c>LoadWorkerAsync</c>). Property tests
 /// <c>IsDryRun_defaults_to_false</c> + <c>IsDryRun_set_and_get_roundtrips</c>
-/// in DbLoaderTests ARE subsumed — see the follow-up commit that
-/// prunes them.
+/// in DbLoaderTests ARE subsumed and have been pruned from that file.
 /// </remarks>
 public sealed class DbLoaderSupportsDryRunContractTests
     : SupportsDryRunContractTests<DbLoader<DryRunContractRecord>>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -681,31 +681,13 @@ public class DbLoaderTests
 
     // ------------------------------------------------------------------
     // IsDryRun (#21)
+    //
+    // Property-contract coverage (defaults, roundtrip, set-back-to-false)
+    // is provided by SupportsDryRunContractTests<DbLoader<T>> — see
+    // DbLoaderSupportsDryRunContractTests. Only the batched behavioural
+    // scenario remains here because the contract's default per-row path
+    // doesn't reach the InsertBatchSize code path.
     // ------------------------------------------------------------------
-
-    [Fact]
-    public void IsDryRun_defaults_to_false()
-    {
-        using var conn = TestDb.CreateConnection();
-        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
-
-        Assert.False(loader.IsDryRun);
-    }
-
-
-
-    [Fact]
-    public void IsDryRun_set_and_get_roundtrips()
-    {
-        using var conn = TestDb.CreateConnection();
-        var loader = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
-
-        loader.IsDryRun = true;
-
-        Assert.True(loader.IsDryRun);
-    }
-
-
 
     [Fact]
     public async Task LoadAsync_when_IsDryRun_is_true_does_not_write_to_database()


### PR DESCRIPTION
## Summary
Reapplied from the original #299 (stacked on the blocked Abstractions/TestKit 0.22 branch) onto #320's 0.21.0/0.14.0 line — same content, no source changes beyond that. `SupportsDryRunContractTests<T>` has been available since TestKit ~0.10.0.

Adopts `SupportsDryRunContractTests<DbLoader<T>>`: adds the property-contract tests + the two behavioural side-effect tests without duplicating `DbLoaderTests` coverage. Kept the pre-existing `LoadAsync_when_IsDryRun_is_true_does_not_write_to_database` test — it exercises the batched `InsertBatchSize` path the contract's per-row default doesn't reach. Pruned `IsDryRun_defaults_to_false` + `IsDryRun_set_and_get_roundtrips` from `DbLoaderTests`, now subsumed by the contract base.

## Test plan
- [x] `dotnet build -c Release -f net10.0` — 0 warnings, 0 errors
- [x] `dotnet test` (net10.0) — 314/314 pass
- [ ] CI green on this PR