### PR TITLE
refactor!: deprecate the constructors superseded by the options overloads

### DIFF
--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/ExtractorBenchmarks.cs
@@ -4,6 +4,11 @@ using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using JetBrains.Annotations;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Benchmarks;
 
 /// <summary>

--- a/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.DbClient.Benchmarks/LoaderBenchmarks.cs
@@ -5,6 +5,11 @@ using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using JetBrains.Annotations;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Benchmarks;
 
 /// <summary>

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -104,6 +104,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="connection"/> or <paramref name="commandText"/> is null.
     /// </exception>
+    [Obsolete("Use the constructor that takes DbExtractorOptions. This constructor will be removed in a future release.")]
     public DbExtractor
     (
         DbConnection connection,
@@ -139,6 +140,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="connection"/>, <paramref name="commandText"/>, or <paramref name="parameters"/> is null.
     /// </exception>
+    [Obsolete("Use the constructor that takes DbExtractorOptions. This constructor will be removed in a future release.")]
     public DbExtractor
     (
         DbConnection connection,
@@ -180,6 +182,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// <exception cref="InvalidOperationException">
     /// <typeparamref name="TRecord"/> does not have a <c>[Table]</c> attribute.
     /// </exception>
+    [Obsolete("Use the constructor that takes DbExtractorOptions. This constructor will be removed in a future release.")]
     public DbExtractor
     (
         DbConnection connection,
@@ -220,6 +223,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// <paramref name="factory"/> returned a null connection from
     /// <see cref="DbProviderFactory.CreateConnection"/>.
     /// </exception>
+    [Obsolete("Use the constructor that takes DbExtractorOptions. This constructor will be removed in a future release.")]
     public DbExtractor
     (
         DbProviderFactory factory,
@@ -261,10 +265,12 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         DbTransaction? transaction = null,
         ILogger<DbExtractor<TRecord>>? logger = null
     )
+#pragma warning disable CS0618 // Chains into the deprecated ctor deliberately: it is the single initialization path.
         : this(connection, commandText, transaction, logger)
     {
         ApplyOptions(options);
     }
+#pragma warning restore CS0618
 
 
 
@@ -290,10 +296,12 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         DbTransaction? transaction = null,
         ILogger<DbExtractor<TRecord>>? logger = null
     )
+#pragma warning disable CS0618 // Chains into the deprecated ctor deliberately: it is the single initialization path.
         : this(connection, commandText, parameters, transaction, logger)
     {
         ApplyOptions(options);
     }
+#pragma warning restore CS0618
 
 
 
@@ -315,10 +323,12 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         DbTransaction? transaction = null,
         ILogger<DbExtractor<TRecord>>? logger = null
     )
+#pragma warning disable CS0618 // Chains into the deprecated ctor deliberately: it is the single initialization path.
         : this(connection, transaction, logger)
     {
         ApplyOptions(options);
     }
+#pragma warning restore CS0618
 
 
 
@@ -342,10 +352,12 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         DbExtractorOptions? options,
         ILogger<DbExtractor<TRecord>>? logger = null
     )
+#pragma warning disable CS0618 // Chains into the deprecated ctor deliberately: it is the single initialization path.
         : this(factory, connectionString, commandText, logger)
     {
         ApplyOptions(options);
     }
+#pragma warning restore CS0618
 
     /// <summary>
     /// Validates the provider-factory arguments and produces the connection this extractor owns.

--- a/src/Wolfgang.Etl.DbClient/DbLoader.cs
+++ b/src/Wolfgang.Etl.DbClient/DbLoader.cs
@@ -85,6 +85,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
     /// <exception cref="ArgumentNullException">
     /// <paramref name="connection"/> or <paramref name="commandText"/> is null.
     /// </exception>
