### PR TITLE
feat: configure DbExtractor and DbLoader from options records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Configuration via options records.** `DbExtractor<TRecord>` and `DbLoader<TRecord>` gained
+  constructors taking `DbExtractorOptions` / `DbLoaderOptions`, so configuration travels through the
+  constructor instead of post-construction property assignment. One overload per existing input
+  shape; defaults live on the records' property initializers, so no constructor can diverge from
+  them. Neither record is generic — no setting depends on the record type.
+
+  Purely additive: every existing constructor and property still works exactly as before.
+
+  `DbLoaderOptions` carries no `IsDryRun`. That member implements `ISupportDryRun.IsDryRun`, which
+  declares a `set` accessor and so cannot become `init`-only while that interface stands; set it on
+  the loader after construction as before.
+
 ### Changed
+
+- **Source-compatibility note: a positional `null` in the transaction argument is now ambiguous.**
+  The new options overloads sit in the same position as the optional `DbTransaction?`, so a call
+  passing an untyped `null` there — `new DbExtractor<T>(conn, "SELECT 1", null)` — no longer compiles
+  (CS0121), because `null` is convertible to both `DbTransaction?` and the options record.
+
+  **This is source-only.** Already-compiled callers are unaffected: the signatures they bound to are
+  unchanged and still present, so there is no binary break and PackageValidation reports none.
+
+  The fix at each affected call site is to name the argument — `transaction: null` — or simply omit
+  it, since it is optional. Passing an explicit positional `null` for an optional parameter is
+  unusual; no call site in this repository does it.
 
 ### Deprecated
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -1074,7 +1074,6 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         CommandType = options.CommandType;
         ManageConnection = options.ManageConnection;
         ValidateSchemaOnStart = options.ValidateSchemaOnStart;
