### PR TITLE
refactor: give DbExtractor and DbLoader a single initialization path

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -111,11 +111,15 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         DbTransaction? transaction = null,
         ILogger<DbExtractor<TRecord>>? logger = null
     )
+        : this
+        (
+            connection ?? throw new ArgumentNullException(nameof(connection)),
+            commandText ?? throw new ArgumentNullException(nameof(commandText)),
+            transaction,
+            ownsConnection: false,
+            logger
+        )
     {
-        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
-        _transaction = transaction;
-        _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
 
@@ -143,9 +147,15 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         DbTransaction? transaction = null,
         ILogger<DbExtractor<TRecord>>? logger = null
     )
+        : this
+        (
+            connection ?? throw new ArgumentNullException(nameof(connection)),
+            commandText ?? throw new ArgumentNullException(nameof(commandText)),
+            transaction,
+            ownsConnection: false,
+            logger
+        )
     {
-        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
         if (parameters == null)
         {
             throw new ArgumentNullException(nameof(parameters));
@@ -154,8 +164,6 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         // Defensive copy — see the field-level comment on _parameters.
         _parameters = new Dictionary<string, object>(parameters, StringComparer.Ordinal);
         _dynamicParameters = new DynamicParameters(_parameters);
-        _transaction = transaction;
-        _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
 
@@ -178,11 +186,15 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         DbTransaction? transaction = null,
         ILogger<DbExtractor<TRecord>>? logger = null
     )
+        : this
+        (
+            connection ?? throw new ArgumentNullException(nameof(connection)),
+            DbCommandBuilder.BuildSelect<TRecord>(),
+            transaction,
+            ownsConnection: false,
+            logger
+        )
     {
-        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        _commandText = DbCommandBuilder.BuildSelect<TRecord>();
-        _transaction = transaction;
-        _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
 
@@ -215,10 +227,49 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         string commandText,
         ILogger<DbExtractor<TRecord>>? logger = null
     )
+        : this
+        (
+            CreateOwnedConnection(factory, connectionString, commandText),
+            commandText,
+            transaction: null,
+            ownsConnection: true,
+            logger
+        )
+    {
+    }
+
+
+
+    /// <summary>
+    /// Validates the provider-factory arguments and produces the connection this extractor owns.
+    /// </summary>
+    /// <remarks>
+    /// The validation lives here rather than in the constructor body because a constructor's
+    /// <c>this(...)</c> arguments are evaluated before its body runs. Keeping the checks in this
+    /// order preserves both the original <c>ParamName</c> for each argument and the guarantee that
+    /// no connection is created when any argument is null.
+    /// </remarks>
+    /// <param name="factory">The provider factory used to create the connection.</param>
+    /// <param name="connectionString">The connection string applied to the new connection.</param>
+    /// <param name="commandText">The command text, validated here to preserve argument order.</param>
+    /// <returns>A new <see cref="DbConnection"/> owned by this extractor.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/>, <paramref name="connectionString"/> or
+    /// <paramref name="commandText"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="factory"/> produced a <c>null</c> connection.
+    /// </exception>
+    private static DbConnection CreateOwnedConnection
+    (
+        DbProviderFactory factory,
+        string connectionString,
+        string commandText
+    )
     {
         if (factory == null) throw new ArgumentNullException(nameof(factory));
         if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
-        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+        if (commandText == null) throw new ArgumentNullException(nameof(commandText));
 
         var conn = factory.CreateConnection()
             ?? throw new InvalidOperationException
@@ -227,9 +278,29 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 "The provider factory does not produce DbConnection instances."
             );
         conn.ConnectionString = connectionString;
-        _connection = conn;
-        _ownsConnection = true;
-        _logger = logger ?? (ILogger)NullLogger.Instance;
+        return conn;
+    }
+
+
+
+    /// <summary>
+    /// The single initialization path. Every other constructor chains into this one, so the shared
+    /// fields are assigned in exactly one place and cannot drift between input shapes.
+    /// </summary>
+    private DbExtractor
+    (
+        DbConnection connection,
+        string commandText,
+        DbTransaction? transaction,
+        bool ownsConnection,
+        ILogger? logger
+    )
+    {
+        _connection = connection;
+        _commandText = commandText;
+        _transaction = transaction;
+        _ownsConnection = ownsConnection;
+        _logger = logger ?? NullLogger.Instance;
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -92,12 +92,15 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         DbTransaction? transaction = null,
         ILogger<DbLoader<TRecord>>? logger = null
     )
+        : this
+        (
+            connection ?? throw new ArgumentNullException(nameof(connection)),
+            commandText ?? throw new ArgumentNullException(nameof(commandText)),
+            transaction,
+            ownsConnection: false,
+            logger
+        )
     {
-        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
-        _callerTransaction = transaction;
-        _ownsTransaction = transaction == null;
-        _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
 
@@ -127,14 +130,17 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         DbTransaction? transaction = null,
         ILogger<DbLoader<TRecord>>? logger = null
     )
+        : this
+        (
+            connection ?? throw new ArgumentNullException(nameof(connection)),
+            writeMode == WriteMode.Update
+                ? DbCommandBuilder.BuildUpdate<TRecord>()
+                : DbCommandBuilder.BuildInsert<TRecord>(),
+            transaction,
+            ownsConnection: false,
+            logger
+        )
     {
-        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        _commandText = writeMode == WriteMode.Update
-            ? DbCommandBuilder.BuildUpdate<TRecord>()
-            : DbCommandBuilder.BuildInsert<TRecord>();
-        _callerTransaction = transaction;
-        _ownsTransaction = transaction == null;
-        _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
 
@@ -167,10 +173,49 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         string commandText,
         ILogger<DbLoader<TRecord>>? logger = null
     )
