### PR TITLE
test: pin the pre-cancelled-token contract on DbLoader

### DIFF
--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/PreCancelledTokenTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/PreCancelledTokenTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+/// <summary>
+/// Pins the pre-cancelled-token contract: a loader handed an already-cancelled token must read
+/// <em>nothing</em> from its source.
+/// </summary>
+/// <remarks>
+/// The guard exists in <c>LoadWorkerAsync</c>, but nothing in this repository proved it — the
+/// TestKit loader contract base that covers this is not adopted here, only the dry-run one. These
+/// tests count actual reads rather than trusting the guard's presence.
+/// <para>
+/// It matters more here than for most loaders: a database cursor is exactly the non-replayable
+/// source where a silently-drained first row cannot be recovered.
+/// </para>
+/// </remarks>
+public class PreCancelledTokenTests
+{
+    /// <summary>A source that records how many items were actually pulled from it.</summary>
+    private sealed class CountingSource
+    {
+        internal int ItemsRead;
+
+        // The token is deliberately NOT observed here. If this source honoured cancellation it
+        // would throw on its own and the test would pass without proving anything about the
+        // loader. Ignoring it is what makes "zero items read" attributable to the loader's
+        // upfront guard rather than to the source's good behaviour.
+#pragma warning disable RCS1163 // Unused parameter - intentional, see above.
+        internal async IAsyncEnumerable<PersonRecord> ItemsAsync
+        (
+            [EnumeratorCancellation] CancellationToken token = default
+        )
+#pragma warning restore RCS1163
+        {
+            foreach (var name in new[] { "Alice", "Bob", "Carol" })
+            {
+                ItemsRead++;
+                yield return new PersonRecord { FirstName = name, LastName = "X", Age = 30 };
+                await Task.Yield();
+            }
+        }
+    }
+
+
+    private static SqliteConnection Connection()
+    {
+        var conn = new SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "CREATE TABLE People (first_name TEXT, last_name TEXT, age INTEGER);";
+        cmd.ExecuteNonQuery();
+        return conn;
+    }
+
+
+    [Fact]
+    public async Task LoadAsync_with_a_pre_cancelled_token_reads_nothing()
+    {
+        using var conn = Connection();
+        var source = new CountingSource();
+
+        var sut = new DbLoader<PersonRecord>
+        (
+            conn,
+            "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)",
+            options: null
+        );
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            () => sut.LoadAsync(source.ItemsAsync(cts.Token), cts.Token)
+        );
+
+        Assert.Equal(0, source.ItemsRead);
+    }
+
+
+    [Fact]
+    public async Task LoadAsync_with_a_pre_cancelled_token_writes_nothing()
+    {
+        using var conn = Connection();
+        var source = new CountingSource();
+
+        var sut = new DbLoader<PersonRecord>
+        (
+            conn,
+            "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)",
+            options: null
+        );
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            () => sut.LoadAsync(source.ItemsAsync(cts.Token), cts.Token)
+        );
+
+        using var count = conn.CreateCommand();
+        count.CommandText = "SELECT COUNT(*) FROM People";
+        Assert.Equal(0L, (long)count.ExecuteScalar()!);
+    }
+
+
+    [Fact]
+    public async Task LoadAsync_with_a_live_token_still_reads_everything()
+    {
+        // Guards against "fixing" cancellation by never reading at all.
+        using var conn = Connection();
+        var source = new CountingSource();
+
+        var sut = new DbLoader<PersonRecord>
+        (
+            conn,
+            "INSERT INTO People (first_name, last_name, age) VALUES (@FirstName, @LastName, @Age)",
+            options: null
+        );
+
+        await sut.LoadAsync(source.ItemsAsync(), CancellationToken.None);
+
+        Assert.Equal(3, source.ItemsRead);
+    }
+}


### PR DESCRIPTION
Closes #329 — **but not as a fix.** The defect that issue describes does not exist in this repository, and did not exist when it was filed.

## What #329 claimed

It was raised by pattern-matching a confirmed defect in ETL-SqlBulkCopy#267, and states the check sits *inside* the `await foreach` — "verified by inspection on `main` at time of filing" (2026-08-13).

## What `main` actually contained on that date

```csharp
protected override async Task LoadWorkerAsync(IAsyncEnumerable<TRecord> items, CancellationToken token)
{
    // Contract: a pre-cancelled token must load zero rows. …
    token.ThrowIfCancellationRequested();
    _stopwatch.Restart();
```

Already the **first statement**, with the same explanatory comment it carries today. The stated verification did not hold.

## What *was* genuinely missing

**Proof.** This repo adopts only `SupportsDryRunContractTests` from TestKit — not the loader contract base that covers pre-cancellation — so the guard sat unverified. It could have regressed at any point without a failing test.

Three tests that count **actual reads** rather than trusting the guard's presence:

| test | asserts |
|---|---|
| `…reads_nothing` | pre-cancelled token → **0 items pulled from the source** |
| `…writes_nothing` | pre-cancelled token → **0 rows in the table** |
| `…with_a_live_token_still_reads_everything` | live token → all 3 read |

**The third is not filler.** Without it, a regression that broke enumeration entirely would satisfy the first two — "reads nothing" is trivially true for a loader that reads nothing ever.

## One deliberate suppression

The test source **ignores its own `CancellationToken`**. If it honoured cancellation it would throw on its own, and "zero items read" would prove nothing about `DbLoader`. Ignoring it is what makes the assertion attributable to the loader's upfront guard.

That trips `RCS1163` (unused parameter), suppressed inline **with the reasoning**, so the parameter is not later tidied away — which would silently convert a meaningful test into a tautological one.

## Why bother, given there was no bug

A **database cursor is exactly the non-replayable source** where a silently-drained first row cannot be recovered. Having that behaviour pinned rather than merely present is worth three tests.

## Verification

3 tests, all passing on net10.0.