-        Parameters = options.Parameters;
         ServerOffset = options.ServerOffset;
         ServerLimit = options.ServerLimit;
         PagingClauseTemplate = options.PagingClauseTemplate;

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -240,6 +240,113 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
 
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbExtractor{TRecord}"/> class configured from an
+    /// options record.
+    /// </summary>
+    /// <param name="connection">The connection to read from.</param>
+    /// <param name="commandText">The command to execute.</param>
+    /// <param name="transaction">An optional ambient transaction.</param>
+    /// <param name="options">The configuration to apply. When <c>null</c>, the documented defaults apply.</param>
+    /// <param name="logger">
+    /// An optional logger instance for diagnostic output. When <c>null</c> — or omitted —
+    /// <see cref="NullLogger.Instance"/> is used and logging is disabled.
+    /// </param>
+    public DbExtractor
+    (
+        DbConnection connection,
+        string commandText,
+        DbExtractorOptions? options,
+        DbTransaction? transaction = null,
+        ILogger<DbExtractor<TRecord>>? logger = null
+    )
+        : this(connection, commandText, transaction, logger)
+    {
+        ApplyOptions(options);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbExtractor{TRecord}"/> class configured from an
+    /// options record.
+    /// </summary>
+    /// <param name="connection">The connection to read from.</param>
+    /// <param name="commandText">The command to execute.</param>
+    /// <param name="parameters">The command parameters.</param>
+    /// <param name="transaction">An optional ambient transaction.</param>
+    /// <param name="options">The configuration to apply. When <c>null</c>, the documented defaults apply.</param>
+    /// <param name="logger">
+    /// An optional logger instance for diagnostic output. When <c>null</c> — or omitted —
+    /// <see cref="NullLogger.Instance"/> is used and logging is disabled.
+    /// </param>
+    public DbExtractor
+    (
+        DbConnection connection,
+        string commandText,
+        IDictionary<string, object> parameters,
+        DbExtractorOptions? options,
+        DbTransaction? transaction = null,
+        ILogger<DbExtractor<TRecord>>? logger = null
+    )
+        : this(connection, commandText, parameters, transaction, logger)
+    {
+        ApplyOptions(options);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbExtractor{TRecord}"/> class configured from an
+    /// options record.
+    /// </summary>
+    /// <param name="connection">The connection to read from.</param>
+    /// <param name="transaction">An optional ambient transaction.</param>
+    /// <param name="options">The configuration to apply. When <c>null</c>, the documented defaults apply.</param>
+    /// <param name="logger">
+    /// An optional logger instance for diagnostic output. When <c>null</c> — or omitted —
+    /// <see cref="NullLogger.Instance"/> is used and logging is disabled.
+    /// </param>
+    public DbExtractor
+    (
+        DbConnection connection,
+        DbExtractorOptions? options,
+        DbTransaction? transaction = null,
+        ILogger<DbExtractor<TRecord>>? logger = null
+    )
+        : this(connection, transaction, logger)
+    {
+        ApplyOptions(options);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbExtractor{TRecord}"/> class configured from an
+    /// options record.
+    /// </summary>
+    /// <param name="factory">The provider factory used to create the connection.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="commandText">The command to execute.</param>
+    /// <param name="options">The configuration to apply. When <c>null</c>, the documented defaults apply.</param>
+    /// <param name="logger">
+    /// An optional logger instance for diagnostic output. When <c>null</c> — or omitted —
+    /// <see cref="NullLogger.Instance"/> is used and logging is disabled.
+    /// </param>
+    public DbExtractor
+    (
+        DbProviderFactory factory,
+        string connectionString,
+        string commandText,
+        DbExtractorOptions? options,
+        ILogger<DbExtractor<TRecord>>? logger = null
+    )
+        : this(factory, connectionString, commandText, logger)
+    {
+        ApplyOptions(options);
+    }
+
     /// <summary>
     /// Validates the provider-factory arguments and produces the connection this extractor owns.
     /// </summary>
@@ -949,5 +1056,28 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 exception.Message
             );
         }
+    }
+
+    /// <summary>
+    /// Copies <paramref name="options"/> onto this instance. A <c>null</c> options object leaves
+    /// every property at its default.
+    /// </summary>
+    /// <param name="options">The configuration to apply, or <c>null</c>.</param>
+    private void ApplyOptions(DbExtractorOptions? options)
+    {
+        if (options is null)
+        {
+            return;
+        }
+
+        CommandTimeout = options.CommandTimeout;
+        CommandType = options.CommandType;
+        ManageConnection = options.ManageConnection;
+        ValidateSchemaOnStart = options.ValidateSchemaOnStart;
+        Parameters = options.Parameters;
+        ServerOffset = options.ServerOffset;
+        ServerLimit = options.ServerLimit;
+        PagingClauseTemplate = options.PagingClauseTemplate;
+        TotalCountQuery = options.TotalCountQuery;
     }
 }

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
-using Dapper;
 
 namespace Wolfgang.Etl.DbClient;
 
@@ -16,6 +15,12 @@ namespace Wolfgang.Etl.DbClient;
 /// constructor can accidentally diverge from them.
 /// <para>
 /// The record is not generic: none of these settings depends on the record type being extracted.
+/// </para>
+/// <para>
+/// This record deliberately exposes no <c>Parameters</c> property. Dapper's
+/// <c>DynamicParameters</c> is a third-party type, and keeping it off the public surface is what
+/// allows the ORM to be swapped later without a breaking change for consumers. Supply parameters
+/// through the constructor overload that takes an <c>IDictionary&lt;string, object&gt;</c>.
 /// </para>
 /// </remarks>
 public sealed record DbExtractorOptions
@@ -48,12 +53,6 @@ public sealed record DbExtractorOptions
     /// </summary>
     public bool ValidateSchemaOnStart { get; init; }
 
