### PR TITLE
fix(tests): Verify snapshot path resolution breaks under PathMap

### DIFF
--- a/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/SqlSnapshotTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Snapshots/SqlSnapshotTests.cs
@@ -81,13 +81,42 @@ public class SqlSnapshotTests
     // Internal (not public) so xUnit1013 doesn't flag it as an unmarked
     // test method. [ModuleInitializer] works with any accessibility
     // as long as the method is static, returns void, and takes no args.
+    //
+    // Deliberately ignores the `sourceFile` callback parameter (Verify's own
+    // [CallerFilePath] capture) and resolves the project directory from
+    // AppContext.BaseDirectory instead. CI builds set ContinuousIntegrationBuild
+    // + <PathMap> (#255, cross-OS reproducibility), which rewrites embedded
+    // source paths to a fictional `/_/...` root — `sourceFile` would resolve to
+    // that non-existent path in CI, and Directory.CreateDirectory would fail
+    // with UnauthorizedAccessException trying to create `/_` under filesystem
+    // root. AppContext.BaseDirectory reflects the real runtime output
+    // directory and is never rewritten by PathMap (that only touches
+    // compile-time embedded literals).
     [ModuleInitializer]
     internal static void Init() => Verifier.DerivePathInfo(
-        (sourceFile, _, type, method) =>
+        (_, _, type, method) =>
             new PathInfo(
-                directory: Path.Combine(Path.GetDirectoryName(sourceFile) ?? ".", "Snapshots"),
+                directory: Path.Combine(ResolveProjectDirectory(), "Snapshots"),
                 typeName: type.Name,
                 methodName: method.Name));
+
+
+
+    private static string ResolveProjectDirectory()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir != null; dir = dir.Parent)
+        {
+            if (dir.GetFiles("*.csproj").Length > 0)
+            {
+                return dir.FullName;
+            }
+        }
+
+        throw new InvalidOperationException
+        (
+            $"Could not locate the Tests.Snapshots project directory by walking up from '{AppContext.BaseDirectory}'."
+        );
+    }
 
     [Fact]
     public Task Select_orders() => Verifier.Verify(DbCommandBuilder.BuildSelect<OrderRecord>());


### PR DESCRIPTION
## Summary
**Urgent** — this bug is likely already live on `main`, independent of #319. `main` picked up `<PathMap>` (#255) via #324 (the protected-file split), and `Tests.Snapshots`' `Verifier.DerivePathInfo` callback relies on Verify.Xunit's own `[CallerFilePath]` capture (`sourceFile`) to locate its snapshot directory — which PathMap fictionalizes to `/_/...` for cross-OS build reproducibility, causing `UnauthorizedAccessException: Access to the path '/_' is denied` on Linux CI.

Found while investigating an unrelated Stage 1 coverage-gate failure on #319 (whose branch also carries PathMap) — traced the root cause to the shared `PathMap` dependency, not anything specific to #319's own changes.

## Fix
Stop relying on the compile-time-embedded `sourceFile`. Resolve the project directory from `AppContext.BaseDirectory` (walk up until a `.csproj` is found) instead — that reflects the real runtime output location and is never touched by PathMap (which only rewrites compile-time embedded literals).

Same root-cause class as this org's `reference_callerfilepath_ci_deterministic_paths` pattern (different repo, same fix shape).

## Test plan
- [x] Reproduced locally: `dotnet test -p:CI=true` (forces `PathMap` the same way CI's `CI=true` env var does) — failed before the fix, exactly matching the CI stack trace
- [x] Confirmed the fix resolves it: 5/5 `Tests.Snapshots` pass under `-p:CI=true`
- [x] Confirmed normal local (non-CI) usage is unaffected: 5/5 pass without the flag
- [ ] CI green on this PR