### PR TITLE
ci(fuzz): scope issues:write to the fuzz job (least-privilege)

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -37,16 +37,17 @@ on:
 
 permissions:
   contents: read
-  # `issues: write` is required for the auto-file / auto-comment step
-  # at the bottom of the job. Job-level scope (rather than
-  # workflow-level) so the earlier fuzz-execution steps run with
-  # least-privilege.
-  issues: write
 
 jobs:
   fuzz:
     name: Continuous fuzz (${{ inputs.iterations || '100000' }} iters)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Auto-files a `fuzz-failure` tracking issue on regression (or
+      # comments on an existing open one). Scoped to this job so the
+      # rest of the workflow can't touch issues.
+      issues: write
     timeout-minutes: 60
     steps:
       - name: Checkout code


### PR DESCRIPTION
Workflow-permissions audit found this workflow granting `issues: write` at the top level. Only the `fuzz` job (specifically its auto-file / auto-comment step) needs it, and the top-level comment even acknowledges this ("Job-level scope (rather than workflow-level) so the earlier fuzz-execution steps run with least-privilege") — the comment intent matched a job-level scope but the placement was still workflow-level.

## Change

- Top-level permissions reduced to `contents: read`.
- The `fuzz` job gains its own `permissions:` block with `contents: read` + `issues: write`.
- Comment moved with the write scope and rewritten to match the new placement.

## Why it matters

Defense in depth: if a second job is ever added to this workflow, it inherits `contents: read` only — not the ability to open or comment on issues. The `issues: write` scope stays contained to the one job that actually files the `fuzz-failure` tracking issue.

Fleet-wide workflow-permissions audit — 361 of 364 workflows across the fleet already follow this pattern; this PR + ETL-Documentation/deploy-docs.yaml are the two outliers.