### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.9.0] - 2026-08-13
+
+### Changed
+
+- Adopted **ETL core 0.22.0** — `Wolfgang.Etl.Abstractions` 0.21.0 -> 0.22.0, along with the
+  test-only `Wolfgang.Etl.TestKit` / `Wolfgang.Etl.TestKit.Xunit` references. 0.22.0 is the release in
+  which the TestKit packages were folded into the ETL-Abstractions repository and now build and ship
+  from there. The public API of all four core packages is unchanged.
+- Inherited from Abstractions 0.22.0: the `await foreach` sites in `ExtractorBase` and
+  `TransformerBase` now use `ConfigureAwait(false)`, removing a sync-over-async deadlock risk for
+  consumers on the `net462` and `netstandard2.0` targets that drive the pipeline from a
+  synchronization context. No behavioural change on the modern targets.
+
 ## [0.8.0] - 2026-08-11
 
 MINOR release. Adds per-row error handling on `DbExtractor<T>`, plus

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -91,7 +91,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.21.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.22.0" />
   </ItemGroup>
 
   <!-- Source generator: built alongside the runtime, packed into the same

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -25,7 +25,7 @@
                                   <Version>; set explicitly here so it's
                                   discoverable in a metadata dump.
          ===================================================================== -->
-    <Version>0.8.0</Version>
+    <Version>0.9.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <InformationalVersion>$(Version)</InformationalVersion>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -55,6 +55,20 @@
          DbProviderFixtureBase for the Docker availability probe. Pin explicitly
          so a future Testcontainers update can't silently break compilation. -->
     <PackageReference Include="Docker.DotNet.Enhanced" Version="3.126.1" />
+    <!-- SECURITY PIN, not a feature bump (#331). Testcontainers depends
+         transitively on an SSH.NET carrying the HIGH-severity advisory
+         GHSA-q939-rpr3-3284. NuGet audit surfaces that as NU1903, which is an
+         ERROR here because the repo treats warnings as errors — so it fails the
+         build outright and takes every Integration job (all providers, all
+         TFMs) down with it, including SQLite which needs no container.
+
+         Pinning the transitive dependency forward is the remedy; suppressing
+         NU1903 is not. SSH.NET is only used by Testcontainers to drive a REMOTE
+         Docker daemon over SSH — these tests use a local daemon, so the package
+         is not on any path they exercise.
+
+         Mirrors the same pin in ETL-SqlBulkCopy (#264). -->
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -133,9 +133,9 @@
          3.50.3 transitively — don't pin lib.e_sqlite3 directly, that
          package line never reached 3.50.x itself. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="Wolfgang.Etl.ErrorPolicies" Version="0.21.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.14.0" />
+    <PackageReference Include="Wolfgang.Etl.ErrorPolicies" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.22.0" />
   </ItemGroup>
 
   <!-- Copy native SQLite DLL to output for .NET Framework (no RID-based probing) -->


### PR DESCRIPTION
Release PR: promotes the version bump and the ETL core 0.22.0 uptake from `vNext` to `main`.

## Why this is needed

`release.yaml` builds from the **tag commit**, and its first job validates that the tag version matches a `<Version>` in a `src/` csproj. The version bump landed on `vNext`, so tagging `main` before this merge produced:

```
Release tag 'vX.Y.0' (version 'X.Y.0') does not match any src csproj version. Found: <old>.
```

Nothing was published — `Validate Release Build` fails first and every downstream job (pack, publish, attest) skips. So NuGet is untouched and the version number is still free.

## Order that works

1. Merge this PR (`vNext` -> `main`).
2. Delete the failed Release **and** its tag — the tag currently points at a `main` commit that predates the version bump.
3. Re-create the tag on the new `main` tip and publish the Release; `release.yaml` then validates and publishes.

Re-running the failed workflow without step 2 will not help: the tag object still points at the old commit.
