### PR TITLE
ci(workflows): sync 7 protected workflow files ahead of v0.9.1 (protected-only)

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -54,6 +54,11 @@ on:
       - ".github/workflows/aot-smoke.yaml"
   workflow_dispatch:
 
+# Least-privilege default at the top level; individual jobs elevate
+# only if they need more. Satisfies Scorecard's TokenPermissionsID rule
+# which flags a missing top-level permissions block.
+permissions: read-all
+
 jobs:
   aot-smoke:
     name: PublishAot + PublishTrimmed

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -14,9 +14,13 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write    # benchmark-action pushes commits to gh-pages
-  deployments: write # benchmark-action records a deployment
+# Top-level default is read-only; the five per-RDBMS jobs below elevate
+# to `contents: write` + `deployments: write` locally because each one
+# uses benchmark-action/github-action-benchmark to commit to gh-pages
+# and record a deployment. Scorecard's TokenPermissionsID rule requires
+# top-level to be no more than read; the elevation belongs on the jobs
+# that actually push.
+permissions: read-all
 
 concurrency:
   group: benchmarks-${{ github.ref }}
@@ -36,6 +40,9 @@ jobs:
   benchmark-sqlite:
     name: "Benchmarks / sqlite"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -73,6 +80,9 @@ jobs:
     name: "Benchmarks / sqlserver"
     runs-on: ubuntu-latest
     needs: benchmark-sqlite
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2022-latest
@@ -124,6 +134,9 @@ jobs:
     name: "Benchmarks / postgres"
     runs-on: ubuntu-latest
     needs: benchmark-sqlserver
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     services:
       postgres:
         image: postgres:16-alpine
@@ -175,6 +188,9 @@ jobs:
     name: "Benchmarks / mysql"
     runs-on: ubuntu-latest
     needs: benchmark-postgres
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     services:
       mysql:
         image: mysql:8.0
@@ -228,6 +244,9 @@ jobs:
     name: "Benchmarks / mariadb"
     runs-on: ubuntu-latest
     needs: benchmark-mysql
+    permissions:
+      contents: write     # benchmark-action commits to gh-pages
+      deployments: write  # benchmark-action records a deployment
     services:
       mariadb:
         image: mariadb:11.4.4

--- a/.github/workflows/integration-status.yaml
+++ b/.github/workflows/integration-status.yaml
@@ -19,9 +19,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write    # write per-RDBMS status JSONs to gh-pages
-  pull-requests: read
+# Top-level default is read-only; only `publish-status` elevates to
+# `contents: write` (it commits the per-RDBMS status JSONs to gh-pages).
+# `test-matrix` runs `dotnet test` and uploads artifacts — read-only is
+# sufficient. Scorecard's TokenPermissionsID rule wants top-level to be
+# no more than read.
+permissions: read-all
 
 concurrency:
   # Serialize against ourselves so two pushes to main never race the
@@ -135,6 +138,9 @@ jobs:
     needs: test-matrix
     # Run even when some cells failed — we still want fresh badge state.
     if: always() && github.repository != 'Chris-Wolfgang/repo-template'
+    permissions:
+      contents: write     # write per-RDBMS status JSONs to gh-pages
+      pull-requests: read
 
     steps:
       - name: Checkout gh-pages

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -55,6 +55,69 @@ jobs:
           # in README.md resolves. Requires the repo to be public (this repo is).
           publish_results: true
 
