### PR TITLE
fix(scorecard): bind ruleId before membership check so SARIF filter doesn't abort

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -93,26 +93,38 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # `.ruleId` inside a pipeline is evaluated against the pipeline's
+          # current input, NOT the outer `select` context. The previous form
+          # `["FuzzingID",...] | index(.ruleId)` tried to `.ruleId` the
+          # noise-rule LIST — under jq 1.8 that raises
+          # "Cannot index array with string 'ruleId'" and the whole filter
+          # aborts (exit 5), which then aborts the SARIF upload and leaves
+          # every earlier finding open on `main`. Bind the ruleId as `$rid`
+          # first so the membership check sees the result's ruleId, not the
+          # list.
           jq '
             .runs |= map(
-              .results |= map(select(
-                (["FuzzingID","CIIBestPracticesID","CodeReviewID","PinnedDependenciesID","BranchProtectionID"] | index(.ruleId) | not)
-                and
-                (
-                  .ruleId != "TokenPermissionsID"
-                  or (
-                    (.locations[0].physicalLocation.artifactLocation.uri // "") as $u
-                    | (.locations[0].physicalLocation.region.startLine // 0) as $l
-                    | [
-                        {u:".github/workflows/release.yaml",           l:1013},
-                        {u:".github/workflows/release.yaml",           l:1054},
-                        {u:".github/workflows/docfx.yaml",             l:59},
-                        {u:".github/workflows/shadow-baseline.yaml",   l:120}
-                      ] as $ignore
-                    | ($ignore | any(.u == $u and .l == $l)) | not
+              .results |= map(
+                (.ruleId // "") as $rid
+                | select(
+                    (["FuzzingID","CIIBestPracticesID","CodeReviewID","PinnedDependenciesID","BranchProtectionID"] | index($rid) | not)
+                    and
+                    (
+                      $rid != "TokenPermissionsID"
+                      or (
+                        (.locations[0].physicalLocation.artifactLocation.uri // "") as $u
+                        | (.locations[0].physicalLocation.region.startLine // 0) as $l
+                        | [
+                            {u:".github/workflows/release.yaml",           l:1013},
+                            {u:".github/workflows/release.yaml",           l:1054},
+                            {u:".github/workflows/docfx.yaml",             l:59},
+                            {u:".github/workflows/shadow-baseline.yaml",   l:120}
+                          ] as $ignore
+                        | ($ignore | any(.u == $u and .l == $l)) | not
+                      )
+                    )
                   )
-                )
-              ))
+              )
             )
           ' results.sarif > results.filtered.sarif
           mv results.filtered.sarif results.sarif


### PR DESCRIPTION
## Summary

The Scorecard SARIF filter in \`scorecard.yaml\` has been aborting on every workflow run since PR #341 landed (2026-08-20):

\`\`\`
jq: error (at results.sarif:NNNN): Cannot index array with string \"ruleId\"
##[error]Process completed with exit code 5.
\`\`\`

Because exit 5 trips \`set -e\`, the SARIF upload steps that follow never run. Every finding already open on \`refs/heads/main\` stays open, and no new SARIF is filed — the filter's whole purpose (drop unfixable-rule noise + justified TokenPermissionsID sites) is defeated.

## Root cause

The membership check reads:

\`\`\`jq
[\"FuzzingID\",...] | index(.ruleId)
\`\`\`

Inside a pipeline, \`.ruleId\` is evaluated against the pipeline's **current input** — at that point the noise-rule list itself — not the outer \`select\` context. jq 1.8 rejects \`[array] | .ruleId\` with \"Cannot index array with string 'ruleId'\" and aborts the whole document.

## Fix

Bind \`(.ruleId // \"\") as \$rid\` per result and reference \`\$rid\` inside both the membership check and the TokenPermissionsID guard. Same input, same intended behavior — the filter no longer errors.

## Verification (local, against the 2026-08-19 SARIF — the last one to upload successfully)

- **Pre-filter**: 28 findings (BranchProtectionID×1, CIIBestPracticesID×1, CodeReviewID×1, FuzzingID×1, PinnedDependenciesID×14, TokenPermissionsID×10)
- **Post-filter**: 6 findings (all TokenPermissionsID at unjustified sites, as designed)

## What this does NOT do

The 28 stale Scorecard alerts on \`refs/heads/main\` will not auto-close from this fix landing on vNext — they only close when a new SARIF that OMITS them is uploaded under \`refs/heads/main\`, which happens on the next push-to-main scorecard run (\`push: branches: [main]\` trigger). Once this fix reaches main via the next release cycle, the next scheduled Tuesday scorecard run (or any main-branch push) will clear them.

Alternately, the stale ones can be dismissed manually alongside this PR — that path is being followed here.

Umbrella: #328.

## Test plan
- [x] Fix reproduced locally: exit 5 → exit 0
- [x] Post-filter finding shape matches the design intent (6 unjustified TokenPermissionsID)
- [ ] After merge to vNext + eventual release: next scorecard run on main is green