### PR TITLE
fix: pin SSH.NET forward to clear NU1903 (#331)

### DIFF
--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -55,6 +55,20 @@
          DbProviderFixtureBase for the Docker availability probe. Pin explicitly
          so a future Testcontainers update can't silently break compilation. -->
     <PackageReference Include="Docker.DotNet.Enhanced" Version="3.126.1" />
+    <!-- SECURITY PIN, not a feature bump (#331). Testcontainers depends
+         transitively on an SSH.NET carrying the HIGH-severity advisory
+         GHSA-q939-rpr3-3284. NuGet audit surfaces that as NU1903, which is an
+         ERROR here because the repo treats warnings as errors — so it fails the
+         build outright and takes every Integration job (all providers, all
+         TFMs) down with it, including SQLite which needs no container.
+
+         Pinning the transitive dependency forward is the remedy; suppressing
+         NU1903 is not. SSH.NET is only used by Testcontainers to drive a REMOTE
+         Docker daemon over SSH — these tests use a local daemon, so the package
+         is not on any path they exercise.
+
+         Mirrors the same pin in ETL-SqlBulkCopy (#264). -->
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Unblocks the 0.9.0 release: every Integration job on #333 is failing because the integration test project cannot build.

## Diagnosis

All ten Integration jobs failed — five providers x two TFMs — **including SQLite, which needs no container**. That uniformity is the tell: a build failure, not a database problem.

Testcontainers depends transitively on an SSH.NET carrying HIGH-severity advisory GHSA-q939-rpr3-3284. NuGet audit raises NU1903, and because this repo treats warnings as errors, the project fails to build outright.

Reproduced locally:

```
error NU1903: Warning As Error: Package 'SSH.NET' 2024.2.0 has a known high severity vulnerability
```

**Not caused by the ETL core 0.22.0 uptake.** This is #331, which became blocking once the advisory landed — the gated workflow last passed on 2026-08-11, before that.

## Fix

Pin the transitive dependency forward to SSH.NET 2026.0.0. Suppressing NU1903 is not the remedy, and there is no upstream Testcontainers release that takes a patched SSH.NET.

SSH.NET is only used by Testcontainers to drive a **remote** Docker daemon over SSH; these tests use a local daemon, so it is not on any path they exercise. Mirrors the identical pin in ETL-SqlBulkCopy#264.

## Verification

- Integration test project: Release build **0 warnings / 0 errors** (previously failed).
- Full solution: `dotnet build -c Release` **0 warnings / 0 errors** (previously failed at solution scope).

Closes #331