### PR TITLE
chore(release): bump PackageValidationBaselineVersion to 0.8.0

### DIFF
--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -48,7 +48,7 @@
          once the version being released here is live on the flatcontainer CDN,
          never to the in-flight version (the pack step downloads the baseline). -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.7.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.8.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Post-release step for v0.8.0 (confirmed live on NuGet). Bumps `PackageValidationBaselineVersion` 0.7.0 → 0.8.0 per the standard timing convention: stays at the last *published* version during a release, bumps only after confirmed live (bumping early fails restore with `NU1102`).

## Test plan
- [x] `dotnet build -c Release` clean across all TFMs
- [x] `dotnet pack -c Release` clean against the new 0.8.0 baseline
- [ ] CI green on this PR