### PR TITLE
security(scorecard): tighten top-level permissions in 3 workflows

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -54,6 +54,11 @@ on:
       - ".github/workflows/aot-smoke.yaml"
   workflow_dispatch:
 
+# Least-privilege default at the top level; individual jobs elevate
+# only if they need more. Satisfies Scorecard's TokenPermissionsID rule
+# which flags a missing top-level permissions block.
+permissions: read-all
+
 jobs:
   aot-smoke:
     name: PublishAot + PublishTrimmed

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -34,14 +34,19 @@ on:
     - cron: '37 5 * * 3'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write   # required to upload SARIF to Code Scanning
+# Least-privilege default at the top level; the `semgrep` job below
+# elevates `security-events: write` locally for its SARIF upload.
+# Satisfies Scorecard's TokenPermissionsID rule which flags top-level
+# `security-events: write`.
+permissions: read-all
 
 jobs:
   semgrep:
     name: Semgrep scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # required to upload SARIF to Code Scanning
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -40,6 +40,12 @@ on:
   # Manual trigger for full re-scan (e.g. after tightening the config).
   workflow_dispatch:
 
+# Least-privilege default at the top level; the `zizmor` job elevates
+# `security-events: write` locally for its SARIF upload. Satisfies
+# Scorecard's TokenPermissionsID rule which flags a missing top-level
+# permissions block.
+permissions: read-all
+
 jobs:
   zizmor:
     name: zizmor


### PR DESCRIPTION
## Summary

Second of a 5-PR stack against umbrella #328. **Stacked on #339** — merge that one first.

Clears **3 of the 10** Scorecard `TokenPermissionsID` alerts by adding top-level `permissions: read-all` to workflows that had no top-level block, or by moving broad top-level scope down to the job that needs it.

### Fixed
| Workflow | Alert (line) | Fix |
|---|---|---|
| `aot-smoke.yaml` | :1 no topLevel permission defined | added top-level `permissions: read-all` |
| `workflow-security.yaml` | :1 no topLevel permission defined | added top-level `permissions: read-all` |
| `semgrep.yaml` | :37 topLevel `security-events: write` | moved write to `semgrep` job; top-level now `read-all` |

### Deferred to PR-3 (SARIF filter)
4 alerts on job-level `contents: write` that genuinely need the write — those jobs push to gh-pages or attach GitHub Release assets:
- `release.yaml:1013` (trigger-docs → docfx)
- `release.yaml:1054` (update-release-artifacts)
- `docfx.yaml:59` (build-and-deploy)
- `shadow-baseline.yaml:120` (publish)

Scorecard's rule flags any job-level `contents: write` regardless of whether it's justified, so per `reference_scorecard_dismissal_not_durable` (dismissing via UI decays across weekly re-runs) the durable fix is to filter these findings from the SARIF at upload time.

### PR-1 (#339) already handled
- `benchmarks.yaml:18/19` (top-level contents/deployments write → job-level)
- `integration-status.yaml:23` (top-level contents write → publish-status job only)

## Test plan
- [ ] `Workflow security audit` (zizmor + actionlint) green on this PR.
- [ ] `Semgrep SAST` still succeeds — the job-level permission-scoping doesn't drop `security-events: write` on the SARIF upload step.
- [ ] `AOT + trim smoke` green on this PR.
- [ ] After merging PRs #339 + this + PR-3, verify open TokenPermissions alerts on main:
  ```
  gh api "repos/Chris-Wolfgang/Etl-DbClient/code-scanning/alerts?state=open&tool_name=Scorecard" --jq '[.[] | select(.rule.id=="TokenPermissionsID")] | length'  # expect 0
  ```

Refs #328.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>