### PR TITLE
security(inspectcode): extend .DotSettings noise floor with 4 rules (26 alerts)

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -54,6 +54,11 @@ on:
       - ".github/workflows/aot-smoke.yaml"
   workflow_dispatch:
 
+# Least-privilege default at the top level; individual jobs elevate
+# only if they need more. Satisfies Scorecard's TokenPermissionsID rule
+# which flags a missing top-level permissions block.
+permissions: read-all
+
 jobs:
   aot-smoke:
     name: PublishAot + PublishTrimmed

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -14,9 +14,13 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write    # benchmark-action pushes commits to gh-pages
-  deployments: write # benchmark-action records a deployment
+# Top-level default is read-only; the five per-RDBMS jobs below elevate
+# to `contents: write` + `deployments: write` locally because each one
+# uses benchmark-action/github-action-benchmark to commit to gh-pages
+# and record a deployment. Scorecard's TokenPermissionsID rule requires
+# top-level to be no more than read; the elevation belongs on the jobs
+# that actually push.
+permissions: read-all
 
 concurrency:
   group: benchmarks-${{ github.ref }}
@@ -36,6 +40,9 @@ jobs:
   benchmark-sqlite:
     name: "Benchmarks / sqlite"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -73,6 +80,9 @@ jobs:
     name: "Benchmarks / sqlserver"
     runs-on: ubuntu-latest
     needs: benchmark-sqlite
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2022-latest
@@ -124,6 +134,9 @@ jobs:
     name: "Benchmarks / postgres"
     runs-on: ubuntu-latest
     needs: benchmark-sqlserver
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     services:
       postgres:
         image: postgres:16-alpine
@@ -175,6 +188,9 @@ jobs:
     name: "Benchmarks / mysql"
     runs-on: ubuntu-latest
     needs: benchmark-postgres
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     services:
       mysql:
         image: mysql:8.0
@@ -228,6 +244,9 @@ jobs:
     name: "Benchmarks / mariadb"
     runs-on: ubuntu-latest
     needs: benchmark-mysql
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     services:
       mariadb:
         image: mariadb:11.4.4

--- a/.github/workflows/integration-status.yaml
+++ b/.github/workflows/integration-status.yaml
@@ -19,9 +19,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write    # write per-RDBMS status JSONs to gh-pages
-  pull-requests: read
+# Top-level default is read-only; only `publish-status` elevates to
+# `contents: write` (it commits the per-RDBMS status JSONs to gh-pages).
+# `test-matrix` runs `dotnet test` and uploads artifacts — read-only is
+# sufficient. Scorecard's TokenPermissionsID rule wants top-level to be
+# no more than read.
+permissions: read-all
 
 concurrency:
   # Serialize against ourselves so two pushes to main never race the
@@ -135,6 +138,9 @@ jobs:
     needs: test-matrix
     # Run even when some cells failed — we still want fresh badge state.
     if: always() && github.repository != 'Chris-Wolfgang/repo-template'
+    permissions:
+      contents: write     # write per-RDBMS status JSONs to gh-pages
+      pull-requests: read
 
     steps:
       - name: Checkout gh-pages

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -55,6 +55,69 @@ jobs:
           # in README.md resolves. Requires the repo to be public (this repo is).
           publish_results: true
 
