### PR TITLE
chore(deps): move the ETL core packages to 0.23.4

### DIFF
--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -80,18 +80,18 @@
     prevent NuGet from resolving an older transitive version — no runtime assembly is copied.
   -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.23.4" />
   </ItemGroup>
 
   <!-- Source generator: built alongside the runtime, packed into the same

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Wolfgang.Etl.DbClient.Tests.Integration.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Npgsql" Version="9.0.3" />

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/Wolfgang.Etl.DbClient.Tests.Unit.csproj
@@ -125,17 +125,17 @@
   <!-- Shared dependencies (all TFMs) -->
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <!-- GHSA-2m69-gcr7-jv3q: see sister-csproj note in Example.AutoSql.
          The bundle_e_sqlite3/core line pulls patched native lib.e_sqlite3
          3.50.3 transitively — don't pin lib.e_sqlite3 directly, that
          package line never reached 3.50.x itself. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="Wolfgang.Etl.ErrorPolicies" Version="0.22.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.ErrorPolicies" Version="0.23.4" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.23.4" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.23.4" />
   </ItemGroup>
 
   <!-- Copy native SQLite DLL to output for .NET Framework (no RID-based probing) -->


### PR DESCRIPTION
Closes #358 — the bump held since 2026-08-28, now rebased and retargeted for this release.

**Note the branch name says `0.23.3`.** It was cut when that was current; the content targets **0.23.4**. Renaming it would have orphaned the tracking history, so it is left as-is.

## What changes

`Wolfgang.Etl.Abstractions`, `Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit` **0.22.0 → 0.23.4**, across 4 references in 2 projects. This was the **last repo in the fleet still on 0.22.0**.

## Retargeted on pickup, as #358 instructed

0.23.4 shipped on 2026-08-29, after this branch was cut. Per the issue's own instruction to re-check on rebase, it is retargeted rather than shipping a superseded version.

0.23.4 carries **no runtime API change** — CI, test-coverage and packaging work — and its dependency floors are byte-identical to 0.23.3, verified from both nuspecs.

## The `NU1605` cascade is already handled

#358 documents a **two-step** cascade where the second failure only appears after fixing the first, and originates in `ErrorPolicies` rather than Abstractions — so reading the Abstractions changelog alone does not predict it.

The original commit raised `Microsoft.Bcl.AsyncInterfaces` and `Microsoft.Extensions.Logging.Abstractions` to **10.0.11** in the same pass, which is exactly what the hidden second failure needed. Confirmed by a clean Release build after the retarget rather than assumed.

## Rebase

`vNext` had moved **18 commits** ahead — the whole constructor standard (#359, #361, #362, #363) plus the parameter abstraction (#368). Rebased cleanly, no conflicts.

## Verification

Release build clean; **20 project × TFM combinations, 0 failures** — run after the retarget, not carried over from the pre-rebase state.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>