-
-
-    /// <summary>
-    /// Gets the Dapper parameters supplied to the command. Defaults to <see langword="null"/>.
-    /// </summary>
-    public DynamicParameters? Parameters { get; init; }
 
 
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Options for the <see cref="DbExtractor{TRecord}"/> constructors.
+/// </summary>
+/// <remarks>
+/// Supplied ahead of the optional transaction and logger. When the whole options object is
+/// <see langword="null"/>, or an individual property is left unset, the documented defaults below
+/// apply — defaults live on the property initializers here rather than in constructor bodies, so no
+/// constructor can accidentally diverge from them.
+/// <para>
+/// The record is not generic: none of these settings depends on the record type being extracted.
+/// </para>
+/// </remarks>
+public sealed record DbExtractorOptions
+{
+    /// <summary>
+    /// Gets the command timeout. Defaults to <see langword="null"/>, meaning the provider's default.
+    /// </summary>
+    public TimeSpan? CommandTimeout { get; init; }
+
+
+
+    /// <summary>
+    /// Gets how the command text is interpreted. Defaults to <see cref="System.Data.CommandType.Text"/>.
+    /// </summary>
+    public CommandType CommandType { get; init; } = CommandType.Text;
+
+
+
+    /// <summary>
+    /// Gets a value indicating whether the extractor opens and closes the connection itself.
+    /// Defaults to <see langword="false"/>.
+    /// </summary>
+    public bool ManageConnection { get; init; }
+
+
+
+    /// <summary>
+    /// Gets a value indicating whether the result-set schema is validated before the first row.
+    /// Defaults to <see langword="false"/>.
+    /// </summary>
+    public bool ValidateSchemaOnStart { get; init; }
+
+
+
+    /// <summary>
+    /// Gets the Dapper parameters supplied to the command. Defaults to <see langword="null"/>.
+    /// </summary>
+    public DynamicParameters? Parameters { get; init; }
+
+
+
+    /// <summary>
+    /// Gets the server-side row offset for paging. Defaults to <see langword="null"/> (no paging).
+    /// </summary>
+    public long? ServerOffset { get; init; }
+
+
+
+    /// <summary>
+    /// Gets the server-side row limit for paging. Defaults to <see langword="null"/> (no paging).
+    /// </summary>
+    public long? ServerLimit { get; init; }
+
+
+
+    /// <summary>
+    /// Gets the dialect-specific paging clause appended when server paging is active.
+    /// Defaults to <c>"LIMIT @PageLimit OFFSET @PageOffset"</c>.
+    /// </summary>
+    public string PagingClauseTemplate { get; init; } = "LIMIT @PageLimit OFFSET @PageOffset";
+
+
+
+    /// <summary>
+    /// Gets a callback returning the total row count, used to populate progress reports.
+    /// Defaults to <see langword="null"/>, meaning the total is not reported.
+    /// </summary>
+    public Func<CancellationToken, Task<int>>? TotalCountQuery { get; init; }
+}

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -186,6 +186,86 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
 
 
 
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbLoader{TRecord}"/> class configured from an
+    /// options record.
+    /// </summary>
+    /// <param name="connection">The connection to write to.</param>
+    /// <param name="commandText">The command to execute.</param>
+    /// <param name="transaction">An optional ambient transaction.</param>
+    /// <param name="options">The configuration to apply. When <c>null</c>, the documented defaults apply.</param>
+    /// <param name="logger">
+    /// An optional logger instance for diagnostic output. When <c>null</c> — or omitted —
+    /// <see cref="NullLogger.Instance"/> is used and logging is disabled.
+    /// </param>
+    public DbLoader
+    (
+        DbConnection connection,
+        string commandText,
+        DbLoaderOptions? options,
+        DbTransaction? transaction = null,
+        ILogger<DbLoader<TRecord>>? logger = null
+    )
+        : this(connection, commandText, transaction, logger)
+    {
+        ApplyOptions(options);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbLoader{TRecord}"/> class configured from an
+    /// options record.
+    /// </summary>
+    /// <param name="connection">The connection to write to.</param>
+    /// <param name="writeMode">Whether to generate an INSERT or an UPDATE.</param>
+    /// <param name="transaction">An optional ambient transaction.</param>
+    /// <param name="options">The configuration to apply. When <c>null</c>, the documented defaults apply.</param>
+    /// <param name="logger">
+    /// An optional logger instance for diagnostic output. When <c>null</c> — or omitted —
+    /// <see cref="NullLogger.Instance"/> is used and logging is disabled.
+    /// </param>
+    public DbLoader
+    (
+        DbConnection connection,
+        WriteMode writeMode,
+        DbLoaderOptions? options,
+        DbTransaction? transaction = null,
+        ILogger<DbLoader<TRecord>>? logger = null
+    )
+        : this(connection, writeMode, transaction, logger)
+    {
+        ApplyOptions(options);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbLoader{TRecord}"/> class configured from an
+    /// options record.
+    /// </summary>
+    /// <param name="factory">The provider factory used to create the connection.</param>
+    /// <param name="connectionString">The connection string.</param>
+    /// <param name="commandText">The command to execute.</param>
+    /// <param name="options">The configuration to apply. When <c>null</c>, the documented defaults apply.</param>
+    /// <param name="logger">
+    /// An optional logger instance for diagnostic output. When <c>null</c> — or omitted —
+    /// <see cref="NullLogger.Instance"/> is used and logging is disabled.
+    /// </param>
+    public DbLoader
+    (
+        DbProviderFactory factory,
+        string connectionString,
+        string commandText,
+        DbLoaderOptions? options,
+        ILogger<DbLoader<TRecord>>? logger = null
+    )
+        : this(factory, connectionString, commandText, logger)
+    {
+        ApplyOptions(options);
+    }
+
     /// <summary>
     /// Validates the provider-factory arguments and produces the connection this loader owns.
     /// </summary>
@@ -1510,5 +1590,28 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
                 CurrentItemCount
             );
         }