+      # Filter known-noise findings BEFORE upload. Dismissing individual
+      # alerts via `gh api ... code-scanning/alerts/N` decays across the
+      # weekly re-run because the SARIF fingerprint drifts — the same
+      # finding re-appears as a new alert-id. Filtering at the SARIF layer
+      # is the durable fix.
+      #
+      # Filter policy:
+      #   - Drop ENTIRE rules whose findings cannot be resolved for this
+      #     repo:
+      #       * FuzzingID              — Scorecard misses SharpFuzz
+      #         (fuzz.yaml exists but the detector recognizes only a
+      #         short list of fuzzing tools).
+      #       * CIIBestPracticesID     — no OpenSSF badge; policy call
+      #         until the maintainer opts into the CII questionnaire.
+      #       * CodeReviewID           — solo-maintainer repo; PRs get
+      #         merged after passing CI + optional Copilot review.
+      #         Enforcing "N approved reviewers" isn't a viable policy.
+      #       * PinnedDependenciesID   — flags every `dotnet` /`pip` /
+      #         `bash download-then-run` invocation as "not pinned by
+      #         hash". `dotnet` pins via SDK version (setup-dotnet); pip
+      #         pins are handled inside individual workflows; downloads
+      #         are pinned by SHA where practical. Not fixable.
+      #       * BranchProtectionID     — Chris uses org-level rulesets
+      #         (not classic branch protection); Scorecard's detector
+      #         doesn't fully cover rulesets.
+      #
+      #   - Drop TokenPermissionsID findings at specific (file, line)
+      #     tuples where the job GENUINELY needs `contents: write`:
+      #       * release.yaml:1013   — trigger-docs → docfx (gh-pages push)
+      #       * release.yaml:1054   — update-release-artifacts (attach)
+      #       * docfx.yaml:59       — build-and-deploy (gh-pages push)
+      #       * shadow-baseline.yaml:120 — publish (gh-pages push)
+      #     All other TokenPermissionsID findings (top-level writes,
+      #     unjustified job writes) continue to fire.
+      - name: Filter SARIF (drop known-noise findings)
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq '
+            .runs |= map(
+              .results |= map(select(
+                (["FuzzingID","CIIBestPracticesID","CodeReviewID","PinnedDependenciesID","BranchProtectionID"] | index(.ruleId) | not)
+                and
+                (
+                  .ruleId != "TokenPermissionsID"
+                  or (
+                    (.locations[0].physicalLocation.artifactLocation.uri // "") as $u
+                    | (.locations[0].physicalLocation.region.startLine // 0) as $l
+                    | [
+                        {u:".github/workflows/release.yaml",           l:1013},
+                        {u:".github/workflows/release.yaml",           l:1054},
+                        {u:".github/workflows/docfx.yaml",             l:59},
+                        {u:".github/workflows/shadow-baseline.yaml",   l:120}
+                      ] as $ignore
+                    | ($ignore | any(.u == $u and .l == $l)) | not
+                  )
+                )
+              ))
+            )
+          ' results.sarif > results.filtered.sarif
+          mv results.filtered.sarif results.sarif
+          echo "Filtered SARIF result count: $(jq '[.runs[].results[]] | length' results.sarif)"
+
       # Upload as an artifact so the SARIF is retrievable even if the
       # code-scanning upload later fails (e.g. quota, transient API).
       - name: Upload SARIF as artifact

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -34,14 +34,19 @@ on:
     - cron: '37 5 * * 3'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write   # required to upload SARIF to Code Scanning
+# Least-privilege default at the top level; the `semgrep` job below
+# elevates `security-events: write` locally for its SARIF upload.
+# Satisfies Scorecard's TokenPermissionsID rule which flags top-level
+# `security-events: write`.
+permissions: read-all
 
 jobs:
   semgrep:
     name: Semgrep scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # required to upload SARIF to Code Scanning
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -22,11 +22,13 @@ on:
       - 'tests/**'
       - 'examples/**'
       - '.github/workflows/semgrep.yaml'
+      - '.semgrepignore'
   push:
     branches: [main, vNext]
     paths:
       - 'src/**'
       - '.github/workflows/semgrep.yaml'
+      - '.semgrepignore'
   schedule:
     # Weekly Wed 05:37 UTC — catches new rule releases against unchanged code.
     - cron: '37 5 * * 3'

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -40,6 +40,12 @@ on:
   # Manual trigger for full re-scan (e.g. after tightening the config).
   workflow_dispatch:
 
+# Least-privilege default at the top level; the `zizmor` job elevates
+# `security-events: write` locally for its SARIF upload. Satisfies
+# Scorecard's TokenPermissionsID rule which flags a missing top-level
+# permissions block.
+permissions: read-all
+
 jobs:
   zizmor:
     name: zizmor

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,9 +1,34 @@
 # Paths Semgrep should not scan.
 #
-# Rules:
+# Rules (each path ignored has a specific justification — do NOT add
+# blanket `tests/` here; that would drop legitimate SAST on test code):
+#
 #   - benchmarks/  — micro-benchmark harness, not production code. Uses
 #     compile-time-literal DDL strings (`CREATE TABLE`, `DROP TABLE`) to
-#     seed a fixture DB; no user input reaches the SQL layer. The existing
-#     `// nosemgrep:` inline comment in BenchmarkContext.cs is preserved
-#     as belt-and-braces, but ignoring the directory is the durable fix.
+#     seed a fixture DB; no user input reaches the SQL layer.
+#
+#   - tests/**/Fixtures/  — integration-test fixtures (Sqlite/SqlServer/
+#     Postgres/MySql/MariaDb/CockroachDb) run DDL against per-test
+#     databases. Every call site uses a compile-time string literal
+#     (e.g. `ExecuteAsync(conn, "DROP TABLE contract_items;", ...)`);
+#     the `string sql` parameter never carries user input. Semgrep's
+#     csharp-sqli rule can't see that constraint and flags the
+#     assignment inside the helper.
+#
+#   - tests/**/TestDb.cs  — Unit-test in-memory-SQLite bootstrap.
+#     `CountRowsAsync(conn, string table = "People")` interpolates
+#     `table` into `SELECT COUNT(*) FROM {table}`. All callers pass
+#     the default or a hard-coded literal from within the test class.
+#
+#   - tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs
+#     Same pattern: `CountRows(conn, string table)` interpolates a
+#     hard-coded literal from a test-only caller.
+#
+# CodeQL scans everything (including tests) and provides the real SAST
+# coverage on this repo; Semgrep is the second-opinion layer whose
+# strength is src/ analysis. Where Semgrep and CodeQL disagree on a
+# test-only false positive, silencing Semgrep is the low-cost fix.
 benchmarks/
+tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/
+tests/Wolfgang.Etl.DbClient.Tests.Unit/TestDb.cs
+tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,9 @@
+# Paths Semgrep should not scan.
+#
+# Rules:
+#   - benchmarks/  — micro-benchmark harness, not production code. Uses
+#     compile-time-literal DDL strings (`CREATE TABLE`, `DROP TABLE`) to
+#     seed a fixture DB; no user input reaches the SQL layer. The existing
+#     `// nosemgrep:` inline comment in BenchmarkContext.cs is preserved
+#     as belt-and-braces, but ignoring the directory is the durable fix.
+benchmarks/

--- a/Wolfgang.Etl.DbClient.slnx.DotSettings
+++ b/Wolfgang.Etl.DbClient.slnx.DotSettings
@@ -36,6 +36,39 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 
 	<!--
+	  Redundant-* / partial-record style rules — silenced because they fire
+	  in tests and examples where the extra syntax is intentional for reader
+	  intent, not accidental:
+
+	    - RedundantTypeArgumentsOfMethod: tests spell out generic type
+	      arguments (e.g. `SomeMethod<Foo>(...)` when `Foo` could be inferred)
+	      to make the SUT-under-test's type-signature obvious at the call
+	      site. Inference works, but writing the type is a documentation
+	      choice.
+	    - RedundantCast: tests use explicit casts to pin down which
+	      overload runs (Assert.Equal vs collection Assert.Equal, etc.),
+	      or to prove the SUT accepts a given contract type.
+	    - RedundantArgumentDefaultValue: tests pass the default value
+	      explicitly to make "this parameter matters" obvious at the
+	      call site — swapping to positional-default would hide intent.
+	    - PartialTypeWithSinglePart: the DbTableGenerator source generator
+	      requires consumer records/classes to be declared `partial` so it
+	      can emit the second part with the SQL statement constants and
+	      Bind helper (see DbTableGeneratorTests). ReSharper doesn't run
+	      the source generator during InspectCode, so it sees "partial" as
+	      redundant. Roslyn's incremental-generator pipeline produces the
+	      other part.
+
+	  All current instances fire in tests/, examples/, or benchmarks/ —
+	  never in src/. Silenced fleet-wide for consistency with other repos
+	  that carry the same rules in their noise floor.
+	-->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantTypeArgumentsOfMethod/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCast/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentDefaultValue/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!--
 	  .CSharpErrors — silenced repo-wide.
 
 	  This is InspectCode's meta-category for "the ReSharper C# language service


### PR DESCRIPTION
## Summary

Fourth of a 5-PR stack against umbrella #328. **Stacked on #341** — merge that (and #339, #340) first.

Clears **26 of the 35** open InspectCode alerts by silencing four style-noise rules that fire exclusively in \`tests/\`, \`examples/\`, and \`benchmarks/\` — never in \`src/\`. Consistent with the noise-floor pattern documented in session-memory \`reference_inspectcode_noise_floor\` and matches the fleet-canonical starter profile shipped by ETL-FixedWidth / Extensions-Logging-Data.

### Rules added
| Rule | # alerts | Why it's noise here |
|---|--:|---|
| \`RedundantTypeArgumentsOfMethod\` | 11 | Tests spell out generics for reader clarity (e.g. \`EtlPipeline.Create<Foo>()\`) |
| \`RedundantCast\` | 6 | Tests use explicit casts to pin down which xUnit overload runs, or to prove SUT accepts a contract type |
| \`RedundantArgumentDefaultValue\` | 4 | Tests pass \`IsolationLevel.ReadCommitted\` etc. explicitly so intent is obvious at call site |
| \`PartialTypeWithSinglePart\` | 5 | \`DbTableGenerator\` source generator requires \`partial\` on consumer records so it can emit SQL constants + Bind helper; InspectCode doesn't run the generator |

### Deferred to PR-5 (9 alerts remaining)
Safety-oriented rules get per-instance investigation, not blanket suppression:
- \`AccessToDisposedClosure\` × 7 (all in \`tests/Concurrency/\`)
- \`ShortLivedHttpClient\` × 1 (in \`tests/SourceLink/SourceLinkPdbTests.cs\`)
- \`UsingStatementResourceInitialization\` × 1 (same file)

## Test plan
- [ ] \`ReSharper InspectCode\` job on this PR runs green.
- [ ] After merge, verify open InspectCode alerts on main drop from 35 → 9:
  \`\`\`
  gh api \"repos/Chris-Wolfgang/Etl-DbClient/code-scanning/alerts?state=open&tool_name=InspectCode\" --jq 'length'   # expect 9
  \`\`\`
- [ ] Confirm no \`src/\` alerts are silenced — grep the affected rules from the SARIF and prove all instances are in tests / examples / benchmarks.

## Trade-offs
- Silencing at the rule level (not per-file) means new instances of these rules in \`src/\` would also be silenced. Acceptable because:
  - .editorconfig / Roslynator / Meziantou cover the same territory with better fidelity for src.
  - \`Assert.Equal(\` explicit-cast usage is a xUnit-test pattern that would rarely be idiomatic in src.
  - \`partial\` on a source-generator target is CORRECT src-side; silencing is fine.

Refs #328.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>