### PR TITLE
security(inspectcode): inline disable/restore AccessToDisposedClosure at 3 sites

### DIFF
--- a/Wolfgang.Etl.DbClient.slnx.DotSettings
+++ b/Wolfgang.Etl.DbClient.slnx.DotSettings
@@ -69,35 +69,6 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 
 	<!--
-	  AccessToDisposedClosure — silenced because every current instance
-	  fires in Tests.Concurrency/, in the Coyote testing pattern:
-
-	      using var cts = new CancellationTokenSource();
-	      var cancelTask = Task.Run(() => cts.Cancel());
-	      var workTask   = Task.Run(async () => { ... uses cts.Token ... });
-	      Task.WaitAll(cancelTask, workTask);   // both closures complete
-	                                            // BEFORE the `using` scope
-	                                            // exits and cts is disposed.
-
-	  ReSharper's flow analysis conservatively assumes the Task.Run
-	  closures may outlive the `using` scope, but the WaitAll on the same
-	  scope guarantees they don't. If a future test drops the WaitAll
-	  before the disposal boundary, that IS a real race — and this
-	  suppression would hide it. Two mitigations:
-
-	    1. All current sites fire in tests only. Nothing in src/ uses this
-	       pattern (verified 2026-08-22 across all InspectCode alerts).
-	    2. Coyote scheduling explores the closure completion ordering
-	       and would surface an ObjectDisposedException if the disposal
-	       race actually reached the closure body — see the
-	       Specification.Assert in each test's body.
-
-	  Revisit if this rule starts firing in src/ (add a scoped filter
-	  or move to inline `// ReSharper disable once` at each site).
-	-->
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AccessToDisposedClosure/@EntryIndexedValue">DO_NOT_SHOW</s:String>
-
-	<!--
 	  .CSharpErrors — silenced repo-wide.
 
 	  This is InspectCode's meta-category for "the ReSharper C# language service

--- a/Wolfgang.Etl.DbClient.slnx.DotSettings
+++ b/Wolfgang.Etl.DbClient.slnx.DotSettings
@@ -69,6 +69,35 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 
 	<!--
+	  AccessToDisposedClosure — silenced because every current instance
+	  fires in Tests.Concurrency/, in the Coyote testing pattern:
+
+	      using var cts = new CancellationTokenSource();
+	      var cancelTask = Task.Run(() => cts.Cancel());
+	      var workTask   = Task.Run(async () => { ... uses cts.Token ... });
+	      Task.WaitAll(cancelTask, workTask);   // both closures complete
+	                                            // BEFORE the `using` scope
+	                                            // exits and cts is disposed.
+
+	  ReSharper's flow analysis conservatively assumes the Task.Run
+	  closures may outlive the `using` scope, but the WaitAll on the same
+	  scope guarantees they don't. If a future test drops the WaitAll
+	  before the disposal boundary, that IS a real race — and this
+	  suppression would hide it. Two mitigations:
+
+	    1. All current sites fire in tests only. Nothing in src/ uses this
+	       pattern (verified 2026-08-22 across all InspectCode alerts).
+	    2. Coyote scheduling explores the closure completion ordering
+	       and would surface an ObjectDisposedException if the disposal
+	       race actually reached the closure body — see the
+	       Specification.Assert in each test's body.
+
+	  Revisit if this rule starts firing in src/ (add a scoped filter
+	  or move to inline `// ReSharper disable once` at each site).
+	-->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AccessToDisposedClosure/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!--
 	  .CSharpErrors — silenced repo-wide.
 
 	  This is InspectCode's meta-category for "the ReSharper C# language service

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/ExtractorCancellationConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/ExtractorCancellationConcurrencyTests.cs
@@ -92,6 +92,13 @@ public class ExtractorCancellationConcurrencyTests
                 conn,
                 "SELECT id AS Id, value AS Value FROM cancel_probe ORDER BY id");
 
+            // ReSharper disable AccessToDisposedClosure
+            // `cts` is captured in the two Task.Run closures below. The
+            // Task.WaitAll after the two Task.Run calls, but inside the
+            // same `using` scope as `cts`, guarantees both closures
+            // finish before `cts` is disposed — there is no disposed-
+            // closure race here. ReSharper's flow analysis can't see
+            // the WaitAll boundary. Restored right after the boundary.
             using var cts = new CancellationTokenSource();
             var observed = 0;
 