+    [Obsolete("Use the constructor that takes DbLoaderOptions. This constructor will be removed in a future release.")]
     public DbLoader
     (
         DbConnection connection,
@@ -123,6 +124,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
     /// <paramref name="writeMode"/> is <see cref="WriteMode.Update"/> and no <c>[Key]</c>
     /// properties exist.
     /// </exception>
+    [Obsolete("Use the constructor that takes DbLoaderOptions. This constructor will be removed in a future release.")]
     public DbLoader
     (
         DbConnection connection,
@@ -166,6 +168,7 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
     /// <paramref name="factory"/> returned a null connection from
     /// <see cref="DbProviderFactory.CreateConnection"/>.
     /// </exception>
+    [Obsolete("Use the constructor that takes DbLoaderOptions. This constructor will be removed in a future release.")]
     public DbLoader
     (
         DbProviderFactory factory,
@@ -207,10 +210,12 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         DbTransaction? transaction = null,
         ILogger<DbLoader<TRecord>>? logger = null
     )
+#pragma warning disable CS0618 // Chains into the deprecated ctor deliberately: it is the single initialization path.
         : this(connection, commandText, transaction, logger)
     {
         ApplyOptions(options);
     }
+#pragma warning restore CS0618
 
 
 
@@ -234,10 +239,12 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         DbTransaction? transaction = null,
         ILogger<DbLoader<TRecord>>? logger = null
     )
+#pragma warning disable CS0618 // Chains into the deprecated ctor deliberately: it is the single initialization path.
         : this(connection, writeMode, transaction, logger)
     {
         ApplyOptions(options);
     }
+#pragma warning restore CS0618
 
 
 
@@ -261,10 +268,12 @@ public class DbLoader<TRecord> : LoaderBase<TRecord, DbReport>, ISupportDryRun
         DbLoaderOptions? options,
         ILogger<DbLoader<TRecord>>? logger = null
     )
+#pragma warning disable CS0618 // Chains into the deprecated ctor deliberately: it is the single initialization path.
         : this(factory, connectionString, commandText, logger)
     {
         ApplyOptions(options);
     }
+#pragma warning restore CS0618
 
     /// <summary>
     /// Validates the provider-factory arguments and produces the connection this loader owns.

--- a/src/Wolfgang.Etl.DbClient/EtlPipelineDbClientExtensions.cs
+++ b/src/Wolfgang.Etl.DbClient/EtlPipelineDbClientExtensions.cs
@@ -78,7 +78,7 @@ public static class EtlPipelineDbClientExtensions
             throw new ArgumentNullException(nameof(commandText));
         }
 
-        var extractor = new DbExtractor<T>(connection, commandText, transaction);
+        var extractor = new DbExtractor<T>(connection, commandText, options: null, transaction);
         return new DbExtractorBuilder<T>(pipeline, extractor);
     }
 
@@ -169,7 +169,7 @@ public static class EtlPipelineDbClientExtensions
             throw new ArgumentNullException(nameof(commandText));
         }
 
-        var loader = new DbLoader<T>(connection, commandText, transaction);
+        var loader = new DbLoader<T>(connection, commandText, options: null, transaction);
         var sink = pipeline.To(loader);
         return new DbLoaderBuilder<T>(sink, loader);
     }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/ExtractorCancellationConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/ExtractorCancellationConcurrencyTests.cs
@@ -28,6 +28,11 @@ using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 // VSTHRD002: `Task.WaitAll` inside a `RunUnderCoyote(Action)` body is
 // intentional — the Coyote scheduler drives the exploration in a
 // synchronous body delegate. Rewriting these joins as `await` would

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/LoaderCancellationConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/LoaderCancellationConcurrencyTests.cs
@@ -28,6 +28,11 @@ using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 // VSTHRD002: `Task.WaitAll` inside a `RunUnderCoyote(Action)` body is
 // intentional — the Coyote scheduler drives the exploration in a
 // synchronous body delegate. Rewriting these joins as `await` would

--- a/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/OwnedConnectionDisposalConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Concurrency/OwnedConnectionDisposalConcurrencyTests.cs
@@ -33,6 +33,11 @@ using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 // VSTHRD002: `Task.WaitAll` inside a `RunUnderCoyote(Action)` body is
 // intentional — the Coyote scheduler drives the exploration in a
 // synchronous body delegate. Rewriting these joins as `await` would

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
@@ -2,6 +2,11 @@ using System.Diagnostics.CodeAnalysis;
 using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Tests.Integration;
 
 /// <summary>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbLoaderIntegrationTestsBase.cs
@@ -2,6 +2,11 @@ using System.Diagnostics.CodeAnalysis;
 using Wolfgang.Etl.DbClient.Tests.Integration.Fixtures;
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Tests.Integration;
 
 /// <summary>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/ColumnAttributeTypeMapperTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/ColumnAttributeTypeMapperTests.cs
@@ -2,6 +2,11 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Tests.Unit;
 
 /// <summary>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/CultureInvarianceTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/CultureInvarianceTests.cs
@@ -39,6 +39,11 @@ using JetBrains.Annotations;
 using Microsoft.Data.Sqlite;
 using Xunit;
 
+
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
 namespace Wolfgang.Etl.DbClient.Tests.Unit;
 
 /// <summary>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorLoggingTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorLoggingTests.cs
