### PR TITLE
fix(ci): fail loudly when integration tests skip instead of running

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -969,6 +969,7 @@ jobs:
           fi
 
       - name: Verify Docker is available
+        if: steps.locate.outputs.found == 'true'
         # Preflight so an unavailable daemon fails LOUDLY here. Without it the
         # fixtures degrade to Skip.IfNot(...) on every test, dotnet test exits 0,
         # and the whole chain reports success with zero DB round-trips (#357).
@@ -993,6 +994,7 @@ jobs:
 
 
       - name: Assert integration tests actually ran
+        if: steps.locate.outputs.found == 'true'
         # Second guard, independent of the Docker preflight: a run where every
         # test reported Skipped exits 0 and looks identical to a passing run.
         # Fail if nothing executed, or if anything was skipped on CI.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -968,6 +968,14 @@ jobs:
             echo "project=$proj" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify Docker is available
+        # Preflight so an unavailable daemon fails LOUDLY here. Without it the
+        # fixtures degrade to Skip.IfNot(...) on every test, dotnet test exits 0,
+        # and the whole chain reports success with zero DB round-trips (#357).
+        run: |
+          docker version
+          docker info
+
       - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
         if: steps.locate.outputs.found == 'true'
         run: |
@@ -982,6 +990,36 @@ jobs:
             --logger "console;verbosity=normal" \
             --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
             --results-directory "./TestResults-Integration"
+
+
+      - name: Assert integration tests actually ran
+        # Second guard, independent of the Docker preflight: a run where every
+        # test reported Skipped exits 0 and looks identical to a passing run.
+        # Fail if nothing executed, or if anything was skipped on CI.
+        shell: bash
+        run: |
+          trx=$(find . -name 'integration-*.trx' -print -quit)
+          if [ -z "$trx" ]; then
+            echo "::error::No .trx produced - the integration run did not execute."
+            exit 1
+          fi
+          python - "$trx" <<'PY'
+          import re, sys, xml.etree.ElementTree as ET
+          root = ET.parse(sys.argv[1]).getroot()
+          ns = {'t': re.match(r'\{(.*)\}', root.tag).group(1)} if root.tag.startswith('{') else {}
+          c = root.find('.//t:Counters', ns) if ns else root.find('.//Counters')
+          if c is None:
+              print('::error::No <Counters> in the .trx - cannot verify the run.'); sys.exit(1)
+          total = int(c.get('total', 0)); executed = int(c.get('executed', 0))
+          passed = int(c.get('passed', 0)); skipped = total - executed
+          print(f'total={total} executed={executed} passed={passed} skipped={skipped}')
+          if total == 0:
+              print('::error::Zero tests in the .trx.'); sys.exit(1)
+          if executed == 0:
+              print('::error::Every test was skipped - Docker or the fixture is unavailable.'); sys.exit(1)
+          if skipped:
+              print(f'::error::{skipped} test(s) skipped on CI; integration tests must not skip here.'); sys.exit(1)
+          PY
 
       - name: Upload integration test results
         if: always() && steps.locate.outputs.found == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -625,6 +625,14 @@ jobs:
             echo "project=$proj" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify Docker is available
+        # Preflight so an unavailable daemon fails LOUDLY here. Without it the
+        # fixtures degrade to Skip.IfNot(...) on every test, dotnet test exits 0,
+        # and the whole chain reports success with zero DB round-trips (#357).
+        run: |
+          docker version
+          docker info
+
       - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
         if: steps.locate.outputs.found == 'true'
         run: |
@@ -636,6 +644,36 @@ jobs:
             --logger "console;verbosity=normal" \
             --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
             --results-directory "./TestResults-Integration"