@@ -121,6 +128,7 @@ public class ExtractorCancellationConcurrencyTests
             });
 
             Task.WaitAll(cancelTask, enumerateTask);
+            // ReSharper restore AccessToDisposedClosure
 
             // Invariant: extractor's own counter never exceeds what the
             // consumer observed. If the extractor incremented the count

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/LoaderCancellationConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/LoaderCancellationConcurrencyTests.cs
@@ -83,6 +83,13 @@ public class LoaderCancellationConcurrencyTests
                 conn,
                 "INSERT INTO load_probe (value) VALUES (@Value)");
 
+            // ReSharper disable AccessToDisposedClosure
+            // `cts` is captured in the two Task.Run closures below. The
+            // Task.WaitAll after the two Task.Run calls, but inside the
+            // same `using` scope as `cts`, guarantees both closures
+            // finish before `cts` is disposed — there is no disposed-
+            // closure race here. ReSharper's flow analysis can't see
+            // the WaitAll boundary. Restored right after the boundary.
             using var cts = new CancellationTokenSource();
 
             var cancelTask = Task.Run(() =>
@@ -103,6 +110,7 @@ public class LoaderCancellationConcurrencyTests
             });
 
             Task.WaitAll(cancelTask, loadTask);
+            // ReSharper restore AccessToDisposedClosure
 
             // Count what actually landed in the destination.
             int actualRows;

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/OwnedConnectionDisposalConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/OwnedConnectionDisposalConcurrencyTests.cs
@@ -92,6 +92,13 @@ public class OwnedConnectionDisposalConcurrencyTests
                 // no-op each run.
                 "SELECT id AS Id FROM sqlite_master WHERE 1=0");
 
+            // ReSharper disable AccessToDisposedClosure
+            // `cts` is captured in the two Task.Run closures below. The
+            // Task.WaitAll after the two Task.Run calls, but inside the
+            // same `using` scope as `cts`, guarantees both closures
+            // finish before `cts` is disposed — there is no disposed-
+            // closure race here. ReSharper's flow analysis can't see
+            // the WaitAll boundary. Restored right after the boundary.
             using var cts = new CancellationTokenSource();
 
             var cancelTask = Task.Run(() =>
@@ -120,6 +127,7 @@ public class OwnedConnectionDisposalConcurrencyTests
             });
 
             Task.WaitAll(cancelTask, enumTask);
+            // ReSharper restore AccessToDisposedClosure
 
             // First-run invariant: either it completed normally, or it
             // was cancelled, or it threw a DB-related exception because


### PR DESCRIPTION
## Summary

Silences InspectCode's `AccessToDisposedClosure` false positive at the three concurrency test sites where `cts` is captured in `Task.Run` closures that are joined by `Task.WaitAll` inside the same `using` scope. Uses inline `// ReSharper disable AccessToDisposedClosure` / `// ReSharper restore AccessToDisposedClosure` regions per Chris's PR review feedback (narrower than a global DotSettings entry — if a future test drops the WaitAll from the disposal boundary, that IS a real race and the analyzer will still fire).

Files:
- tests/Wolfgang.Etl.DbClient.Tests.Concurrency/LoaderCancellationConcurrencyTests.cs
- tests/Wolfgang.Etl.DbClient.Tests.Concurrency/OwnedConnectionDisposalConcurrencyTests.cs
- tests/Wolfgang.Etl.DbClient.Tests.Concurrency/ExtractorCancellationConcurrencyTests.cs

Net DotSettings diff vs. main: **zero**.

## Context — why 35 alerts remain open on `main`

The other 26 of the 35 open InspectCode alerts on `main` are already covered by suppressions committed in PR #342 (redundancy family via .DotSettings) and PR #343 (inline SourceLink comments). They remain open because the InspectCode job runs under `pull_request` — it files SARIF under PR head refs, never `refs/heads/main`. Last `refs/heads/main` InspectCode analysis was 2026-08-08, before the fleet noise-floor extension shipped, so `main` alerts never got re-processed.

Once this PR merges (and eventually reaches the next release), all 35 stale alerts will be dismissed via `gh api code-scanning/alerts` with `reason: false positive`, referencing this PR and the respective suppression sites.

Umbrella: #328.

## Test plan
- [x] Diff is inline-suppression comments only — no code change, no DotSettings change
- [x] Each region brackets from `using var cts` through `Task.WaitAll` — the exact scope where the false positive fires
- [x] Rationale documented at each site
- [ ] CI green