### PR TITLE
Gate PublicApiAnalyzers on Exists('PublicAPI.*.txt') - parity with repo-template@623211a

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -73,7 +73,7 @@
          Library projects under src/ should opt in; test / example /
          benchmark projects should not. Per-repo enablement is tracked as a
          follow-up maintenance issue. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" Condition="Exists('PublicAPI.Shipped.txt') or Exists('PublicAPI.Unshipped.txt')">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Backport of Chris-Wolfgang/repo-template@623211a to this repo - adds `Condition="Exists(...)"` to the `Microsoft.CodeAnalysis.PublicApiAnalyzers` `PackageReference` in `Directory.Build.props` so the analyzer only loads for projects that opt in by committing `PublicAPI.Shipped.txt` or `PublicAPI.Unshipped.txt`.

**Why this matters**: without the Condition, the analyzer loads in every project (src + tests + benchmarks + examples + samples) and emits `RS0016` / `RS0037` / `RS0036` for every public member in projects that don't track PublicAPI, flooding InspectCode with hundreds of false positives per repo. Measured on `Chris-Wolfgang/ETL-Json` before the same fix (PR #271): **524 RS0016 / RS0037 / RS0036 alerts on test / benchmark / example projects**, all silenced by this one-line change.

**Zero behavior change** for projects that already track PublicAPI (i.e., every `src/` project in this repo). The analyzer still loads there and enforces surface-tracking as before.

## Test plan

- [ ] CI confirms build stays green
- [ ] Fresh InspectCode scan on `main` after merge - RS0016 / RS0037 / RS0036 count on non-src projects should drop to zero

Refs Chris-Wolfgang/ETL-Json#271 (same fix landed there yesterday).