### PR TITLE
feat(dbextractor): wire ErrorPolicy through per-row extraction

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -627,11 +627,6 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
             // try/catch scope only cover the body, not the enumerator's own
             // MoveNextAsync — a bad-row exception thrown by Dapper's materialiser
             // would then bypass the policy entirely.
-            //
-            // On ItemErrorAction.Skip, HandleItemError already increments the
-            // skipped-items counter and returns false to indicate "swallow and
-            // continue"; on Abort it returns true and we rethrow with the
-            // original stack via ExceptionDispatchInfo.
             var enumerator = _connection
                 .QueryUnbufferedAsync<TRecord>(commandText, param, _transaction, CommandTimeoutSeconds, CommandType)
                 .GetAsyncEnumerator(token);
@@ -650,8 +645,15 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                         }
                         record = enumerator.Current;
                     }
-                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    catch (System.Data.DataException ex)
                     {
+                        // Scoped to DataException — the type Dapper wraps row-materialization
+                        // failures in (e.g. "Error parsing column N") — so ErrorPolicy only ever
+                        // sees per-row failures. A broader `catch (Exception)` here would also
+                        // catch connection-level failures (a dropped connection, a syntax error
+                        // surfacing lazily); those aren't per-row, MoveNextAsync would likely keep
+                        // throwing the same fault on every subsequent call, and routing them
+                        // through ItemErrorAction.Skip would spin the loop instead of terminating.
                         rowIndex++;
                         var action = HandleItemError
                         (

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -620,28 +620,82 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
             long rowIndex = 0;
 
-            await foreach (var record in _connection.QueryUnbufferedAsync<TRecord>(commandText, param, _transaction, CommandTimeoutSeconds, CommandType).ConfigureAwait(false))
+            // The Dapper stream is enumerated with a manual MoveNextAsync loop so
+            // per-row failures (a mapper throw on a bad column, an unexpected null
+            // hitting a non-nullable property) can be routed through the base
+            // class's ErrorPolicy pipeline. `await foreach` would let the loop's
+            // try/catch scope only cover the body, not the enumerator's own
+            // MoveNextAsync — a bad-row exception thrown by Dapper's materialiser
+            // would then bypass the policy entirely.
+            //
+            // On ItemErrorAction.Skip, HandleItemError already increments the
+            // skipped-items counter and returns false to indicate "swallow and
+            // continue"; on Abort it returns true and we rethrow with the
+            // original stack via ExceptionDispatchInfo.
+            var enumerator = _connection
+                .QueryUnbufferedAsync<TRecord>(commandText, param, _transaction, CommandTimeoutSeconds, CommandType)
+                .GetAsyncEnumerator(token);
+            try
             {
-                token.ThrowIfCancellationRequested();
-                rowIndex++;
-
-                if (rowIndex <= SkipItemCount)
+                while (true)
                 {
-                    IncrementCurrentSkippedItemCount();
-                    LogDebugRowSkipped(rowIndex);
-                    continue;
-                }
+                    token.ThrowIfCancellationRequested();
 
-                if (CurrentItemCount >= MaximumItemCount)
-                {
-                    LogDebugMaxReached();
-                    LogExtractionCompleted();
-                    yield break;
-                }
+                    TRecord record;
+                    try
+                    {
+                        if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                        {
+                            break;
+                        }
+                        record = enumerator.Current;
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        rowIndex++;
+                        var action = HandleItemError
+                        (
+                            new ItemErrorContext
+                            (
+                                rowIndex,
+                                ex,
+                                rawContent: null
+                            )
+                        );
+                        if (action == ItemErrorAction.Abort)
+                        {
+                            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+                        }
+                        // ItemErrorAction.Skip — HandleItemError already incremented
+                        // the error-item counter on the base. Log and continue.
+                        LogDebugRowErrorSkipped(rowIndex, ex);
+                        continue;
+                    }
 
-                LogDebugRowExtracted(rowIndex);
-                IncrementCurrentItemCount();
-                yield return record;
+                    rowIndex++;
+
+                    if (rowIndex <= SkipItemCount)
+                    {
+                        IncrementCurrentSkippedItemCount();
+                        LogDebugRowSkipped(rowIndex);
+                        continue;
+                    }
+
+                    if (CurrentItemCount >= MaximumItemCount)
+                    {
+                        LogDebugMaxReached();
+                        LogExtractionCompleted();
+                        yield break;
+                    }
+
+                    LogDebugRowExtracted(rowIndex);
+                    IncrementCurrentItemCount();
+                    yield return record;
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
             }
 
             LogExtractionCompleted();
@@ -848,6 +902,22 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 "Extracted row {RowIndex} (item #{ItemCount})",
                 rowIndex,
                 CurrentItemCount + 1
+            );
+        }
+    }
+
+
+
+    private void LogDebugRowErrorSkipped(long rowIndex, Exception exception)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug
+            (
+                exception,
+                "Row {RowIndex} skipped by ErrorPolicy: {ExceptionMessage}",
+                rowIndex,
+                exception.Message
             );
         }
     }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -1,4 +1,5 @@
 using Dapper;
