### PR TITLE
fix(scorecard): bind ruleId before membership check so SARIF filter doesn't abort (protected/expedite to main)

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -93,26 +93,38 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # `.ruleId` inside a pipeline is evaluated against the pipeline's
+          # current input, NOT the outer `select` context. The previous form
+          # `["FuzzingID",...] | index(.ruleId)` tried to `.ruleId` the
+          # noise-rule LIST — under jq 1.8 that raises
+          # "Cannot index array with string 'ruleId'" and the whole filter
+          # aborts (exit 5), which then aborts the SARIF upload and leaves
+          # every earlier finding open on `main`. Bind the ruleId as `$rid`
+          # first so the membership check sees the result's ruleId, not the
+          # list.
           jq '
             .runs |= map(
-              .results |= map(select(
-                (["FuzzingID","CIIBestPracticesID","CodeReviewID","PinnedDependenciesID","BranchProtectionID"] | index(.ruleId) | not)
-                and
-                (
-                  .ruleId != "TokenPermissionsID"
-                  or (
-                    (.locations[0].physicalLocation.artifactLocation.uri // "") as $u
-                    | (.locations[0].physicalLocation.region.startLine // 0) as $l
-                    | [
-                        {u:".github/workflows/release.yaml",           l:1013},
-                        {u:".github/workflows/release.yaml",           l:1054},
-                        {u:".github/workflows/docfx.yaml",             l:59},
-                        {u:".github/workflows/shadow-baseline.yaml",   l:120}
-                      ] as $ignore
-                    | ($ignore | any(.u == $u and .l == $l)) | not
+              .results |= map(
+                (.ruleId // "") as $rid
+                | select(
+                    (["FuzzingID","CIIBestPracticesID","CodeReviewID","PinnedDependenciesID","BranchProtectionID"] | index($rid) | not)
+                    and
+                    (
+                      $rid != "TokenPermissionsID"
+                      or (
+                        (.locations[0].physicalLocation.artifactLocation.uri // "") as $u
+                        | (.locations[0].physicalLocation.region.startLine // 0) as $l
+                        | [
+                            {u:".github/workflows/release.yaml",           l:1013},
+                            {u:".github/workflows/release.yaml",           l:1054},
+                            {u:".github/workflows/docfx.yaml",             l:59},
+                            {u:".github/workflows/shadow-baseline.yaml",   l:120}
+                          ] as $ignore
+                        | ($ignore | any(.u == $u and .l == $l)) | not
+                      )
+                    )
                   )
-                )
-              ))
+              )
             )
           ' results.sarif > results.filtered.sarif
           mv results.filtered.sarif results.sarif


### PR DESCRIPTION
## Summary

Protected-only expedited PR to `main` — extracts the `scorecard.yaml` jq context fix from PR #351 (which targets vNext) so the **\"Code scanning configuration error — Scorecard is reporting errors\"** banner on the Security overview clears without waiting for the next release cycle.

## Why the split

`scorecard.yaml` is on the protected-files list (Detect .NET Projects guard), so this needs to land as a single-file bypass-merge to `main` per the protected-file-pr-split flow. Non-workflow changes will still ride vNext → main normally via PR #351 (which stays open — after this merges into main, that PR just no-ops on this hunk).

## The fix (identical to PR #351)

`.ruleId` inside a jq pipeline is evaluated against the pipeline's **current input**, not the outer `select` context. The previous form

\`\`\`jq
[\"FuzzingID\",...] | index(.ruleId)
\`\`\`

tried to `.ruleId` the noise-rule LIST itself — under jq 1.8 that raises \"Cannot index array with string 'ruleId'\" and aborts the whole filter (exit 5). `set -e` then aborts the SARIF upload steps that follow, so every finding already open on `refs/heads/main` stays open and no new SARIF is filed. Bind `(.ruleId // \"\") as \$rid` per result; reference `\$rid` in the membership check and TokenPermissionsID guard.

## Verification (local, 2026-08-19 SARIF — last successful upload)

- Pre-filter: 28 findings
- Post-filter: 6 findings (the 6 unjustified TokenPermissionsID sites, as designed)
- All 6 have since been fixed at source in PR #346 (top-level `permissions: read-all` across aot-smoke / workflow-security / benchmarks / integration-status / semgrep), so the next scorecard run after this merges should upload a **0-finding SARIF** and the banner should clear.

## Merge plan

- **Expected**: Detect .NET Projects guard will fail (workflow file changed). Admin-bypass merge, same pattern as PR #346's 7-file sync.
- **After merge**: trigger a scorecard `workflow_dispatch` (or wait for the next Tuesday cron) to verify the filter runs green.

## Test plan
- [x] Same jq fix as PR #351 — verified pre/post finding count locally
- [ ] After bypass-merge: manually trigger scorecard run, confirm exit 0 and \"Filtered SARIF result count: 0\" (all 6 unjustified sites already fixed at source)
- [ ] Security overview banner clears

Umbrella: #328. Companion: #351.