### PR TITLE
chore(release): advance PackageValidation baseline to 0.9.0

### DIFF
--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -48,7 +48,7 @@
          once the version being released here is live on the flatcontainer CDN,
          never to the in-flight version (the pack step downloads the baseline). -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.8.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.9.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Post-release chore following the 0.9.0 release.

`PackageValidationBaselineVersion` tracks the **last published** version and is deliberately left alone during release prep — advancing it early would validate the package against itself and silently disable the ABI gate for that release.

0.9.0 is now live on nuget.org, so it becomes the baseline for the next release. Left at 0.8.0, the next release would have been validated against a two-versions-back baseline, weakening the gate without failing anything visibly.

## Verification

`dotnet pack -c Release` succeeds with PackageValidation green against the new 0.9.0 baseline — no CP-series errors. That is the meaningful check, since PackageValidation downloads the published 0.9.0 package from nuget.org and compares the built assembly against it.

One line changed.