+using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.ErrorPolicies;
 using Wolfgang.Etl.TestKit.Xunit;
@@ -893,6 +894,35 @@ public class DbExtractorTests
         // No ErrorPolicy set — default is Abort, so pre-existing behavior
         // (the row's exception propagates) is preserved bit-for-bit.
         await Assert.ThrowsAnyAsync<Exception>
+        (
+            async () => await extractor.ExtractAsync().ToListAsync()
+        );
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_ErrorPolicy_is_Skip_still_propagates_non_row_failures()
+    {
+        using var conn = TestDb.CreateConnection();
+        using (var seed = conn.CreateCommand())
+        {
+            seed.CommandText = "CREATE TABLE People (first_name TEXT);";
+            await seed.ExecuteNonQueryAsync();
+        }
+
+        // A bad column name fails at command execution, not row materialization —
+        // SQLite throws its own provider exception (SqliteException), never a
+        // Dapper DataException. ErrorPolicy only ever catches DataException, so
+        // this must propagate even under Skip — routing a connection/execution-level
+        // fault through ItemErrorAction would otherwise spin the read loop instead
+        // of terminating (MoveNextAsync would keep failing the same way forever).
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT nonexistent_column FROM People")
+        {
+            ErrorPolicy = ItemErrorPolicy.Skip
+        };
+
+        await Assert.ThrowsAsync<SqliteException>
         (
             async () => await extractor.ExtractAsync().ToListAsync()
         );

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -1,5 +1,6 @@
 using Dapper;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.ErrorPolicies;
 using Wolfgang.Etl.TestKit.Xunit;
 using Xunit;
 
@@ -833,5 +834,67 @@ public class DbExtractorTests
         // counters — those advance only when ExtractAsync streams rows.
         Assert.Equal(5, count);
         Assert.Equal(0, extractor.CurrentItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // ErrorPolicy
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_when_ErrorPolicy_is_Skip_swallows_bad_row_and_continues()
+    {
+        using var conn = TestDb.CreateConnection();
+        using (var seed = conn.CreateCommand())
+        {
+            // A non-numeric age fails Dapper's conversion to PersonRecord.Age
+            // (int) while materializing that row. A NULL age does NOT
+            // reproduce this — Dapper coerces DBNull to default(int) silently
+            // rather than throwing.
+            seed.CommandText = @"
+                CREATE TABLE People (first_name TEXT, age INTEGER);
+                INSERT INTO People (first_name, age) VALUES ('Ada', 30);
+                INSERT INTO People (first_name, age) VALUES ('Bad', 'oops');";
+            await seed.ExecuteNonQueryAsync();
+        }
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, age AS Age FROM People")
+        {
+            ErrorPolicy = ItemErrorPolicy.Skip
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        // Only the good row survives; the bad row bumped the error-item counter
+        // instead of aborting or landing a half-mapped record.
+        Assert.Single(results);
+        Assert.Equal("Ada", results[0].FirstName);
+        Assert.Equal(1, extractor.CurrentErrorItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_ErrorPolicy_is_default_aborts_on_bad_row()
+    {
+        using var conn = TestDb.CreateConnection();
+        using (var seed = conn.CreateCommand())
+        {
+            seed.CommandText = @"
+                CREATE TABLE People (first_name TEXT, age INTEGER);
+                INSERT INTO People (first_name, age) VALUES ('Ada', 30);
+                INSERT INTO People (first_name, age) VALUES ('Bad', 'oops');";
+            await seed.ExecuteNonQueryAsync();
+        }
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, age AS Age FROM People");
+
+        // No ErrorPolicy set — default is Abort, so pre-existing behavior
+        // (the row's exception propagates) is preserved bit-for-bit.
+        await Assert.ThrowsAnyAsync<Exception>
+        (
+            async () => await extractor.ExtractAsync().ToListAsync()
+        );
     }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -128,6 +128,7 @@
          3.50.3 transitively — don't pin lib.e_sqlite3 directly, that
          package line never reached 3.50.x itself. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="Wolfgang.Etl.ErrorPolicies" Version="0.21.0" />
     <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
     <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.14.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
Reapplied from the original #303 (stacked on the blocked Abstractions/TestKit 0.22 branch) onto #320's 0.21.0/0.14.0 line — only `Wolfgang.Etl.ErrorPolicies` 0.21.0 is needed (`HandleItemError` / `ItemErrorAction` / `ItemErrorContext` landed in Abstractions 0.21.0, `Wolfgang.Etl.ErrorPolicies` shipped lockstep at 0.21.0), already published.

Wires the `ErrorPolicy` property into `DbExtractor<TRecord>.ExtractWorkerAsync`:

```csharp
using Wolfgang.Etl.ErrorPolicies;

var extractor = new DbExtractor<Order>(conn, sql)
{
    ErrorPolicy = ItemErrorPolicy.SkipAndLog(logger)
    // or .Skip / .Abort / .SkipAndDeadLetter(deadLetters) / .SkipDeadLetterAndLog(...)
};
```

Retires the `await foreach` sugar over Dapper's stream in favor of a manual `GetAsyncEnumerator` + `while` loop — `await foreach`'s try/catch only scopes the loop body, but the failure mode this targets (Dapper's mapper throwing on a bad column) is raised inside `MoveNextAsync` itself, which sugar would let bypass `ErrorPolicy` entirely.

- `ItemErrorAction.Abort` (default): rethrow via `ExceptionDispatchInfo.Capture(ex).Throw()`, preserving the stack.
- `ItemErrorAction.Skip`: base already ticked `CurrentErrorItemCount`; log at Debug and continue.
- `OperationCanceledException` is exempted via a `when` guard.

**Deferred**: `DbLoader` wire-up — the batching + auto-transaction paths make Skip-vs-Abort non-trivial. Separate PR + design discussion.

## Test coverage note
The original #303's drafted Skip-path test assumed a `NULL` column value would trigger the Dapper mapper throw — verified that's wrong (Dapper coerces `DBNull` to `default(int)` silently rather than throwing). A non-numeric string in the `int` column is what actually throws; fixed before committing. Added both the Skip-path test and a default-Abort regression test.

## Test plan
- [x] `dotnet build -c Release` — clean across all TFMs, 0 warnings/errors
- [x] `dotnet test` (net10.0) — 316/316 pass
- [x] `dotnet pack -c Release` — clean, no `CP0002`/`CP0008` against the 0.7.0 `PackageValidation` baseline
- [ ] CI green on this PR