@@ -1,6 +1,11 @@
 using Microsoft.Extensions.Logging;
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Tests.Unit;
 
 public class DbExtractorLoggingTests

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderLoggingTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderLoggingTests.cs
@@ -1,6 +1,11 @@
 using Microsoft.Extensions.Logging;
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Tests.Unit;
 
 public class DbLoaderLoggingTests

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderSupportsDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbLoaderSupportsDryRunContractTests.cs
@@ -4,6 +4,11 @@ using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.TestKit.Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Tests.Unit;
 
 /// <summary>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbOptionsDefaultsTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbOptionsDefaultsTests.cs
@@ -4,6 +4,11 @@ using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Tests.Unit;
 
 /// <summary>

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbUpdateTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbUpdateTests.cs
@@ -1,5 +1,10 @@
 using Xunit;
 
+// Constructs via the deprecated constructors. Migrating to the options overloads is
+// follow-up work; the deprecation exists to warn consumers, and the options constructors
+// are covered by DbOptionsDefaultsTests.
+#pragma warning disable CS0618
+
 namespace Wolfgang.Etl.DbClient.Tests.Unit;
 
 public class DbUpdateTests

--- a/tools/GcProfileWorkload/Program.cs
+++ b/tools/GcProfileWorkload/Program.cs
@@ -21,6 +21,11 @@ using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
 using Wolfgang.Etl.DbClient.Tools.GcProfileWorkload;
 
+// Constructs via the deprecated constructors; migrating to the options overloads is
+// follow-up work. Anchored here rather than relying on the suppression lower in this file,
+// which begins after these call sites.
+#pragma warning disable CS0618
+
 const int rowsPerBatch = 5_000;
 var durationSeconds = ParseDuration(args);
 
@@ -124,6 +129,13 @@ static async IAsyncEnumerable<Widget> GenerateBatch(int count)
         }
     }
 }
+
+// This file still configures through the deprecated property setters. Migrating it to the
+// options constructors is follow-up work, tracked separately - the deprecation's purpose is
+// to warn consumers, and the options constructors are covered by DbOptionsDefaultsTests.
+// Several sites here assign after construction, so they cannot move to a constructor without
+// restructuring the test.
+#pragma warning disable CS0618
 
 namespace Wolfgang.Etl.DbClient.Tools.GcProfileWorkload
 {


### PR DESCRIPTION
Stacked on #362. Separated from the setter deprecation deliberately — same release and same warning wave for consumers, but properties and constructors are different axes and each diff stays reviewable.

## What changes

All **seven** pre-options public constructors marked `[Obsolete]`, each naming the overload that supersedes it:

| deprecated | superseded by |
|---|---|
| `DbExtractor(connection, commandText, …)` | the options overload at the same shape |
| `DbExtractor(connection, commandText, parameters, …)` | ditto |
| `DbExtractor(connection, …)` | ditto |
| `DbExtractor(factory, connectionString, commandText, …)` | ditto |
| `DbLoader(connection, commandText, …)` | ditto |
| `DbLoader(connection, writeMode, …)` | ditto |
| `DbLoader(factory, connectionString, commandText, …)` | ditto |

## The chaining detail

The options constructors chain **into** the ones now deprecated, so they would emit `CS0618` against themselves. Each chain site carries a suppression stating the chain is deliberate: it is the single initialization path from #359, and duplicating the setup to silence the warning would reintroduce precisely the drift that change removed. Pair balance is asserted per file.

## Two things deliberately deferred

Both blocked by the same constraint — **`[Obsolete]` members still participate in overload resolution**, so a collision they cause survives deprecation and clears only on deletion:

1. **Combining the `(commandText)` and `(commandText, parameters)` options overloads** by making `parameters` optional
2. **Making `options` itself optional**

Verified by compiling the collision rather than reasoning about it — an `[Obsolete]` ctor alongside an all-optional-tail ctor gives `CS0121` on the plain call:

```
error CS0121: ambiguous between 'Probe(string, int?, string?)'
                            and 'Probe(string, IDictionary<string,object>?, Opts?, int?, string?)'
```

An earlier probe on the real code made `options` optional on one constructor and produced **106 `CS0121` errors** in the unit tests alone. Both changes belong in the removal release.

## Migration

- **2 `src` sites genuinely migrated** — `EtlPipelineDbClientExtensions` now calls the options overloads with `options: null`. Those extension methods expose no options surface of their own; forwarding one is worth a follow-up.
- **Test / example / benchmark / tool files carry file-scoped suppressions.** This wave reached **15 files the setter deprecation did not**, because many tests construct without ever setting a property. Migrating them is follow-up work, recorded in each suppression rather than left implicit.

## Verification

Release build clean; **20 project × TFM combinations, 0 failures** — 321 unit tests on net10.0, 318 on net462, 42 integration on each of net10.0/net8.0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>