### PR TITLE
chore(pack): advance PackageValidation baseline to 0.9.1

### DIFF
--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -48,7 +48,7 @@
          once the version being released here is live on the flatcontainer CDN,
          never to the in-flight version (the pack step downloads the baseline). -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.9.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.9.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Post-deploy follow-up to the v0.9.1 release ([#344](https://github.com/Chris-Wolfgang/Etl-DbClient/pull/344), tag `v0.9.1`). Bumps `PackageValidationBaselineVersion` from **0.9.0 → 0.9.1** in \`src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj\`.

## Why + timing

Per session-memory \`reference_packagevalidation_baseline_timing\`, the baseline must point at the **last version actually published on NuGet** — the pack step downloads the baseline .nupkg from api.nuget.org to run \`Microsoft.DotNet.ApiCompat\` against it. Bumping to an in-flight or unindexed version would fail the pack.

Verified before opening:
- release.yaml [run 32502325639](https://github.com/Chris-Wolfgang/Etl-DbClient/actions/runs/32502325639) — SUCCESS
- NuGet flatcontainer index (\`https://api.nuget.org/v3-flatcontainer/wolfgang.etl.dbclient/index.json\`) — latest is \`0.9.1\`

## Test plan
- [ ] Stage 1/2/3 green (build + tests + Release-mode analyzers)
- [ ] \`dotnet pack -c Release\` runs \`RunPackageValidation\` against 0.9.1 as the baseline — expect clean (no breaking changes since v0.9.1 shipped; the diff is empty).
- [ ] After merge, verify \`main\` at \`chore/baseline-0.9.1\` tip shows the bumped baseline.

## Post-merge

Closes item 2 of [#347](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/347). Remaining items on that issue:
- Item 1: NuGet CDN v0.9.1 indexing — already verified ✓
- Item 3: Remote branch cleanup — already done ✓
- Item 4: Confirm code-scanning alert count drops after next scan cycles
- Item 5: Ruleset (no revert needed) — nothing to do ✓

Once item 4 confirms, #347 can close.

Refs #347.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>