### PR TITLE
feat: pack third-party notices into the published package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Third-party notices are now packed into the package (#353).** `THIRD-PARTY-NOTICES.md`
+  ships at the package root, listing every runtime dependency and its licence. Previously the
+  `license-audit` workflow generated this file as a build artifact only, so consumers installing
+  the package never received it.
+
 - **Configuration via options records.** `DbExtractor<TRecord>` and `DbLoader<TRecord>` gained
   constructors taking `DbExtractorOptions` / `DbLoaderOptions`, so configuration travels through the
   constructor instead of post-construction property assignment. One overload per existing input

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,56 @@
+# Third-Party Notices
+
+`Wolfgang.Etl.DbClient` redistributes no third-party code, but its published package
+declares the runtime dependencies below. Their licences are reproduced or linked here
+for attribution.
+
+Generated against the dependency set as of **Wolfgang.Etl.DbClient 0.10.0**. The
+`license-audit` workflow regenerates this list and fails the build if any dependency
+declares a licence outside `.github/license/allowed-licenses.json`.
+
+## Runtime dependencies
+
+| Package | Version | Licence |
+|---|---|---|
+| [Dapper](https://www.nuget.org/packages/Dapper) | 2.1.66 | Apache-2.0 |
+| [Microsoft.Bcl.AsyncInterfaces](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces) | 10.0.11 | MIT |
+| [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions) | 10.0.11 | MIT |
+| [System.Memory](https://www.nuget.org/packages/System.Memory) | 4.6.3 | MIT |
+
+`Wolfgang.Etl.Abstractions` is also a runtime dependency. It is first-party — part of
+this same project family, MIT licensed — so it is listed separately rather than as a
+third-party notice.
+
+`JetBrains.Annotations` is referenced with `PrivateAssets="all"`: it is a
+compile-time-only aid, is not part of the published dependency graph, and consumers
+never acquire it.
+
+## Licence texts
+
+### Apache-2.0 — Dapper
+
+Licensed under the Apache License, Version 2.0. You may obtain a copy at
+<https://www.apache.org/licenses/LICENSE-2.0>.
+
+Distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the licence for the specific language governing permissions and
+limitations.
+
+### MIT — Microsoft.Bcl.AsyncInterfaces, Microsoft.Extensions.Logging.Abstractions, System.Memory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be included in all copies
+or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,9 @@
 declares the runtime dependencies below. Their licences are reproduced or linked here
 for attribution.
 
-Generated against the dependency set as of **Wolfgang.Etl.DbClient 0.10.0**. The
+Reflects the runtime dependency versions declared in
+`src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj`, which are listed explicitly below
+rather than tied to a package version that would drift. The
 `license-audit` workflow regenerates this list and fails the build if any dependency
 declares a licence outside `.github/license/allowed-licenses.json`.
 

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\THIRD-PARTY-NOTICES.md" Condition="Exists('..\..\THIRD-PARTY-NOTICES.md')">
+    <None Include="..\..\THIRD-PARTY-NOTICES.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -60,6 +60,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\..\THIRD-PARTY-NOTICES.md" Condition="Exists('..\..\THIRD-PARTY-NOTICES.md')">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
     <None Include="..\..\README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>


### PR DESCRIPTION
Closes #353. Two files — no workflow changes, so **no protected-file split needed**, which I had expected to be required.

## Most of this already existed

`license-audit.yaml` and `.github/license/allowed-licenses.json` are both present, and the allowlist already covers every licence this package ships. So the audit gate has been working.

**What was missing is the part consumers see.** The workflow generated `THIRD-PARTY-NOTICES.md` as a build **artifact** — it never reached anyone installing the package. This commits the file and packs it at the package root.

## Licences verified from each nuspec, not assumed

| package | version | declared licence |
|---|---|---|
| Dapper | 2.1.66 | **Apache-2.0** |
| Microsoft.Bcl.AsyncInterfaces | 10.0.11 | MIT |
| Microsoft.Extensions.Logging.Abstractions | 10.0.11 | MIT |
| System.Memory | 4.6.3 | MIT |

**The compound-expression trap from the Etl-Csv implementation does not apply here.** CsvHelper declares a two-option SPDX expression, and the audit tool compares the declared string as *text* — so an allowlist holding only one of the options rejects it. Every dependency here declares a single plain identifier, so the existing allowlist is already sufficient. Worth stating explicitly, since that was the one thing that made the Csv equivalent non-trivial.

## Two entries documented rather than silently omitted

- **`Wolfgang.Etl.Abstractions`** — a runtime dependency, but first-party. Listed apart from the third-party table rather than dropped, so its absence from that table is not mistaken for an oversight.
- **`JetBrains.Annotations`** — excluded, because `PrivateAssets="all"` keeps it out of the published dependency graph entirely. Consumers never acquire it.

## Verification

`dotnet pack -c Release` clean, and **`THIRD-PARTY-NOTICES.md` confirmed present inside the produced `.nupkg`** — inspected in the archive, not merely referenced by the csproj. That distinction mattered on the Csv equivalent and is the only check that actually proves a consumer receives the file.