### PR TITLE
fix(ci): make the Linux coverage gate actually gate

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -852,11 +852,11 @@ jobs:
           failed_projects=""
           threshold=${CODECOV_MINIMUM:-90}
           
-          while read -r line; do
+          while IFS= read -r line; do
             # Match lines with module names and percentages
-            if echo "$line" | grep -qE '^[^ ].*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
+            if echo "$line" | grep -qE '^[^ ]+.*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
               module=$(echo "$line" | awk '{print $1}')
-              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%')
+              percent=$(echo "$line" | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | grep -oE '^[0-9]+')
               
               echo "Checking module: '$module' - Coverage: ${percent}%"
               


### PR DESCRIPTION
Closes #370. Protected-file-only (`pr.yaml`), so it needs an admin-bypass merge — deliberately small to eyeball.

Targets `main` rather than `vNext`: it fixes a guard that should apply to every PR immediately, and it is independent of the release content.

## Two defects, not one

#370 described the first. The second surfaced while confirming *which* of the two loops to patch — `pr.yaml` carries two copies of the same "Enforce 90% coverage threshold" step, in `test-linux-core` (line 855) and `test-macos-core` (line 1715), and only the macOS one had been fixed.

### 1. Class rows were gated as projects

The filter uses `^[^ ]` to skip ReportGenerator's **indented** per-class rows, but `read` strips leading `IFS` whitespace — the indentation was gone before `grep` saw it, so every class row matched.

### 2. The gate never failed — the more serious one

```bash
percent=$(echo "$line" | awk '{print $NF}' | tr -d '%')   # "89.4"
if [ "$percent" -lt "$threshold" ]; then                  # exit 2, not a comparison
```

`[ "89.4" -lt 90 ]` errors rather than comparing, and `if` treats non-zero as false — so a **sub-threshold module passed silently**. ReportGenerator reports decimals, so this affected essentially every module.

Verified in a real shell against a `Wolfgang.Etl.DbClient    89.4%` row:

```
855 parses  -> '89.4'   ->  NOT flagged (exit=2)   <-- sub-threshold passes
1715 parses -> '89'     ->  FLAGGED (correct)
```

**Defect 1 gates the wrong rows. Defect 2 means the Linux gate does not gate at all.**

## The fix

Align 855 with 1715, which was already correct: `IFS= read`, `^[^ ]+`, and integer-part parsing.

`release.yaml` in this repo has no bare `read`, so it is unaffected.

## Verification

- `pr.yaml` parses — 13 jobs
- 0 bare `while read -r line` remain; both occurrences now use `IFS= read`
- both parsings exercised in a real shell, above

## Fleet implication

**Likely present in every repo sharing this `pr.yaml` shape.** Defect 1 stays dormant until a repo instruments its test assemblies (#371) — which is why it only ever surfaced on ETL-SqlBulkCopy. **Defect 2 is live everywhere right now**: any repo using this Linux gate has a coverage gate that cannot fail.

Worth a fleet sweep once this is confirmed here.

## Unblocks

#371 (instrument test assemblies) — which must not land before this, since instrumentation is what makes the class rows appear.