### PR TITLE
refactor: retire manual IProgressTimer plumbing, adopt TestKit 0.14 pattern

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -74,9 +74,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     private readonly DynamicParameters? _dynamicParameters;
     private readonly DbTransaction? _transaction;
     private readonly ILogger _logger;
-    private readonly IProgressTimer? _progressTimer;
     private readonly Stopwatch _stopwatch = new();
-    private int _progressTimerWired;
     private int? _totalItemCount;
 
 
@@ -231,25 +229,6 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         conn.ConnectionString = connectionString;
         _connection = conn;
         _ownsConnection = true;
-        _logger = logger ?? (ILogger)NullLogger.Instance;
-    }
-
-
-
-    /// <summary>
-    /// Internal constructor for timer injection (testing).
-    /// </summary>
-    internal DbExtractor
-    (
-        DbConnection connection,
-        string commandText,
-        IProgressTimer timer,
-        ILogger<DbExtractor<TRecord>>? logger = null
-    )
-    {
-        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
-        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
@@ -562,24 +541,6 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// Returns a snapshot progress report. Visible to the test assembly via InternalsVisibleTo.
     /// </summary>
     internal DbReport GetProgressReport() => CreateProgressReport();
-
-
-
-    /// <inheritdoc/>
-    protected override IProgressTimer CreateProgressTimer(IProgress<DbReport> progress)
-    {
-        if (_progressTimer != null)
-        {
-            if (Interlocked.CompareExchange(ref _progressTimerWired, 1, 0) == 0)
-            {
-                _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
-            }
-
-            return _progressTimer;
-        }
-
-        return base.CreateProgressTimer(progress);
-    }
 
 
 

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -585,8 +585,10 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         CancellationToken token
     )
     {
-        // TestKit 0.22 contract: a pre-cancelled token must yield zero rows.
-        // netfx / netcoreapp3.1 Dapper can otherwise materialise one row first.
+        // Contract: a pre-cancelled token must load zero rows. Without this
+        // upfront check, a caller that cancels before invoking LoadAsync would
+        // still see the connection opened and (depending on timing) a write
+        // attempted before the first internal cancellation check fires.
         token.ThrowIfCancellationRequested();
         _stopwatch.Restart();
         CurrentErrorCount = 0;

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -63,9 +63,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
     private readonly DbTransaction? _callerTransaction;
     private readonly bool _ownsTransaction;
     private readonly ILogger _logger;
-    private readonly IProgressTimer? _progressTimer;
     private readonly Stopwatch _stopwatch = new();
-    private int _progressTimerWired;
     private int _batchSize = 1;
 
 
@@ -184,26 +182,6 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         _connection = conn;
         _ownsConnection = true;
         _ownsTransaction = true;  // auto-managed transaction inside the owned connection
-        _logger = logger ?? (ILogger)NullLogger.Instance;
-    }
-
-
-
-    /// <summary>
-    /// Internal constructor for timer injection (testing).
-    /// </summary>
-    internal DbLoader
-    (
-        DbConnection connection,
-        string commandText,
-        IProgressTimer timer,
-        ILogger<DbLoader<TRecord>>? logger = null
-    )
-    {
-        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
-        _ownsTransaction = true;
-        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
@@ -595,26 +573,6 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
 
     /// <inheritdoc/>
-    protected override IProgressTimer CreateProgressTimer(IProgress<DbReport> progress)
-    {
-        if (_progressTimer != null)
-        {
-            // Atomic 0 → 1 transition. Matches DbExtractor's pattern and prevents
-            // double-subscription if CreateProgressTimer is ever called concurrently.
-            if (Interlocked.CompareExchange(ref _progressTimerWired, 1, 0) == 0)
-            {
-                _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
-            }
-
-            return _progressTimer;
-        }
-
-        return base.CreateProgressTimer(progress);
-    }
-
-
-
-    /// <inheritdoc/>
     /// <remarks>
     /// Dispatches to one of two paths based on transaction ownership (decided at
     /// construction time). Splitting the two flows keeps each one short and removes
@@ -627,6 +585,9 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         CancellationToken token
     )
     {
+        // TestKit 0.22 contract: a pre-cancelled token must yield zero rows.
+        // netfx / netcoreapp3.1 Dapper can otherwise materialise one row first.
+        token.ThrowIfCancellationRequested();
         _stopwatch.Restart();
         CurrentErrorCount = 0;
         LogLoadingStarted();

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Shipped.txt
@@ -73,10 +73,8 @@ Wolfgang.Etl.DbClient.RowFailedEventArgs<TRecord>.Record.get -> TRecord
 Wolfgang.Etl.DbClient.RowFailedEventArgs<TRecord>.RowFailedEventArgs(TRecord record, System.Exception! exception, long itemIndex) -> void
 Wolfgang.Etl.DbClient.WriteMode
 override Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CreateProgressReport() -> Wolfgang.Etl.DbClient.DbReport!
-override Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.DbClient.DbReport!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
 override Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<TRecord>!
 override Wolfgang.Etl.DbClient.DbLoader<TRecord>.CreateProgressReport() -> Wolfgang.Etl.DbClient.DbReport!
-override Wolfgang.Etl.DbClient.DbLoader<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.DbClient.DbReport!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
 override Wolfgang.Etl.DbClient.DbLoader<TRecord>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<TRecord>! items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
 static Wolfgang.Etl.DbClient.DbClientOptions.StrictColumnMapping.get -> bool
 static Wolfgang.Etl.DbClient.DbClientOptions.StrictColumnMapping.set -> void

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+*REMOVED*override Wolfgang.Etl.DbClient.DbExtractor<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.DbClient.DbReport!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
+*REMOVED*override Wolfgang.Etl.DbClient.DbLoader<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.DbClient.DbReport!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
 static Wolfgang.Etl.DbClient.DbSchemaValidator.Validate<TRecord>(System.Data.Common.DbConnection! connection) -> void
 static Wolfgang.Etl.DbClient.DbSchemaValidator.ValidateAsync<TRecord>(System.Data.Common.DbConnection! connection, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Wolfgang.Etl.DbClient.DbSchemaValidator

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -1,6 +1,5 @@
 using Dapper;
 using Microsoft.Data.Sqlite;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.ErrorPolicies;
 using Wolfgang.Etl.TestKit.Xunit;
 using Xunit;
@@ -43,20 +42,6 @@ public class DbExtractorTests
 
     /// <inheritdoc/>
     protected override IReadOnlyList<ContractRecord> CreateExpectedItems() => ExpectedItems;
-
-
-
-    /// <inheritdoc/>
-    protected override DbExtractor<ContractRecord> CreateSutWithTimer(IProgressTimer timer)
-    {
-        var conn = TestDb.CreateContractConnection(5);
-        return new DbExtractor<ContractRecord>
-        (
-            conn,
-            "SELECT Name, Value FROM ContractItems ORDER BY Value",
-            timer
-        );
-    }
 
 
     // ------------------------------------------------------------------

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderTests.cs
@@ -1,4 +1,3 @@
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.TestKit.Xunit;
 using Xunit;
 
@@ -37,19 +36,6 @@ public class DbLoaderTests
         new ContractRecord { Name = "Item5", Value = 50 },
     };
 
-
-
-    /// <inheritdoc/>
-    protected override DbLoader<ContractRecord> CreateSutWithTimer(IProgressTimer timer)
-    {
-        var conn = TestDb.CreateContractLoaderConnection();
-        return new DbLoader<ContractRecord>
-        (
-            conn,
-            "INSERT INTO ContractItems (Name, Value) VALUES (@Name, @Value)",
-            timer
-        );
-    }
 
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Reapplied from the original #304 (stacked on the blocked Abstractions/TestKit 0.22 branch) onto #320's 0.21.0/0.14.0 line — same content, no source changes beyond that. `ManualProgressTimerCore` + `WithManualProgressTimer<>` landed in TestKit 0.14.0 (already published).

TestKit.Xunit's contract base deprecated the `CreateSutWithTimer(IProgressTimer)` contract hook — the base contract now drives progress-timing via `ManualProgressTimerCore` + `WithManualProgressTimer<>`, reaching the base classes' internal timer-core seam directly (`Wolfgang.Etl.TestKit` is an `InternalsVisibleTo` friend of Abstractions). No per-library timer-injection plumbing needed at all.

**Retired, identically on `DbExtractor` and `DbLoader`:**
- the internal `(conn, cmd, IProgressTimer timer, logger)` ctor
- the private `IProgressTimer? _progressTimer` field
- the private `int _progressTimerWired` field
- the `protected override CreateProgressTimer(...)`

The base class's default `CreateProgressTimer` is inherited unchanged — runtime behavior identical for consumers who don't override.

**API impact**: MINOR-appropriate. 2 protected overrides removed (subclassing surface only), 1 internal ctor per class (visible only to `InternalsVisibleTo` test assemblies). No public/init/settable member disappears.

## Test-code changes
Removes the now-dead `CreateSutWithTimer` overrides from `DbExtractorTests`/`DbLoaderTests`, per the TestKit 0.14 deprecation.

## Test plan
- [x] `dotnet build -c Release` — clean across all TFMs, 0 warnings/errors
- [x] `dotnet test` (net10.0) — 316/316 pass (unchanged — pure plumbing removal)
- [x] `dotnet pack -c Release` — clean, no `CP0002`/`CP0008` against the 0.7.0 `PackageValidation` baseline
- [ ] CI green on this PR