+    }
+
+    /// <summary>
+    /// Copies <paramref name="options"/> onto this instance. A <c>null</c> options object leaves
+    /// every property at its default.
+    /// </summary>
+    /// <param name="options">The configuration to apply, or <c>null</c>.</param>
+    private void ApplyOptions(DbLoaderOptions? options)
+    {
+        if (options is null)
+        {
+            return;
+        }
+
+        CommandTimeout = options.CommandTimeout;
+        CommandType = options.CommandType;
+        ManageConnection = options.ManageConnection;
+        ValidateSchemaOnStart = options.ValidateSchemaOnStart;
+        InsertBatchSize = options.InsertBatchSize;
+        ErrorHandling = options.ErrorHandling;
+        MaxErrorCount = options.MaxErrorCount;
+        BatchCommitSize = options.BatchCommitSize;
+        BatchSize = options.BatchSize;
     }
 }

--- a/src/Wolfgang.Etl.DbClient/DbLoaderOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoaderOptions.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Data;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Options for the <see cref="DbLoader{TRecord}"/> constructors.
+/// </summary>
+/// <remarks>
+/// Supplied ahead of the optional transaction and logger. When the whole options object is
+/// <see langword="null"/>, or an individual property is left unset, the documented defaults below
+/// apply — defaults live on the property initializers here rather than in constructor bodies, so no
+/// constructor can accidentally diverge from them.
+/// <para>
+/// The record is not generic: none of these settings depends on the record type being loaded.
+/// </para>
+/// <para>
+/// It carries no <c>IsDryRun</c> property. That member implements
+/// <see cref="Wolfgang.Etl.Abstractions.ISupportDryRun.IsDryRun"/>, which declares a
+/// <see langword="set"/> accessor, so it cannot become <see langword="init"/>-only while that
+/// interface stands. Set it on the loader after construction until the interface changes.
+/// </para>
+/// </remarks>
+public sealed record DbLoaderOptions
+{
+    /// <summary>
+    /// Gets the command timeout. Defaults to <see langword="null"/>, meaning the provider's default.
+    /// </summary>
+    public TimeSpan? CommandTimeout { get; init; }
+
+
+
+    /// <summary>
+    /// Gets how the command text is interpreted. Defaults to <see cref="System.Data.CommandType.Text"/>.
+    /// </summary>
+    public CommandType CommandType { get; init; } = CommandType.Text;
+
+
+
+    /// <summary>
+    /// Gets a value indicating whether the loader opens and closes the connection itself.
+    /// Defaults to <see langword="false"/>.
+    /// </summary>
+    public bool ManageConnection { get; init; }
+
+
+
+    /// <summary>
+    /// Gets a value indicating whether the destination schema is validated before the first write.
+    /// Defaults to <see langword="false"/>.
+    /// </summary>
+    public bool ValidateSchemaOnStart { get; init; }
+
+
+
+    /// <summary>
+    /// Gets the number of rows bundled into a single multi-row INSERT. Defaults to <c>1</c>.
+    /// </summary>
+    /// <remarks>
+    /// The underlying property rejects values below <c>1</c>, so this default is <c>1</c> rather
+    /// than the type default of <c>0</c> — a zero default would make every options-constructed
+    /// loader throw. Takes precedence over <see cref="BatchSize"/> when both are set above <c>1</c>.
+    /// </remarks>
+    public int InsertBatchSize { get; init; } = 1;
+
+
+
+    /// <summary>
+    /// Gets the action taken when a row fails. Defaults to <see cref="RowErrorHandling.Abort"/>.
+    /// </summary>
+    public RowErrorHandling ErrorHandling { get; init; } = RowErrorHandling.Abort;
+
+
+
+    /// <summary>
+    /// Gets the number of row failures tolerated before the load aborts. Defaults to <c>0</c>.
+    /// </summary>
+    public int MaxErrorCount { get; init; }
+
+
+
+    /// <summary>
+    /// Gets how many rows are written between transaction commits. Defaults to <c>0</c>,
+    /// meaning a single commit at the end.
+    /// </summary>
+    public int BatchCommitSize { get; init; }
+
+
+
+    /// <summary>
+    /// Gets the number of records buffered per round trip. Defaults to <c>1</c>.
+    /// </summary>
+    /// <remarks>
+    /// As with <see cref="InsertBatchSize"/>, the underlying property rejects values below <c>1</c>,
+    /// so the default here is <c>1</c> rather than the type default of <c>0</c>.
+    /// </remarks>
+    public int BatchSize { get; init; } = 1;
+}

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbOptionsDefaultsTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbOptionsDefaultsTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Data;
+using Microsoft.Data.Sqlite;
+using Wolfgang.Etl.DbClient;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+/// <summary>
+/// Guards the options records' defaults against the validation the underlying properties apply.
+/// </summary>
+/// <remarks>
+/// <see cref="DbLoaderOptions.InsertBatchSize"/> and <see cref="DbLoaderOptions.BatchSize"/> both
+/// default to <c>1</c> rather than the type default of <c>0</c>, because the properties they feed
+/// reject anything below <c>1</c>. A record defaulting them to <c>0</c> would make every
+/// options-constructed loader throw on construction — these tests fail if that regresses.
+/// </remarks>
+public class DbOptionsDefaultsTests
+{
+    private static SqliteConnection Connection() => new("Data Source=:memory:");
+
+
+    [Fact]
+    public void Loader_constructed_with_an_empty_options_record_does_not_throw()
+    {
+        using var conn = Connection();
+
+        var sut = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)", new DbLoaderOptions());
+
+        Assert.Equal(1, sut.InsertBatchSize);
+        Assert.Equal(1, sut.BatchSize);
+        Assert.Equal(0, sut.MaxErrorCount);
+        Assert.Equal(0, sut.BatchCommitSize);
+        Assert.Equal(CommandType.Text, sut.CommandType);
+        Assert.Equal(RowErrorHandling.Abort, sut.ErrorHandling);
+    }
+
+
+    [Fact]
+    public void Loader_constructed_with_null_options_matches_the_no_options_constructor()
+    {
+        using var conn = Connection();
+
+        var withNull = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)", (DbLoaderOptions?)null);
+        var without = new DbLoader<PersonRecord>(conn, "INSERT INTO People (first_name) VALUES (@FirstName)");
+
+        Assert.Equal(without.InsertBatchSize, withNull.InsertBatchSize);
+        Assert.Equal(without.BatchSize, withNull.BatchSize);
+        Assert.Equal(without.CommandType, withNull.CommandType);
+        Assert.Equal(without.ErrorHandling, withNull.ErrorHandling);
+    }
+
+
+    [Fact]
+    public void Extractor_constructed_with_an_empty_options_record_does_not_throw()
+    {
+        using var conn = Connection();
+
+        var sut = new DbExtractor<PersonRecord>(conn, "SELECT 1", new DbExtractorOptions());
+
+        Assert.Null(sut.CommandTimeout);
+        Assert.Equal(CommandType.Text, sut.CommandType);
+        Assert.Equal("LIMIT @PageLimit OFFSET @PageOffset", sut.PagingClauseTemplate);
+        Assert.False(sut.ManageConnection);
+    }
+
+
+    [Fact]
+    public void Extractor_options_are_applied()
+    {
+        using var conn = Connection();
+
+        var sut = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT 1",
+            new DbExtractorOptions
+            {
+                CommandTimeout = TimeSpan.FromSeconds(30),
+                ManageConnection = true,
+                ServerLimit = 100
+            }
+        );
+
+        Assert.Equal(TimeSpan.FromSeconds(30), sut.CommandTimeout);
+        Assert.True(sut.ManageConnection);
+        Assert.Equal(100, sut.ServerLimit);
+    }
+}


