### PR TITLE
chore(api): record the missing public API and enforce RS0016

### DIFF
--- a/src/Wolfgang.Etl.DbClient/.editorconfig
+++ b/src/Wolfgang.Etl.DbClient/.editorconfig
@@ -1,0 +1,19 @@
+root = false
+
+[*.cs]
+
+# RS0016/RS0017/RS0037 — PublicApiAnalyzers defaults these BELOW warning on 5.x, so public
+# API can drift unrecorded through a fully green build. That is exactly what happened: 41
+# symbols were missing when this was raised (#364), including two members removed and never
+# recorded as removed. Raising them makes the drift impossible rather than fixed once.
+#
+# Etl-Csv cannot do this (Chris-Wolfgang/ETL-Csv#263): its record types' compiler-generated
+# <Clone>$ members are neither recordable nor suppressible. This repo has no such members —
+# verified by harvesting at error severity and getting zero diagnostics — so enforcement is
+# available here where it is not there.
+#
+# TreatWarningsAsErrors is on for Release, so CI treats these as errors while local Debug
+# builds still only warn.
+dotnet_diagnostic.RS0016.severity = warning
+dotnet_diagnostic.RS0017.severity = warning
+dotnet_diagnostic.RS0037.severity = warning

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -3,6 +3,49 @@
 *REMOVED*override Wolfgang.Etl.DbClient.DbLoader<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.DbClient.DbReport!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
 static Wolfgang.Etl.DbClient.DbSchemaValidator.Validate<TRecord>(System.Data.Common.DbConnection! connection) -> void
 static Wolfgang.Etl.DbClient.DbSchemaValidator.ValidateAsync<TRecord>(System.Data.Common.DbConnection! connection, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbConnection! connection, string! commandText, System.Collections.Generic.IDictionary<string!, object!>! parameters, Wolfgang.Etl.DbClient.DbExtractorOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbConnection! connection, string! commandText, Wolfgang.Etl.DbClient.DbExtractorOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbConnection! connection, Wolfgang.Etl.DbClient.DbExtractorOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Wolfgang.Etl.DbClient.DbExtractorOptions? options, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions
+Wolfgang.Etl.DbClient.DbExtractorOptions.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbExtractorOptions.CommandTimeout.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbExtractorOptions.CommandType.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.ManageConnection.get -> bool
+Wolfgang.Etl.DbClient.DbExtractorOptions.ManageConnection.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.PagingClauseTemplate.get -> string!
+Wolfgang.Etl.DbClient.DbExtractorOptions.PagingClauseTemplate.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.ServerLimit.get -> long?
+Wolfgang.Etl.DbClient.DbExtractorOptions.ServerLimit.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.ServerOffset.get -> long?
+Wolfgang.Etl.DbClient.DbExtractorOptions.ServerOffset.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.TotalCountQuery.get -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<int>!>?
+Wolfgang.Etl.DbClient.DbExtractorOptions.TotalCountQuery.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.ValidateSchemaOnStart.get -> bool
+Wolfgang.Etl.DbClient.DbExtractorOptions.ValidateSchemaOnStart.init -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbConnection! connection, string! commandText, Wolfgang.Etl.DbClient.DbLoaderOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbConnection! connection, Wolfgang.Etl.DbClient.WriteMode writeMode, Wolfgang.Etl.DbClient.DbLoaderOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Wolfgang.Etl.DbClient.DbLoaderOptions? options, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions
+Wolfgang.Etl.DbClient.DbLoaderOptions.BatchCommitSize.get -> int
+Wolfgang.Etl.DbClient.DbLoaderOptions.BatchCommitSize.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.BatchSize.get -> int
+Wolfgang.Etl.DbClient.DbLoaderOptions.BatchSize.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbLoaderOptions.CommandTimeout.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbLoaderOptions.CommandType.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.ErrorHandling.get -> Wolfgang.Etl.DbClient.RowErrorHandling
+Wolfgang.Etl.DbClient.DbLoaderOptions.ErrorHandling.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.InsertBatchSize.get -> int
+Wolfgang.Etl.DbClient.DbLoaderOptions.InsertBatchSize.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.ManageConnection.get -> bool
+Wolfgang.Etl.DbClient.DbLoaderOptions.ManageConnection.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.MaxErrorCount.get -> int
+Wolfgang.Etl.DbClient.DbLoaderOptions.MaxErrorCount.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.ValidateSchemaOnStart.get -> bool
+Wolfgang.Etl.DbClient.DbLoaderOptions.ValidateSchemaOnStart.init -> void
 Wolfgang.Etl.DbClient.DbSchemaValidator
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ValidateSchemaOnStart.get -> bool
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ValidateSchemaOnStart.set -> void
@@ -10,6 +53,18 @@ Wolfgang.Etl.DbClient.DbLoader<TRecord>.ValidateSchemaOnStart.get -> bool
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.ValidateSchemaOnStart.set -> void
 Wolfgang.Etl.DbClient.DbKeyAttribute
 Wolfgang.Etl.DbClient.DbKeyAttribute.DbKeyAttribute() -> void
+Wolfgang.Etl.DbClient.EtlParameter
+Wolfgang.Etl.DbClient.EtlParameter.DbType.get -> System.Data.DbType?
+Wolfgang.Etl.DbClient.EtlParameter.DbType.init -> void
+Wolfgang.Etl.DbClient.EtlParameter.Direction.get -> System.Data.ParameterDirection
+Wolfgang.Etl.DbClient.EtlParameter.Direction.init -> void
+Wolfgang.Etl.DbClient.EtlParameter.EtlParameter() -> void
+Wolfgang.Etl.DbClient.EtlParameter.Size.get -> int?
+Wolfgang.Etl.DbClient.EtlParameter.Size.init -> void
+Wolfgang.Etl.DbClient.EtlParameter<T>
+Wolfgang.Etl.DbClient.EtlParameter<T>.EtlParameter() -> void
+Wolfgang.Etl.DbClient.EtlParameter<T>.Value.get -> T?
+Wolfgang.Etl.DbClient.EtlParameter<T>.Value.init -> void
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.CommandType(System.Data.CommandType commandType) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.ManageConnection(bool manage) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!


### PR DESCRIPTION
Closes #364. Stacked on #382 — last in the stack deliberately, since the earlier PRs changed what needed recording.

## What was unrecorded

**41 public symbols**, and `PublicAPI.Unshipped.txt` goes **28 → 83** entries: the options records, the `EtlParameter` types and their constructors, plus two members that had been **removed** and never recorded as removed.

## Recorded by the analyzer, not by hand

`dotnet format analyzers --diagnostics RS0016` applied the code fix.

That was the blocker #364 identified, and it was real: this repo's RS0016 reports **short symbol names** (`BatchCommitSize.get`), so reconstructing declaration lines by hand would mean inventing fully-qualified types, nullability annotations and return syntax exactly. One wrong character yields `RS0017` — which is how Chris-Wolfgang/ETL-Csv#263's attempt became unfixable.

## Two unrecorded *removals* surfaced

The fix emitted `*REMOVED*` entries for `CreateProgressTimer` overrides on `DbExtractor` and `DbLoader`, dropped by the TestKit 0.14 refactor.

**Verified genuinely absent** — zero occurrences in either file — rather than trusted from the tool's output. These are protected-member removals, so a real API change had been sitting unrecorded. Worth a reviewer's eye: they will show as breaking at the release fold.

## Enforcement is now on

`RS0016` / `RS0017` / `RS0037` raised to `warning`, which `TreatWarningsAsErrors` makes an error in Release. **That is the fix that stops this recurring** rather than correcting it once — #364 suggested considering it, and it turns out to pass cleanly.

**This is available here and not in Etl-Csv.** ETL-Csv#263 is blocked because its record types carry compiler-generated `<Clone>$` members that are neither recordable nor suppressible. This repo has none — verified by harvesting at `error` severity and getting **zero** diagnostics. So the two repos genuinely differ, and Csv's blocker is not fleet-wide.

## Verification

- Harvested at `error` severity, then re-harvested after the fix: **0 RS0016 remaining**
- Release build clean **with enforcement enabled** — the meaningful check, since it proves the recorded entries actually satisfy the analyzer
- **20 project × TFM combinations, 0 failures**
- The temporary `.editorconfig` used for harvesting was removed; the one in this diff is the permanent enforcement config