+        : this
+        (
+            CreateOwnedConnection(factory, connectionString, commandText),
+            commandText,
+            transaction: null,
+            ownsConnection: true,
+            logger
+        )
+    {
+    }
+
+
+
+    /// <summary>
+    /// Validates the provider-factory arguments and produces the connection this loader owns.
+    /// </summary>
+    /// <remarks>
+    /// The validation lives here rather than in the constructor body because a constructor's
+    /// <c>this(...)</c> arguments are evaluated before its body runs. Keeping the checks in this
+    /// order preserves both the original <c>ParamName</c> for each argument and the guarantee that
+    /// no connection is created when any argument is null.
+    /// </remarks>
+    /// <param name="factory">The provider factory used to create the connection.</param>
+    /// <param name="connectionString">The connection string applied to the new connection.</param>
+    /// <param name="commandText">The command text, validated here to preserve argument order.</param>
+    /// <returns>A new <see cref="DbConnection"/> owned by this loader.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/>, <paramref name="connectionString"/> or
+    /// <paramref name="commandText"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="factory"/> produced a <c>null</c> connection.
+    /// </exception>
+    private static DbConnection CreateOwnedConnection
+    (
+        DbProviderFactory factory,
+        string connectionString,
+        string commandText
+    )
     {
         if (factory == null) throw new ArgumentNullException(nameof(factory));
         if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
-        _commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+        if (commandText == null) throw new ArgumentNullException(nameof(commandText));
 
         var conn = factory.CreateConnection()
             ?? throw new InvalidOperationException
@@ -179,10 +224,36 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
                 "The provider factory does not produce DbConnection instances."
             );
         conn.ConnectionString = connectionString;
-        _connection = conn;
-        _ownsConnection = true;
-        _ownsTransaction = true;  // auto-managed transaction inside the owned connection
-        _logger = logger ?? (ILogger)NullLogger.Instance;
+        return conn;
+    }
+
+
+
+    /// <summary>
+    /// The single initialization path. Every other constructor chains into this one, so the shared
+    /// fields are assigned in exactly one place and cannot drift between input shapes.
+    /// </summary>
+    /// <remarks>
+    /// <c>_ownsTransaction</c> is derived here rather than passed in. The two connection-based
+    /// constructors set it to <c>transaction == null</c>, and the provider-factory constructor set
+    /// it unconditionally to <c>true</c> while supplying no transaction — so the single derivation
+    /// below reproduces all three cases exactly.
+    /// </remarks>
+    private DbLoader
+    (
+        DbConnection connection,
+        string commandText,
+        DbTransaction? transaction,
+        bool ownsConnection,
+        ILogger? logger
+    )
+    {
+        _connection = connection;
+        _commandText = commandText;
+        _callerTransaction = transaction;
+        _ownsTransaction = transaction is null;
+        _ownsConnection = ownsConnection;
+        _logger = logger ?? NullLogger.Instance;
     }
 
 


### PR DESCRIPTION
First step of the constructor-standard work for this repo. **Rule 5 only** — no API change, no behaviour change, no deprecation.

## Where DbClient stands against the standard

Surveyed before touching anything:

| rule | state |
|---|---|
| **Rule 6** — logger last and optional | ✅ already met on all 7 constructors |
| **Rule 5** — single initialization path | ❌ **this PR** |
| **Rule 2** — configuration via options records | ❌ 19 settable properties (9 extractor, 10 loader) — separate PR |

## What changes

`DbExtractor`'s four constructors and `DbLoader`'s three each assigned the shared fields independently — seven copies of the same setup, each free to drift. They now chain into one private constructor per type.

## Three things a careless version of this would have broken

**`ParamName` is preserved.** Every boundary constructor keeps its own `?? throw new ArgumentNullException(nameof(x))`; the core assigns plainly. Routing the guards *through* the core instead would make a null `connection` report a parameter the caller never passed — the defect found by review on Chris-Wolfgang/ETL-FixedWidth#335.

**Validation order survives, including a side effect.** The provider-factory constructors validated `factory` → `connectionString` → `commandText` **before** creating a connection. A constructor's `this(...)` arguments are evaluated before its body, so moving those checks into the body would have created — and leaked — a connection whenever `commandText` was null. They now live in a `CreateOwnedConnection` helper that runs first.

**`DbLoader._ownsTransaction` is derived rather than passed.** The two connection constructors set it to `transaction == null`; the provider-factory constructor set it unconditionally to `true` while supplying no transaction. `transaction is null` reproduces all three cases exactly, and the core documents that so it is not mistaken for a dropped case.

## This is prevention, not a fix

I checked whether the existing divergence was already a live bug. **It is not.** `_ownsConnection` is set only by the factory constructors, `_parameters` / `_dynamicParameters` only by the parameterised overload, and each maps to a genuinely different input shape. The value here is removing the shape that permitted drift — the same shape produced two shipped bugs elsewhere in the fleet (an ETL-Xml `LeaveOpen` flag one constructor set and another didn't; an ETL-FixedWidth internal constructor that hard-coded UTF-8 while its public counterpart honoured the caller's encoding).

## Verification

- Release build clean
- **20 project × TFM combinations — 314 unit tests per TFM plus 42 integration, 0 failures**

The suite carries **40 constructor-named tests across 5 files asserting `ArgumentNullException`**, so the `ParamName` behaviour above is covered by tests rather than merely claimed.

## Not in this PR

Options records and setter deprecation (Rule 2) — that is the larger change and gets its own review, following the split that worked on Etl-Csv (#258 additive, then #259 deprecating).

Also noted while surveying, worth its own issue: **`DbClientOptions.StrictColumnMapping` is global mutable static state** that affects column-mapping behaviour process-wide. That is arguably a worse problem than the instance properties Rule 2 targets, and it is untouched here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>