+
+
+      - name: Assert integration tests actually ran
+        # Second guard, independent of the Docker preflight: a run where every
+        # test reported Skipped exits 0 and looks identical to a passing run.
+        # Fail if nothing executed, or if anything was skipped on CI.
+        shell: bash
+        run: |
+          trx=$(find . -name 'integration-*.trx' -print -quit)
+          if [ -z "$trx" ]; then
+            echo "::error::No .trx produced - the integration run did not execute."
+            exit 1
+          fi
+          python - "$trx" <<'PY'
+          import re, sys, xml.etree.ElementTree as ET
+          root = ET.parse(sys.argv[1]).getroot()
+          ns = {'t': re.match(r'\{(.*)\}', root.tag).group(1)} if root.tag.startswith('{') else {}
+          c = root.find('.//t:Counters', ns) if ns else root.find('.//Counters')
+          if c is None:
+              print('::error::No <Counters> in the .trx - cannot verify the run.'); sys.exit(1)
+          total = int(c.get('total', 0)); executed = int(c.get('executed', 0))
+          passed = int(c.get('passed', 0)); skipped = total - executed
+          print(f'total={total} executed={executed} passed={passed} skipped={skipped}')
+          if total == 0:
+              print('::error::Zero tests in the .trx.'); sys.exit(1)
+          if executed == 0:
+              print('::error::Every test was skipped - Docker or the fixture is unavailable.'); sys.exit(1)
+          if skipped:
+              print(f'::error::{skipped} test(s) skipped on CI; integration tests must not skip here.'); sys.exit(1)
+          PY
 
       - name: Upload integration test results
         if: always() && steps.locate.outputs.found == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -626,6 +626,7 @@ jobs:
           fi
 
       - name: Verify Docker is available
+        if: steps.locate.outputs.found == 'true'
         # Preflight so an unavailable daemon fails LOUDLY here. Without it the
         # fixtures degrade to Skip.IfNot(...) on every test, dotnet test exits 0,
         # and the whole chain reports success with zero DB round-trips (#357).
@@ -647,6 +648,7 @@ jobs:
 
 
       - name: Assert integration tests actually ran
+        if: steps.locate.outputs.found == 'true'
         # Second guard, independent of the Docker preflight: a run where every
         # test reported Skipped exits 0 and looks identical to a passing run.
         # Fail if nothing executed, or if anything was skipped on CI.


### PR DESCRIPTION
Closes #357.

## The gap

`DbProviderFixtureBase.InitializeAsync()` sets `Available = false` and returns without throwing when the Docker probe fails — deliberate, so a dev without Docker gets a clean skip. Every integration test then starts with `Skip.IfNot(Fixture.Available, …)`.

If Docker were ever unavailable **on a runner**, every test for every provider would report `Skipped`, and `dotnet test` exits **0** on an all-skipped run. That is indistinguishable from success all the way up:

- each `test-integration` matrix cell reports `success`
- `test-integration-all` only checks `needs.*.result`, never parses the `.trx` for counts
- `release.yaml` gates `publish-nuget` on the same pair — **a NuGet publish could ship with zero real database round-trips**
- the gh-pages badge flips to `passing`

## Two guards, deliberately independent

**1. Docker preflight** — `docker version && docker info` before the test step, in both `pr.yaml` and `release.yaml`. Matches the pattern already in `AuditTrail`'s `integration.yaml`. Fails immediately instead of degrading into skips.

**2. `.trx` assertion** — after the run, fails when no `.trx` was produced, when it contains zero tests, when every test was skipped, or when *any* test was skipped on CI.

The second is not redundant. The preflight only covers Docker being unavailable; a fixture could report unavailable for some other reason and the preflight would still pass. The `.trx` check catches the failure from the other end regardless of cause.

## Verification

- Both workflows **parse as YAML**
- The heredoc terminator **dedents to column 0** under the `run: |` block scalar — an indented terminator would silently not close the heredoc
- The `.trx` parser was **tested against four synthetic runs**:

| run | result |
|---|---|
| all passed | **PASS** |
| all skipped | FAIL — "every test was skipped" |
| partially skipped | FAIL — "2 test(s) skipped" |
| zero tests | FAIL — "zero tests in the .trx" |

## Note on the protected-file guard

This touches only `.github/workflows/*.yaml`, so it is a **protected-file-only change**. Per the release-cut convention that is the one case where a single admin-bypassed PR is appropriate — there is no non-protected content to lose review coverage on. It also means neither guard executes until this merges and a subsequent PR runs the workflows.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>