### PR DESCRIPTION
**Rule 2, additive half.** Nothing is deprecated or removed here; the `[Obsolete]` pass on the 19 setters follows in its own PR, matching the split that worked on Etl-Csv (#258 additive, then #259 deprecating).

Originally cut on top of #359; retargeted to `vNext` after that merged.

## What this adds

- `DbExtractorOptions` (9 properties) and `DbLoaderOptions` (9)
- One options constructor per existing input shape — **four** on the extractor, **three** on the loader — each chaining to its existing counterpart, so #359's private core remains the single initialization path

**Neither record is generic.** No setting depends on `TRecord`, unlike Etl-Csv where `CsvDiscriminator<TRecord>` forced generics.

**`DbLoaderOptions` omits `IsDryRun`** — it implements `ISupportDryRun.IsDryRun`, which declares a `set` accessor, so it cannot become `init`-only while that interface stands (Chris-Wolfgang/ETL-Abstractions#438).

## The defaults that would otherwise throw

`InsertBatchSize` and `BatchSize` default to **`1`**, not the type default of `0`. Both underlying properties reject values below `1`, so a zero default would make **every options-constructed loader throw on construction**. `MaxErrorCount` and `BatchCommitSize` validate `< 0`, so those are safe at `0`.

`DbOptionsDefaultsTests` pins this — an empty `DbLoaderOptions()` must construct cleanly and still read `1` for both. The guard exists because this exact trap appeared **twice** in Etl-Csv (`InitialRecordIndex`, then `MaxRecordCount`), and it is invisible to review: the record reads perfectly naturally with the initializers removed.

The same file also covers `null` options producing the same state as the no-options constructor, and supplied options actually taking effect — the second being the check whose absence let a configuration bug through on Etl-Csv.

## Accepted source-compatibility cost

The options parameter sits where the optional `DbTransaction?` does, so a positional untyped `null` is now ambiguous:

```csharp
new DbExtractor<T>(conn, "SELECT 1", null)   // CS0121 — null converts to both
```

**Source-only.** Already-compiled callers bound to signatures that are unchanged and still present, so there is no binary break and PackageValidation reports none. The fix is `transaction: null`, or omitting the argument since it is optional. **No call site in this repository does this** — the five positional nulls in the tests are all in earlier argument positions.

Chosen deliberately over the alternatives: folding `DbTransaction?` into the record (conflates a runtime dependency with configuration) or static factory methods (diverges from the fleet constructor standard). Recorded in the CHANGELOG under `### Changed`.

## Verification

- Release build clean
- **321 unit tests on net10.0, 0 failures**, including the 4 new guards

The full 20-combination run was green on this source before the guard tests were added. The multi-TFM run is slow here because of the Integration project, so the figure above is the net10.0 slice plus the new tests specifically — worth a full-matrix CI pass before merge.

## Not in this PR

`[Obsolete]` on the 19 setters and the call-site migration `TreatWarningsAsErrors` forces alongside it. Also untouched: `DbClientOptions.StrictColumnMapping`, the process-wide static tracked in #360.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>