+      # Filter known-noise findings BEFORE upload. Dismissing individual
+      # alerts via `gh api ... code-scanning/alerts/N` decays across the
+      # weekly re-run because the SARIF fingerprint drifts — the same
+      # finding re-appears as a new alert-id. Filtering at the SARIF layer
+      # is the durable fix.
+      #
+      # Filter policy:
+      #   - Drop ENTIRE rules whose findings cannot be resolved for this
+      #     repo:
+      #       * FuzzingID              — Scorecard misses SharpFuzz
+      #         (fuzz.yaml exists but the detector recognizes only a
+      #         short list of fuzzing tools).
+      #       * CIIBestPracticesID     — no OpenSSF badge; policy call
+      #         until the maintainer opts into the CII questionnaire.
+      #       * CodeReviewID           — solo-maintainer repo; PRs get
+      #         merged after passing CI + optional Copilot review.
+      #         Enforcing "N approved reviewers" isn't a viable policy.
+      #       * PinnedDependenciesID   — flags every `dotnet` /`pip` /
+      #         `bash download-then-run` invocation as "not pinned by
+      #         hash". `dotnet` pins via SDK version (setup-dotnet); pip
+      #         pins are handled inside individual workflows; downloads
+      #         are pinned by SHA where practical. Not fixable.
+      #       * BranchProtectionID     — Chris uses org-level rulesets
+      #         (not classic branch protection); Scorecard's detector
+      #         doesn't fully cover rulesets.
+      #
+      #   - Drop TokenPermissionsID findings at specific (file, line)
+      #     tuples where the job GENUINELY needs `contents: write`:
+      #       * release.yaml:1013   — trigger-docs → docfx (gh-pages push)
+      #       * release.yaml:1054   — update-release-artifacts (attach)
+      #       * docfx.yaml:59       — build-and-deploy (gh-pages push)
+      #       * shadow-baseline.yaml:120 — publish (gh-pages push)
+      #     All other TokenPermissionsID findings (top-level writes,
+      #     unjustified job writes) continue to fire.
+      - name: Filter SARIF (drop known-noise findings)
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq '
+            .runs |= map(
+              .results |= map(select(
+                (["FuzzingID","CIIBestPracticesID","CodeReviewID","PinnedDependenciesID","BranchProtectionID"] | index(.ruleId) | not)
+                and
+                (
+                  .ruleId != "TokenPermissionsID"
+                  or (
+                    (.locations[0].physicalLocation.artifactLocation.uri // "") as $u
+                    | (.locations[0].physicalLocation.region.startLine // 0) as $l
+                    | [
+                        {u:".github/workflows/release.yaml",           l:1013},
+                        {u:".github/workflows/release.yaml",           l:1054},
+                        {u:".github/workflows/docfx.yaml",             l:59},
+                        {u:".github/workflows/shadow-baseline.yaml",   l:120}
+                      ] as $ignore
+                    | ($ignore | any(.u == $u and .l == $l)) | not
+                  )
+                )
+              ))
+            )
+          ' results.sarif > results.filtered.sarif
+          mv results.filtered.sarif results.sarif
+          echo "Filtered SARIF result count: $(jq '[.runs[].results[]] | length' results.sarif)"
+
       # Upload as an artifact so the SARIF is retrievable even if the
       # code-scanning upload later fails (e.g. quota, transient API).
       - name: Upload SARIF as artifact

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -22,24 +22,31 @@ on:
       - 'tests/**'
       - 'examples/**'
       - '.github/workflows/semgrep.yaml'
+      - '.semgrepignore'
   push:
     branches: [main, vNext]
     paths:
       - 'src/**'
       - '.github/workflows/semgrep.yaml'
+      - '.semgrepignore'
   schedule:
     # Weekly Wed 05:37 UTC — catches new rule releases against unchanged code.
     - cron: '37 5 * * 3'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write   # required to upload SARIF to Code Scanning
+# Least-privilege default at the top level; the `semgrep` job below
+# elevates `security-events: write` locally for its SARIF upload.
+# Satisfies Scorecard's TokenPermissionsID rule which flags top-level
+# `security-events: write`.
+permissions: read-all
 
 jobs:
   semgrep:
     name: Semgrep scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # required to upload SARIF to Code Scanning
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/shadow-regression.yaml
+++ b/.github/workflows/shadow-regression.yaml
@@ -124,7 +124,34 @@ jobs:
           STRICT: ${{ inputs.strict || 'false' }}
         run: |
           set -euo pipefail
-          # Thresholds: per #130 AC (20% latency, 50% allocations).
+          # Thresholds: allocation-family only (50% alloc, 50% gen0, 200%+abs
+          # floor for gen1/gen2). Cross-time latency (`elapsedMs` /
+          # `rowsPerSecond`) is REPORTED but NOT GATED — see #332.
+          #
+          # Why: the baseline is fetched from gh-pages, recorded by
+          # shadow-baseline.yaml on some prior push to main. Because the
+          # baseline and the current run happen at different times on
+          # different runner instances, the wall-clock latency comparison
+          # false-fails whenever the GitHub runner fleet is slower today
+          # than it was on baseline day. Chris's controlled A/B (three runs
+          # per branch, same machine, back-to-back) has shown +4% at the
+          # mean with overlapping ranges while CI simultaneously reported
+          # +50% "regression" — the 50% is runner drift, not code. Same
+          # commit repeatedly produces +33% / +51% / -8% over reruns.
+          #
+          # Allocation metrics (allocatedBytes / bytesPerRow / genN) are
+          # deterministic and machine-independent — same code path allocates
+          # the same bytes and triggers the same GC frequency regardless of
+          # runner wall-clock. Those stay in the gate.
+          #
+          # Pure-latency regressions (code got slower without changing
+          # allocations) won't be caught here — the pr-benchmarks workflow
+          # (BenchmarkDotNet, HEAD-vs-BASE on the SAME runner) is the correct
+          # place for that comparison. If a same-runner latency gate is
+          # eventually wanted here too, that's #332 Option 2 — measure the
+          # baseline in the same job by running the sample once on the PR's
+          # merge-base and once on the head. Bigger change; deferred.
+          #
           # gen1/gen2 collections are noisy on small per-run sample counts
           # (observed 2, 5, 8 collections across otherwise-identical runs
           # of PR #326/#327 with unchanged allocatedBytes/bytesPerRow) --
@@ -133,8 +160,6 @@ jobs:
           # (see ABS_FLOOR below) on top of the percentage threshold.
           # Added 2026-08-11 after the plain-percentage widening (100%,
           # then 200%) both still false-triggered on PR #326.
-          # rowsPerSecond is the throughput inverse of elapsedMs; failing
-          # on both would be redundant, so gate ONLY elapsedMs on latency.
           # windows-latest's pre-installed Python is only on PATH as
           # `python`, not `python3` — pick whichever exists.
           PYTHON_BIN=python3
@@ -147,25 +172,32 @@ jobs:
           with open("reports/current.json") as f:  cur = json.load(f)
           with open("reports/baseline.json") as f: base = json.load(f)
 
-          # metric -> (direction, threshold_frac, abs_floor)
-          #   direction: "up" means values > baseline are worse; "down" means values < baseline are worse.
+          # metric -> (direction, threshold_frac, abs_floor, gate)
+          #   direction:      "up" means values > baseline are worse; "down" means values < baseline are worse.
           #   threshold_frac: allowed delta beyond baseline (0.20 = 20%).
-          #   abs_floor: if set, the RAW count must ALSO grow by at least this many
+          #   abs_floor:      if set, the RAW count must ALSO grow by at least this many
           #     collections before the percentage threshold can trigger a REGRESS --
           #     keeps tiny-integer noise (e.g. 2 -> 5) from tripping the gate even at
           #     a wide percentage threshold. None = no floor (percentage alone gates).
+          #   gate:           True — regression sets exit=1 (fails the workflow).
+          #                   False — reported in the comparison table only, never fails
+          #                   the workflow (even under strict mode). Use for metrics whose
+          #                   values are legitimately non-deterministic across runs.
           rules = {
-              "elapsedMs":         ("up",   0.20, None),
-              "allocatedBytes":    ("up",   0.50, None),
-              "bytesPerRow":       ("up",   0.50, None),
-              "gen0Collections":   ("up",   0.50, None),
-              "gen1Collections":   ("up",   2.00, 15),
-              "gen2Collections":   ("up",   2.00, 15),
+              # Cross-time wall-clock — reported only, per #332. See header comment.
+              "elapsedMs":         ("up",   0.20, None, False),
+              "rowsPerSecond":     ("down", 0.20, None, False),
+              # Allocation family — deterministic; gate.
+              "allocatedBytes":    ("up",   0.50, None, True),
+              "bytesPerRow":       ("up",   0.50, None, True),
+              "gen0Collections":   ("up",   0.50, None, True),
+              "gen1Collections":   ("up",   2.00, 15,   True),
+              "gen2Collections":   ("up",   2.00, 15,   True),
           }
 
           rows = []
           any_regress = False
-          for m, (direction, thresh, abs_floor) in rules.items():
+          for m, (direction, thresh, abs_floor, gate) in rules.items():
               b = base.get(m)
               c = cur.get(m)
               if b is None or c is None:
@@ -181,10 +213,16 @@ jobs:
               status = "ok"
               if delta > limit and (abs_floor is None or abs(abs_delta) >= abs_floor):
                   status = f"REGRESS delta={delta*100:.1f}% (>{limit*100:.0f}%), abs={abs_delta:+d}"
-                  any_regress = True
+                  if gate:
+                      any_regress = True
+                  else:
+                      status += " [reported only, not gated per #332]"
               elif strict and delta > 0:
                   status = f"drift delta={delta*100:.1f}% (strict)"
-                  any_regress = True
+                  if gate:
+                      any_regress = True
+                  else:
+                      status += " [reported only, not gated per #332]"
               rows.append((m, b, c, f"{delta*100:+.1f}%", status))
 
           print(f"{'metric':<20} {'baseline':>15} {'current':>15} {'delta':>10}  status")

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -40,6 +40,12 @@ on:
   # Manual trigger for full re-scan (e.g. after tightening the config).
   workflow_dispatch:
 
+# Least-privilege default at the top level; the `zizmor` job elevates
+# `security-events: write` locally for its SARIF upload. Satisfies
+# Scorecard's TokenPermissionsID rule which flags a missing top-level
+# permissions block.
+permissions: read-all
+
 jobs:
   zizmor:
     name: zizmor


### PR DESCRIPTION
## Summary

Protected-only PR extracted from the v0.9.1 release stack (#344, vNext → main), following the \`protected-file-pr-split\` skill flow.

Bringing these 7 files across via a small bypass merge means the release PR (#344) itself no longer trips the \`Detect .NET Projects\` guard and can merge through the full ruleset (\`required_review_thread_resolution\`, \`required_status_checks\`) **without** admin bypass. Admin bypass on this small PR waives the ruleset for one small, easy-to-review diff instead of a whole 15-file release.

## Files

All changes originated from PRs #339, #340, #341, and #345:

| File | Change | Origin |
|---|---|---|
| \`aot-smoke.yaml\` | top-level \`permissions: read-all\` | #340 (Scorecard TokenPermissionsID) |
| \`benchmarks.yaml\` | moved \`contents:write\`/\`deployments:write\` from top-level to per-job | #339 (Scorecard + zizmor) |
| \`integration-status.yaml\` | moved \`contents:write\` from top-level to \`publish-status\` job only | #339 (Scorecard + zizmor) |
| \`scorecard.yaml\` | SARIF filter for policy/tool-limitation rules + 4 legit job-level writes | #341 (Scorecard SARIF filter) |
| \`semgrep.yaml\` | moved \`security-events:write\` from top-level to \`semgrep\` job; added \`.semgrepignore\` to \`paths\` | #339, #340 |
| \`workflow-security.yaml\` | top-level \`permissions: read-all\` | #340 (Scorecard TokenPermissionsID) |
| \`shadow-regression.yaml\` | stop gating on cross-time wall-clock \`elapsedMs\` | #345 (Closes #332 Option 1) |

None of these change build/test/release behaviour in a way that requires CI reruns downstream; they only tighten permissions, filter alert noise, and stop false-failing on the shadow-regression latency metric.

## Expected CI shape (per \`protected-file-pr-split\` skill)

- \`Detect .NET Projects\` ❌ — expected; that's the whole point of this PR.
- \`Stage 1/2/3\` ⏭️ — skipped because they depend on \`detect-projects.outputs.has-projects\`.
- Everything else (Secrets Scan, DevSkim, CodeQL, actionlint, zizmor, Semgrep) ✅.

## Merge plan

1. Maintainer eyeballs the diff (7 workflow files, all changes traceable to already-approved PRs #339/#340/#341/#345).
2. Admin-bypass merge this PR.
3. Merge \`origin/main\` back into \`vNext\` — the protected-file delta disappears from #344.
4. #344 flips from UNSTABLE → MERGEABLE with all gates green; no admin bypass needed for the release itself.
5. Tag \`v0.9.1\` on main → \`release.yaml\` fires.

Refs #344 (release v0.9.1), #328 (code-scanning umbrella), #332 (shadow-regression flake).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>