### PR TITLE
ci: reproducible-build manifest + shadow-testing workflows (protected-only)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1068,6 +1068,55 @@ jobs:
       - name: Zip coverage report
         run: zip -r release-coverage.zip ./release-coverage
 
+      # Reproducible-build manifest (#155). Publishes one JSON per release
+      # containing the sha256 of every .nupkg / .snupkg that shipped in
+      # this release, plus enough metadata (version, commit sha, released-at
+      # timestamp) for a third-party reproducer to look up "what should I
+      # get if I rebuild from source at this tag?" without having to
+      # download the actual package first. The manifest gets attached as
+      # a release asset alongside the packages themselves.
+      #
+      # Consumer-side verification recipe is in `docs/REPRODUCIBLE-BUILD.md`.
+      - name: Write reproducible-build manifest
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: |
+          set -euo pipefail
+          tag="$RELEASE_TAG"
+          sha="$RELEASE_SHA"
+          released_at="$RELEASE_PUBLISHED_AT"
+
+          artifacts_json="["
+          first=1
+          for f in ./nuget-packages/*.nupkg ./nuget-packages/*.snupkg; do
+            [ -f "$f" ] || continue
+            name=$(basename "$f")
+            hash=$(sha256sum "$f" | awk '{print $1}')
+            size=$(stat -c '%s' "$f")
+            if [ "$first" = "1" ]; then first=0; else artifacts_json+=","; fi
+            artifacts_json+=$(printf '\n    {"name": "%s", "sha256": "%s", "size": %d}' "$name" "$hash" "$size")
+          done
+          artifacts_json+="\n  ]"
+
+          {
+            echo '{'
+            echo '  "schemaVersion": 1,'
+            echo "  \"package\": \"Wolfgang.Etl.DbClient\","
+            echo "  \"tag\": \"${tag}\","
+            echo "  \"commitSha\": \"${sha}\","
+            echo "  \"releasedAt\": \"${released_at}\","
+            echo "  \"repository\": \"${GITHUB_REPOSITORY}\","
+            echo "  \"instructions\": \"https://github.com/${GITHUB_REPOSITORY}/blob/${tag}/docs/REPRODUCIBLE-BUILD.md\","
+            printf '  "artifacts": %b\n' "$artifacts_json"
+            echo '}'
+          } > reproducible-build-manifest.json
+
+          echo "=== reproducible-build-manifest.json ==="
+          cat reproducible-build-manifest.json
+
       - name: Attach artifacts to release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         with:
@@ -1076,4 +1125,5 @@ jobs:
             ./nuget-packages/*.nupkg
             ./nuget-packages/*.bom.json
             release-coverage.zip
+            reproducible-build-manifest.json
 

--- a/.github/workflows/shadow-baseline.yaml
+++ b/.github/workflows/shadow-baseline.yaml
@@ -1,0 +1,186 @@
+# Shadow-testing baseline capture — writes per-OS metrics from the Shadow
+# Consumer sample to gh-pages under `dev/shadow/<os>.json` on every push
+# to main. The regression-gate follow-up PR fetches from those JSONs at
+# PR time and fails the run when a metric regresses beyond threshold.
+#
+# Separate from `shadow.yaml` (weekly cron + workflow_dispatch, ad-hoc
+# runs) so the "record the golden" and "watch the trend" workflows have
+# distinct triggers and permissions. This workflow needs `contents:
+# write` for the gh-pages push; shadow.yaml stays least-privilege.
+#
+# Follows the same commit-and-retry-on-non-fast-forward pattern
+# integration-status.yaml uses, since benchmarks.yaml / docfx.yaml /
+# integration-status.yaml can all push to gh-pages concurrently.
+#
+# Refs #130.
+
+name: Shadow baseline → gh-pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/**'
+      - '.github/workflows/shadow-baseline.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read   # least-privilege default; publish job grants write below
+
+concurrency:
+  group: shadow-baseline
+  cancel-in-progress: false
+
+jobs:
+  # ============================================================================
+  # MEASURE: run the sample per OS and upload the metrics JSON as an artifact
+  # ============================================================================
+  measure:
+    name: "Measure baseline (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Detect Shadow Consumer sample
+        id: check
+        shell: bash
+        run: |
+          if [ -f samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Shadow Consumer sample not present — skipping baseline capture."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore + Build sample (Release)
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          dotnet restore samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj
+          dotnet build samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj \
+            --no-restore \
+            --configuration Release
+
+      - name: Run sample + capture tagged metrics
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        env:
+          BASELINE_OS: ${{ matrix.os }}
+          BASELINE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          dotnet run --project samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj \
+            --configuration Release \
+            --no-build \
+            1> out/metrics.json
+
+          # Tag with runner + commit metadata so the regression-gate
+          # follow-up can look up the right baseline record deterministically.
+          jq --arg os "$BASELINE_OS" \
+             --arg sha "$BASELINE_SHA" \
+             --arg capturedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+             '. + {os: $os, sha: $sha, capturedAt: $capturedAt, kind: "baseline"}' \
+             out/metrics.json > "out/${BASELINE_OS}.json"
+          rm out/metrics.json
+          echo "=== out/${BASELINE_OS}.json ==="
+          cat "out/${BASELINE_OS}.json"
+
+      - name: Upload measured metrics
+        if: steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: shadow-baseline-${{ matrix.os }}
+          path: out/
+
+
+  # ============================================================================
+  # PUBLISH: pull all per-OS JSONs into gh-pages under dev/shadow/
+  # ============================================================================
+  publish:
+    name: "Publish baselines to gh-pages"
+    runs-on: ubuntu-latest
+    needs: measure
+    permissions:
+      contents: write   # push metrics JSON to gh-pages
+    # Skip the publish job on the template repo — it doesn't have gh-pages
+    # provisioned. Matches the integration-status.yaml guard.
+    if: always() && github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: gh-pages
+          persist-credentials: false
+
+      - name: Download all baseline artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: _baselines
+          pattern: shadow-baseline-*
+          merge-multiple: true
+
+      - name: Move baselines into dev/shadow/
+        shell: bash
+        run: |
+          mkdir -p dev/shadow
+          if [ -d _baselines ]; then
+            for f in _baselines/*.json; do
+              [ -f "$f" ] || continue
+              cp "$f" "dev/shadow/$(basename "$f")"
+              echo "✓ staged dev/shadow/$(basename "$f")"
+            done
+          else
+            echo "::notice::No baseline artifacts to publish (measure job may have skipped)."
+            exit 0
+          fi
+          ls -la dev/shadow/
+
+      - name: Commit + push baselines
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git add dev/shadow/
+          if git diff --cached --quiet; then
+            echo "No baseline changes to commit"
+            exit 0
+          fi
+          git commit -m "chore(shadow): update baseline metrics for ${GITHUB_SHA::7}"
+
+          # Retry on non-fast-forward — benchmarks.yaml / docfx.yaml /
+          # integration-status.yaml can also push to gh-pages concurrently.
+          # Each writer touches a distinct subdir (dev/shadow vs dev/status
+          # vs dev/bench/<rdbms> vs the docs root), so rebase is always
+          # conflict-free.
+          for attempt in 1 2 3 4 5; do
+            if git push origin gh-pages; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed on attempt $attempt — fetching + rebasing"
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+          done
+
+          echo "::error::Failed to push to gh-pages after 5 attempts"
+          exit 1

--- a/.github/workflows/shadow-regression.yaml
+++ b/.github/workflows/shadow-regression.yaml
@@ -1,0 +1,306 @@
+# Shadow-testing regression gate — closes #130 (final of the stack).
+#
+# Runs the Shadow Consumer sample on PRs touching src/ or samples/, per
+# OS, and compares the resulting metrics against the baseline captured on
+# gh-pages by shadow-baseline.yaml (last recorded on push to main).
+#
+# Fails the workflow when a metric regresses beyond a per-metric threshold
+# (defaults per #130 AC: 20% latency, 50% allocations). Files a
+# `shadow-regression` issue on workflow_dispatch runs — same duplicate-
+# detection pattern as the fuzz-failure workflow (#275): comment on the
+# open one if it exists, otherwise create a new one. On pull_request runs,
+# we don't file an issue (the failing check already surfaces on the PR).
+#
+# Baseline lookup URL:
+#   https://chris-wolfgang.github.io/Etl-DbClient/dev/shadow/<os>.json
+#
+# Refs #130.
+
+name: Shadow regression gate
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/**'
+      - '.github/workflows/shadow-regression.yaml'
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Fail on any regression, even below threshold (for local threshold-tuning)"
+        required: false
+        default: "false"
+        type: string
+
+permissions:
+  contents: read
+  issues: write   # for the auto-issue step on workflow_dispatch failures
+
+concurrency:
+  group: shadow-regression-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: "Regression gate (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Guard so the workflow no-ops if the sample project isn't on
+      # the checked-out ref. Same pattern as shadow.yaml / shadow-baseline.yaml.
+      - name: Detect Shadow Consumer sample
+        id: check
+        shell: bash
+        run: |
+          if [ -f samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Shadow Consumer sample not present — skipping regression gate."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore + Build sample (Release)
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          dotnet restore samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj
+          dotnet build samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj \
+            --no-restore \
+            --configuration Release
+
+      - name: Run sample + capture current metrics
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p reports
+          dotnet run --project samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj \
+            --configuration Release \
+            --no-build \
+            1> reports/current.json \
+            2> reports/shadow.log
+          echo "=== current.json ==="
+          cat reports/current.json
+
+      - name: Fetch baseline from gh-pages
+        id: fetch-baseline
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        env:
+          BASELINE_OS: ${{ matrix.os }}
+        run: |
+          set -euo pipefail
+          url="https://chris-wolfgang.github.io/Etl-DbClient/dev/shadow/${BASELINE_OS}.json"
+          echo "Fetching baseline from ${url}"
+          if curl -fsSL "${url}" -o reports/baseline.json; then
+            echo "baseline_present=true" >> "$GITHUB_OUTPUT"
+            echo "=== baseline.json ==="
+            cat reports/baseline.json
+          else
+            echo "::notice::No baseline recorded on gh-pages yet for ${BASELINE_OS}. The regression gate is a no-op until shadow-baseline.yaml has written one; skip is expected on the first PR."
+            echo "baseline_present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compare metrics + gate
+        if: steps.check.outputs.found == 'true' && steps.fetch-baseline.outputs.baseline_present == 'true'
+        id: compare
+        shell: bash
+        env:
+          STRICT: ${{ inputs.strict || 'false' }}
+        run: |
+          set -euo pipefail
+          # Thresholds: per #130 AC (20% latency, 50% allocations).
+          # gen1/gen2 collections are noisier — allow doubling.
+          # rowsPerSecond is the throughput inverse of elapsedMs; failing
+          # on both would be redundant, so gate ONLY elapsedMs on latency.
+          # windows-latest's pre-installed Python is only on PATH as
+          # `python`, not `python3` — pick whichever exists.
+          PYTHON_BIN=python3
+          command -v python3 >/dev/null 2>&1 || PYTHON_BIN=python
+          "$PYTHON_BIN" - <<'PY'
+          import json, os, sys
+
+          strict = os.environ.get("STRICT", "false").lower() == "true"
+
+          with open("reports/current.json") as f:  cur = json.load(f)
+          with open("reports/baseline.json") as f: base = json.load(f)
+
+          # metric -> (direction, threshold_frac)
+          #   direction: "up" means values > baseline are worse; "down" means values < baseline are worse.
+          #   threshold_frac: allowed delta beyond baseline (0.20 = 20%).
+          rules = {
+              "elapsedMs":         ("up",   0.20),
+              "allocatedBytes":    ("up",   0.50),
+              "bytesPerRow":       ("up",   0.50),
+              "gen0Collections":   ("up",   0.50),
+              "gen1Collections":   ("up",   1.00),
+              "gen2Collections":   ("up",   1.00),
+          }
+
+          rows = []
+          any_regress = False
+          for m, (direction, thresh) in rules.items():
+              b = base.get(m)
+              c = cur.get(m)
+              if b is None or c is None:
+                  rows.append((m, "-", "-", "-", "missing"))
+                  continue
+              # Skip zero-baseline rules for gen1/gen2 (noise on tiny values).
+              if b == 0:
+                  rows.append((m, b, c, "-", "baseline=0 → skipped"))
+                  continue
+              delta = (c - b) / b if direction == "up" else (b - c) / b
+              limit = thresh
+              status = "ok"
+              if delta > limit:
+                  status = f"REGRESS Δ={delta*100:.1f}% (>{limit*100:.0f}%)"
+                  any_regress = True
+              elif strict and delta > 0:
+                  status = f"drift Δ={delta*100:.1f}% (strict)"
+                  any_regress = True
+              rows.append((m, b, c, f"{delta*100:+.1f}%", status))
+
+          print(f"{'metric':<20} {'baseline':>15} {'current':>15} {'delta':>10}  status")
+          print("-" * 78)
+          for m, b, c, d, s in rows:
+              print(f"{m:<20} {str(b):>15} {str(c):>15} {str(d):>10}  {s}")
+
+          if any_regress:
+              print("::error::One or more metrics regressed beyond threshold.")
+              # Emit machine-readable summary for the issue-filing step.
+              with open("reports/regression-summary.txt", "w") as f:
+                  f.write(f"{'metric':<20} {'baseline':>15} {'current':>15} {'delta':>10}  status\n")
+                  f.write("-" * 78 + "\n")
+                  for m, b, c, d, s in rows:
+                      f.write(f"{m:<20} {str(b):>15} {str(c):>15} {str(d):>10}  {s}\n")
+              sys.exit(1)
+          PY
+
+      - name: Emit summary to Step Summary
+        if: always() && steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          {
+            echo "### Shadow regression gate — \`${{ matrix.os }}\`"
+            echo ""
+            if [ -f reports/regression-summary.txt ]; then
+              echo '```'
+              cat reports/regression-summary.txt
+              echo '```'
+            elif [ -f reports/current.json ]; then
+              echo "Current metrics:"
+              echo '```json'
+              cat reports/current.json
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload regression artifacts
+        if: always() && steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: shadow-regression-${{ matrix.os }}
+          path: reports/
+          retention-days: 60
+          if-no-files-found: warn
+
+      # ------------------------------------------------------------------
+      # Auto-issue on regression during workflow_dispatch runs.
+      #
+      # We only file for workflow_dispatch — pull_request failures already
+      # surface on the PR itself, and auto-filing there would spam.
+      # ------------------------------------------------------------------
+      - name: File / comment shadow-regression issue
+        # always() is required here: the "Compare metrics + gate" step
+        # exits 1 on a real regression, and a plain `if:` implicitly ANDs
+        # in success() -- which would already be false once a prior step
+        # failed, skipping this step before steps.compare.outcome even
+        # gets evaluated. Without always(), this step (the whole point of
+        # the workflow) would never fire on the failure path it exists for.
+        if: |
+          always()
+          && steps.check.outputs.found == 'true'
+          && steps.compare.outcome == 'failure'
+          && github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OS: ${{ matrix.os }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          summary=""
+          if [ -f reports/regression-summary.txt ]; then
+            summary=$(cat reports/regression-summary.txt)
+          fi
+
+          existing=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --label shadow-regression \
+            --json number \
+            --limit 1 \
+            --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            echo "Existing shadow-regression issue #$existing — commenting."
+            {
+              echo "Additional regression on a manually-triggered shadow run (\`$OS\`)."
+              echo ""
+              echo "- Run: $RUN_URL"
+              echo "- Artifact: \`shadow-regression-$OS\` on the run above (retention 60 days)"
+              echo ""
+              echo "<details><summary>Comparison table</summary>"
+              echo ""
+              echo '```'
+              printf '%s\n' "$summary"
+              echo '```'
+              echo ""
+              echo "</details>"
+            } > /tmp/shadow-comment.md
+            gh issue comment "$existing" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/shadow-comment.md
+          else
+            echo "No open shadow-regression issue — filing a new one."
+            {
+              echo "The shadow-testing gate detected a regression on \`$OS\`."
+              echo ""
+              echo "- Run: $RUN_URL"
+              echo "- Baseline source: \`https://chris-wolfgang.github.io/Etl-DbClient/dev/shadow/$OS.json\`"
+              echo "- Artifact: \`shadow-regression-$OS\` on the run above (retention 60 days)"
+              echo ""
+              echo "Thresholds are documented in \`.github/workflows/shadow-regression.yaml\` and were set to defaults per #130's AC: 20% latency, 50% allocations, 50% gen0, 100% gen1/gen2 (noisier)."
+              echo ""
+              echo "Close this issue once the regression is either accepted (bump baseline via a manual \`workflow_dispatch\` on shadow-baseline.yaml) or resolved (fix the perf regression). The next workflow_dispatch run that still regresses on the same OS re-opens a fresh one automatically."
+              echo ""
+              echo "<details><summary>Comparison table</summary>"
+              echo ""
+              echo '```'
+              printf '%s\n' "$summary"
+              echo '```'
+              echo ""
+              echo "</details>"
+            } > /tmp/shadow-issue.md
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Shadow regression on $OS — see gate output" \
+              --label shadow-regression \
+              --body-file /tmp/shadow-issue.md
+          fi

--- a/.github/workflows/shadow.yaml
+++ b/.github/workflows/shadow.yaml
@@ -1,0 +1,145 @@
+# Shadow-testing gate for realistic consumer workloads.
+#
+# Runs the sample under `samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/`
+# on a weekly cron + workflow_dispatch, parses the JSON metrics line it
+# writes to stdout, and uploads the raw output as an artifact for
+# post-mortem. Baseline capture on gh-pages + regression gate + auto-issue
+# arrive in follow-up PRs so this workflow can land ahead of the metric
+# thresholds being settled.
+#
+# The Shadow Consumer's scenario is a paged ETL loop against SQLite
+# in-memory — deterministic across runners so the metric deltas rather
+# than the absolute values are what matter. See
+# samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/README.md.
+#
+# Refs #130.
+
+name: Shadow-testing
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Weekly Sunday 08:00 UTC — outside the Stryker (Sunday 06:00) +
+    # gc-profile (Sunday 07:00) window so the three heavy scheduled
+    # jobs don't pile up on the runner pool.
+    - cron: '0 8 * * 0'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shadow-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shadow:
+    name: Shadow consumer (${{ matrix.os }} / net10.0)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # Multi-OS from the start so the baseline captured later has
+        # per-OS numbers. Linux/Windows are the two OSes reproducible-
+        # build already exercises; adding macOS would triple runtime for
+        # marginal signal — deferred to a follow-up if a Mac-specific
+        # regression class emerges.
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Guard so the scheduled Sunday 08:00 UTC run on main no-ops when
+      # the sample project isn't on the checked-out ref. The sample
+      # lives on vNext and hasn't merged to main yet; once it has, this
+      # guard becomes a no-op and the block can be dropped.
+      - name: Detect Shadow Consumer sample
+        id: check
+        shell: bash
+        run: |
+          if [ -f samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Shadow Consumer sample not present on this ref — skipping. Merge vNext to main to enable."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore + Build sample (Release)
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          dotnet restore samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj
+          dotnet build samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj \
+            --no-restore \
+            --configuration Release
+
+      - name: Run shadow consumer + capture metrics
+        # The sample writes human-readable progress to stderr and one
+        # JSON line to stdout at the end. Redirect them separately so we
+        # can persist the metrics line as a first-class artifact (that
+        # the regression-gate follow-up PR consumes) AND the human log
+        # for post-mortem. pwsh (not bash+jq) for the tagging step so it
+        # behaves identically on ubuntu-latest and windows-latest --
+        # this repo has never proven jq is on PATH in windows-latest's
+        # Git Bash, only ubuntu-latest. Context values come in via env:
+        # rather than inline ${{ }} expansion in the script body.
+        if: steps.check.outputs.found == 'true'
+        shell: pwsh
+        env:
+          SHADOW_OS: ${{ matrix.os }}
+          SHADOW_SHA: ${{ github.sha }}
+          SHADOW_REF: ${{ github.ref }}
+          SHADOW_RUN_ID: ${{ github.run_id }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path reports | Out-Null
+
+          dotnet run --project samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Wolfgang.Etl.DbClient.Samples.ShadowConsumer.csproj `
+            --configuration Release `
+            --no-build `
+            1> reports/metrics.json `
+            2> reports/shadow.log
+
+          # Tag the metrics with runner metadata so the follow-up
+          # regression gate can pick the right baseline record.
+          $metrics = Get-Content reports/metrics.json -Raw | ConvertFrom-Json
+          $metrics | Add-Member -NotePropertyName os -NotePropertyValue $env:SHADOW_OS
+          $metrics | Add-Member -NotePropertyName sha -NotePropertyValue $env:SHADOW_SHA
+          $metrics | Add-Member -NotePropertyName ref -NotePropertyValue $env:SHADOW_REF
+          $metrics | Add-Member -NotePropertyName runId -NotePropertyValue $env:SHADOW_RUN_ID
+          $metrics | ConvertTo-Json -Depth 10 | Set-Content reports/metrics.json
+
+          Write-Host "=== shadow.log ==="
+          Get-Content reports/shadow.log
+          Write-Host ""
+          Write-Host "=== metrics.json ==="
+          Get-Content reports/metrics.json
+
+      - name: Emit metrics to Step Summary
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          {
+            echo "### Shadow consumer — \`${{ matrix.os }}\` / net10.0"
+            echo ""
+            echo '```json'
+            cat reports/metrics.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload shadow artifacts
+        if: always() && steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: shadow-${{ matrix.os }}
+          path: reports/
+          retention-days: 60
+          if-no-files-found: warn

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -101,6 +101,31 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+
+    <!--
+      Cross-OS reproducibility (#255):
+      Microsoft.SourceLink.GitHub maps source paths under the repo root to
+      GitHub raw URLs, but doesn't touch OTHER absolute paths the compiler
+      bakes into PDB records — most notably MSBuild-computed obj/bin
+      intermediates. Those paths differ per-OS (`D:\a\Etl-DbClient\…` on
+      Windows vs `/home/runner/work/Etl-DbClient/…` on Linux), so the two
+      OSes emit byte-different PDBs (and therefore byte-different DLLs
+      when the debug directory is embedded).
+
+      `<PathMap>` rewrites the leading source root uniformly to `/_/`
+      across every OS. The `/_/` sentinel is the same one dotnet SDK
+      uses when `ContinuousIntegrationBuild=true` implicitly normalises
+      the source path — this makes the explicit intent match the
+      implicit behaviour and covers the intermediates the implicit
+      normalisation misses.
+
+      Scoped to CI only (matching ContinuousIntegrationBuild's own
+      $(CI) condition above) so local dev builds keep real source
+      paths — rewriting them locally would break IDE step-into/
+      breakpoint source mapping for no reproducibility benefit, since
+      only CI-built artifacts get compared/published.
+    -->
+    <PathMap Condition="'$(CI)' == 'true'">$(MSBuildThisFileDirectory)=/_/</PathMap>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Protected-file split ahead of #319 (vNext → main). Extracts just the files that trip the `Detect .NET Projects` guard so #319 can merge through normal review-thread + status-check enforcement instead of a full-diff admin bypass.

**Protected files touched (one logical change set — all from the same #255/#155/#130 batch that makes up #319):**
- `Directory.Build.props` — `<PathMap>` for cross-OS build reproducibility (#255), CI-only
- `.github/workflows/release.yaml` — writes `reproducible-build-manifest.json` as a release asset (#155)
- `.github/workflows/shadow.yaml`, `shadow-baseline.yaml`, `shadow-regression.yaml` — the shadow-testing gate (#130)

## Expected CI state
- `Detect .NET Projects` ❌ — expected, that's the point of this PR
- Everything else ✅ or SKIPPED (Stage 1/2/3 depend on `detect-projects.outputs.has-projects`)

## Plan
1. Review this diff (5 files, additive — 3 new workflows + a scoped `Directory.Build.props` addition + a new release.yaml step)
2. Admin-bypass merge
3. Merge `main` back into `vNext` — the protected-file delta in #319 vanishes
4. #319 flips to mergeable without bypass

Source: #319.