### PR TITLE
feat(paging): add PagingClauseTemplates presets for the paging clause

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -625,6 +625,9 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// For SQL Server, set to <c>OFFSET @PageOffset ROWS FETCH NEXT @PageLimit ROWS ONLY</c>
     /// (and ensure the base SQL ends with an <c>ORDER BY</c>).
     /// </para>
+    /// <para>
+    /// Prefer the presets on <see cref="PagingClauseTemplates"/> over writing the clause by hand.
+    /// </para>
     /// </remarks>
     public string PagingClauseTemplate { get; [Obsolete("Configure PagingClauseTemplate through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; } = "LIMIT @PageLimit OFFSET @PageOffset";
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -74,6 +74,26 @@ public sealed record DbExtractorOptions
     /// Gets the dialect-specific paging clause appended when server paging is active.
     /// Defaults to <c>"LIMIT @PageLimit OFFSET @PageOffset"</c>.
     /// </summary>
+    /// <remarks>
+    /// <b>This is dialect-specific, not standard SQL.</b> The default is the PostgreSQL / MySQL /
+    /// SQLite form; <b>SQL Server rejects <c>LIMIT</c></b> and needs the SQL:2008
+    /// <c>OFFSET … ROWS FETCH NEXT … ROWS ONLY</c> form, as do Oracle 12c+ and Db2. Leaving the
+    /// default in place against those engines produces a runtime syntax error.
+    /// <para>
+    /// Use <see cref="PagingClauseTemplates"/> rather than writing the clause by hand:
+    /// <c>PagingClauseTemplate = PagingClauseTemplates.SqlServer</c>. Any string is accepted, so a
+    /// dialect with no preset can be supplied directly.
+    /// </para>
+    /// <para>
+    /// The <c>OFFSET … FETCH</c> form additionally requires the base SQL to end with an
+    /// <c>ORDER BY</c> — SQL Server and Oracle both reject it otherwise.
+    /// </para>
+    /// <para>
+    /// A custom template must reference both <c>@PageOffset</c> and <c>@PageLimit</c> — those are
+    /// the parameter names supplied when <see cref="ServerOffset"/> and <see cref="ServerLimit"/>
+    /// are set.
+    /// </para>
+    /// </remarks>
     public string PagingClauseTemplate { get; init; } = "LIMIT @PageLimit OFFSET @PageOffset";
 
 

--- a/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
@@ -65,6 +65,11 @@ public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
     /// <see cref="ServerLimit"/> are set. Default:
     /// <c>LIMIT @PageLimit OFFSET @PageOffset</c>.
     /// </summary>
+    /// <remarks>
+    /// The clause is dialect-specific — the default does not work on SQL Server, Oracle or Db2.
+    /// Use a preset from <see cref="PagingClauseTemplates"/>, e.g.
+    /// <c>.PagingClauseTemplate(PagingClauseTemplates.SqlServer)</c>.
+    /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="template"/> is <see langword="null"/>.</exception>
     IDbExtractorBuilder<T> PagingClauseTemplate(string template);
 

--- a/src/Wolfgang.Etl.DbClient/PagingClauseTemplates.cs
+++ b/src/Wolfgang.Etl.DbClient/PagingClauseTemplates.cs
@@ -1,0 +1,60 @@
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Ready-made values for <see cref="DbExtractorOptions.PagingClauseTemplate"/>, one per supported
+/// database.
+/// </summary>
+/// <remarks>
+/// Server-side paging syntax is <b>dialect-specific</b>, not standard SQL. <c>LIMIT … OFFSET …</c>
+/// is the PostgreSQL / MySQL / SQLite form; SQL Server rejects <c>LIMIT</c> outright and wants the
+/// SQL:2008 <c>OFFSET … ROWS FETCH NEXT … ROWS ONLY</c> form, as do Oracle 12c+ and Db2.
+/// <para>
+/// These are conveniences, not a closed set — <see cref="DbExtractorOptions.PagingClauseTemplate"/>
+/// takes any string, so a dialect with no preset here is supplied directly.
+/// </para>
+/// <para>
+/// Every template must reference both <c>@PageOffset</c> and <c>@PageLimit</c>: those are the
+/// parameter names the extractor supplies when <see cref="DbExtractorOptions.ServerOffset"/> and
+/// <see cref="DbExtractorOptions.ServerLimit"/> are set.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var options = new DbExtractorOptions
+/// {
+///     ServerOffset = 100,
+///     ServerLimit = 50,
+///     PagingClauseTemplate = PagingClauseTemplates.SqlServer
+/// };
+/// </code>
+/// </example>
+public static class PagingClauseTemplates
+{
+    private const string LimitOffset = "LIMIT @PageLimit OFFSET @PageOffset";
+
+    private const string OffsetFetch = "OFFSET @PageOffset ROWS FETCH NEXT @PageLimit ROWS ONLY";
+
+
+    /// <summary>MySQL and MariaDB — <c>LIMIT … OFFSET …</c>.</summary>
+    public static string MySql { get; } = LimitOffset;
+
+
+    /// <summary>PostgreSQL — <c>LIMIT … OFFSET …</c>.</summary>
+    public static string PostgreSql { get; } = LimitOffset;
+
+
+    /// <summary>SQLite — <c>LIMIT … OFFSET …</c>. This is also the library default.</summary>
+    public static string Sqlite { get; } = LimitOffset;
+
+
+    /// <summary>SQL Server 2012 and later — SQL:2008 <c>OFFSET … FETCH NEXT …</c>.</summary>
+    public static string SqlServer { get; } = OffsetFetch;
+
+
+    /// <summary>Oracle 12c and later — SQL:2008 <c>OFFSET … FETCH NEXT …</c>.</summary>
+    public static string Oracle { get; } = OffsetFetch;
+
+
+    /// <summary>Db2 — SQL:2008 <c>OFFSET … FETCH NEXT …</c>.</summary>
+    public static string Db2 { get; } = OffsetFetch;
+}

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -3,6 +3,55 @@
 *REMOVED*override Wolfgang.Etl.DbClient.DbLoader<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.DbClient.DbReport!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
 static Wolfgang.Etl.DbClient.DbSchemaValidator.Validate<TRecord>(System.Data.Common.DbConnection! connection) -> void
 static Wolfgang.Etl.DbClient.DbSchemaValidator.ValidateAsync<TRecord>(System.Data.Common.DbConnection! connection, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Wolfgang.Etl.DbClient.PagingClauseTemplates.Db2.get -> string!
+static Wolfgang.Etl.DbClient.PagingClauseTemplates.MySql.get -> string!
+static Wolfgang.Etl.DbClient.PagingClauseTemplates.Oracle.get -> string!
+static Wolfgang.Etl.DbClient.PagingClauseTemplates.PostgreSql.get -> string!
+static Wolfgang.Etl.DbClient.PagingClauseTemplates.Sqlite.get -> string!
+static Wolfgang.Etl.DbClient.PagingClauseTemplates.SqlServer.get -> string!
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbConnection! connection, string! commandText, System.Collections.Generic.IDictionary<string!, object!>! parameters, Wolfgang.Etl.DbClient.DbExtractorOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbConnection! connection, string! commandText, Wolfgang.Etl.DbClient.DbExtractorOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbConnection! connection, Wolfgang.Etl.DbClient.DbExtractorOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.DbExtractor(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Wolfgang.Etl.DbClient.DbExtractorOptions? options, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbExtractor<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions
+Wolfgang.Etl.DbClient.DbExtractorOptions.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbExtractorOptions.CommandTimeout.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbExtractorOptions.CommandType.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.ManageConnection.get -> bool
+Wolfgang.Etl.DbClient.DbExtractorOptions.ManageConnection.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.PagingClauseTemplate.get -> string!
+Wolfgang.Etl.DbClient.DbExtractorOptions.PagingClauseTemplate.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.ServerLimit.get -> long?
+Wolfgang.Etl.DbClient.DbExtractorOptions.ServerLimit.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.ServerOffset.get -> long?
+Wolfgang.Etl.DbClient.DbExtractorOptions.ServerOffset.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.TotalCountQuery.get -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<int>!>?
+Wolfgang.Etl.DbClient.DbExtractorOptions.TotalCountQuery.init -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.ValidateSchemaOnStart.get -> bool
+Wolfgang.Etl.DbClient.DbExtractorOptions.ValidateSchemaOnStart.init -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbConnection! connection, string! commandText, Wolfgang.Etl.DbClient.DbLoaderOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbConnection! connection, Wolfgang.Etl.DbClient.WriteMode writeMode, Wolfgang.Etl.DbClient.DbLoaderOptions? options, System.Data.Common.DbTransaction? transaction = null, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbLoader<TRecord>.DbLoader(System.Data.Common.DbProviderFactory! factory, string! connectionString, string! commandText, Wolfgang.Etl.DbClient.DbLoaderOptions? options, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.DbClient.DbLoader<TRecord>!>? logger = null) -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions
+Wolfgang.Etl.DbClient.DbLoaderOptions.BatchCommitSize.get -> int
+Wolfgang.Etl.DbClient.DbLoaderOptions.BatchCommitSize.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.BatchSize.get -> int
+Wolfgang.Etl.DbClient.DbLoaderOptions.BatchSize.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.CommandTimeout.get -> System.TimeSpan?
+Wolfgang.Etl.DbClient.DbLoaderOptions.CommandTimeout.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.CommandType.get -> System.Data.CommandType
+Wolfgang.Etl.DbClient.DbLoaderOptions.CommandType.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.ErrorHandling.get -> Wolfgang.Etl.DbClient.RowErrorHandling
+Wolfgang.Etl.DbClient.DbLoaderOptions.ErrorHandling.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.InsertBatchSize.get -> int
+Wolfgang.Etl.DbClient.DbLoaderOptions.InsertBatchSize.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.ManageConnection.get -> bool
+Wolfgang.Etl.DbClient.DbLoaderOptions.ManageConnection.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.MaxErrorCount.get -> int
+Wolfgang.Etl.DbClient.DbLoaderOptions.MaxErrorCount.init -> void
+Wolfgang.Etl.DbClient.DbLoaderOptions.ValidateSchemaOnStart.get -> bool
+Wolfgang.Etl.DbClient.DbLoaderOptions.ValidateSchemaOnStart.init -> void
 Wolfgang.Etl.DbClient.DbSchemaValidator
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ValidateSchemaOnStart.get -> bool
 Wolfgang.Etl.DbClient.DbExtractor<TRecord>.ValidateSchemaOnStart.set -> void
@@ -10,6 +59,18 @@ Wolfgang.Etl.DbClient.DbLoader<TRecord>.ValidateSchemaOnStart.get -> bool
 Wolfgang.Etl.DbClient.DbLoader<TRecord>.ValidateSchemaOnStart.set -> void
 Wolfgang.Etl.DbClient.DbKeyAttribute
 Wolfgang.Etl.DbClient.DbKeyAttribute.DbKeyAttribute() -> void
+Wolfgang.Etl.DbClient.EtlParameter
+Wolfgang.Etl.DbClient.EtlParameter.DbType.get -> System.Data.DbType?
+Wolfgang.Etl.DbClient.EtlParameter.DbType.init -> void
+Wolfgang.Etl.DbClient.EtlParameter.Direction.get -> System.Data.ParameterDirection
+Wolfgang.Etl.DbClient.EtlParameter.Direction.init -> void
+Wolfgang.Etl.DbClient.EtlParameter.EtlParameter() -> void
+Wolfgang.Etl.DbClient.EtlParameter.Size.get -> int?
+Wolfgang.Etl.DbClient.EtlParameter.Size.init -> void
+Wolfgang.Etl.DbClient.EtlParameter<T>
+Wolfgang.Etl.DbClient.EtlParameter<T>.EtlParameter() -> void
+Wolfgang.Etl.DbClient.EtlParameter<T>.Value.get -> T?
+Wolfgang.Etl.DbClient.EtlParameter<T>.Value.init -> void
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.CommandType(System.Data.CommandType commandType) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.ManageConnection(bool manage) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
@@ -27,3 +88,4 @@ static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbExtractor<T>(this W
 static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline! pipeline, Wolfgang.Etl.DbClient.DbExtractor<T>! extractor) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
 static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Data.Common.DbConnection! connection, string! commandText, System.Data.Common.DbTransaction? transaction = null) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!
 static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, Wolfgang.Etl.DbClient.DbLoader<T>! loader) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!
+Wolfgang.Etl.DbClient.PagingClauseTemplates

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
@@ -102,4 +102,152 @@ public abstract class DbExtractorIntegrationTestsBase
         Assert.Equal("Item1", results[0].Name);
         Assert.Equal("Item2", results[1].Name);
     }
+
+
+    // ---- Server-side paging -------------------------------------------------
+    //
+    // These run the fixture's own PagingClauseTemplate against its own engine, so a
+    // preset that is syntactically wrong for an RDBMS fails here instead of in a
+    // consumer's query. Every query orders by value: the OFFSET/FETCH form requires
+    // an ORDER BY, and paging without a total order is not deterministic anyway.
+
+    private const string OrderedSelect =
+        "SELECT name AS Name, value AS Value FROM contract_items ORDER BY value";
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_server_paging_is_configured_returns_the_expected_window()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
+        await Fixture.SeedAsync(conn, rowCount: 5);
+
+        var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
+        {
+            PagingClauseTemplate = Fixture.PagingClauseTemplate,
+            ServerOffset = 1,
+            ServerLimit = 2
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Item2", results[0].Name);
+        Assert.Equal("Item3", results[1].Name);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_paging_through_the_whole_table_yields_every_row_exactly_once()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
+        await Fixture.SeedAsync(conn, rowCount: 7);
+
+        // 7 rows in pages of 3 deliberately leaves a partial final page.
+        const int pageSize = 3;
+        var seen = new List<int>();
+
+        for (var offset = 0; ; offset += pageSize)
+        {
+            var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
+            {
+                PagingClauseTemplate = Fixture.PagingClauseTemplate,
+                ServerOffset = offset,
+                ServerLimit = pageSize
+            };
+
+            var page = await extractor.ExtractAsync().ToListAsync();
+
+            if (page.Count == 0)
+            {
+                break;
+            }
+
+            Assert.True(page.Count <= pageSize, $"page at offset {offset} returned {page.Count} rows");
+            seen.AddRange(page.Select(item => item.Value));
+        }
+
+        // No gaps, no duplicates, and in order — the three ways paging goes wrong.
+        Assert.Equal(Enumerable.Range(1, 7).Select(i => i * 10), seen);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_ServerLimit_exceeds_the_rows_remaining_returns_only_what_is_left()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
+        await Fixture.SeedAsync(conn, rowCount: 5);
+
+        var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
+        {
+            PagingClauseTemplate = Fixture.PagingClauseTemplate,
+            ServerOffset = 3,
+            ServerLimit = 100
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Item4", results[0].Name);
+        Assert.Equal("Item5", results[1].Name);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_ServerOffset_is_past_the_last_row_yields_nothing()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
+        await Fixture.SeedAsync(conn, rowCount: 5);
+
+        var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
+        {
+            PagingClauseTemplate = Fixture.PagingClauseTemplate,
+            ServerOffset = 50,
+            ServerLimit = 10
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Empty(results);
+    }
+
+
+
+    [SkippableFact]
+    public async Task ExtractAsync_when_only_ServerLimit_is_set_does_not_page_at_all()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
+        await Fixture.SeedAsync(conn, rowCount: 5);
+
+        // Paging is all-or-nothing: ApplyServerPaging is a no-op unless BOTH ServerOffset
+        // and ServerLimit are set. Pinning it because the failure mode is silent — a caller
+        // who sets only a limit gets every row rather than an error.
+        var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
+        {
+            PagingClauseTemplate = Fixture.PagingClauseTemplate,
+            ServerLimit = 2
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(5, results.Count);
+    }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/CockroachDbFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/CockroachDbFixture.cs
@@ -22,6 +22,9 @@ public sealed class CockroachDbFixture : DbProviderFixtureBase
 
     public override string ProviderName => "cockroachdb";
 
+    // CockroachDB speaks the PostgreSQL wire protocol and shares its paging syntax.
+    public override string PagingClauseTemplate => PagingClauseTemplates.PostgreSql;
+
 
 
     protected override async Task StartAsync()

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/DbProviderFixtureBase.cs
@@ -15,6 +15,8 @@ public abstract class DbProviderFixtureBase : IAsyncLifetime, IDbProviderFixture
 {
     public abstract string ProviderName { get; }
 
+    public abstract string PagingClauseTemplate { get; }
+
     public bool Available { get; private set; }
 
     public string? UnavailableReason { get; private set; }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/IDbProviderFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/IDbProviderFixture.cs
@@ -15,6 +15,16 @@ public interface IDbProviderFixture
 
 
     /// <summary>
+    /// The paging clause this engine requires — normally a preset from
+    /// <see cref="PagingClauseTemplates"/>. Declared per fixture so the paging contract
+    /// tests exercise the real preset against the real engine: if a preset is wrong for
+    /// this RDBMS, the paging tests fail here rather than in a consumer's production query.
+    /// </summary>
+    string PagingClauseTemplate { get; }
+
+
+
+    /// <summary>
     /// True when the underlying environment (e.g. Docker daemon) was reachable
     /// and the schema was provisioned. Tests <c>Skip.IfNot(Available, ...)</c> on
     /// this so a developer without Docker can still run the rest of the suite.

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MariaDbFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MariaDbFixture.cs
@@ -18,6 +18,9 @@ public sealed class MariaDbFixture : DbProviderFixtureBase
 
     public override string ProviderName => "mariadb";
 
+    // MariaDB is MySQL-compatible for paging syntax; no separate preset is warranted.
+    public override string PagingClauseTemplate => PagingClauseTemplates.MySql;
+
 
 
     protected override async Task StartAsync()

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MySqlFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/MySqlFixture.cs
@@ -13,6 +13,8 @@ public sealed class MySqlFixture : DbProviderFixtureBase
 
     public override string ProviderName => "mysql";
 
+    public override string PagingClauseTemplate => PagingClauseTemplates.MySql;
+
 
 
     protected override async Task StartAsync()

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/PostgresFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/PostgresFixture.cs
@@ -13,6 +13,8 @@ public sealed class PostgresFixture : DbProviderFixtureBase
 
     public override string ProviderName => "postgres";
 
+    public override string PagingClauseTemplate => PagingClauseTemplates.PostgreSql;
+
 
 
     protected override async Task StartAsync()

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqlServerFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqlServerFixture.cs
@@ -13,6 +13,8 @@ public sealed class SqlServerFixture : DbProviderFixtureBase
 
     public override string ProviderName => "sqlserver";
 
+    public override string PagingClauseTemplate => PagingClauseTemplates.SqlServer;
+
 
 
     protected override async Task StartAsync()

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/Fixtures/SqliteFixture.cs
@@ -20,6 +20,8 @@ public sealed class SqliteFixture : DbProviderFixtureBase
 
     public override string ProviderName => "sqlite";
 
+    public override string PagingClauseTemplate => PagingClauseTemplates.Sqlite;
+
     // SQLite uses an in-memory connection; no Docker daemon required.
     protected override bool RequiresDocker => false;
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+/// <summary>
+/// Guards the paging presets. A typo in one of these surfaces only as a runtime SQL error on a
+/// database that may not be exercised locally, so it is worth asserting cheaply here.
+/// </summary>
+public class PagingClauseTemplatesTests
+{
+    public static IEnumerable<object[]> AllPresets()
+    {
+        foreach (var property in typeof(PagingClauseTemplates)
+            .GetProperties(BindingFlags.Public | BindingFlags.Static))
+        {
+            yield return new object[] { property.Name, (string)property.GetValue(null)! };
+        }
+    }
+
+
+    [Theory]
+    [MemberData(nameof(AllPresets))]
+    public void Every_preset_references_both_generated_parameter_names(string name, string template)
+    {
+        // Reflection rather than a hand-listed set: a preset added later is covered automatically,
+        // which is the case most likely to be forgotten.
+        Assert.False(string.IsNullOrWhiteSpace(template), $"{name} is empty");
+        Assert.Contains("@PageOffset", template, StringComparison.Ordinal);
+        Assert.Contains("@PageLimit", template, StringComparison.Ordinal);
+    }
+
+
+    [Fact]
+    public void The_library_default_matches_the_Sqlite_preset()
+    {
+        // The documented default is the LIMIT/OFFSET form; if one drifts from the other the docs
+        // become wrong silently.
+        Assert.Equal(PagingClauseTemplates.Sqlite, new DbExtractorOptions().PagingClauseTemplate);
+    }
+
+
+    [Fact]
+    public void The_OffsetFetch_presets_agree_with_each_other()
+    {
+        Assert.Equal(PagingClauseTemplates.SqlServer, PagingClauseTemplates.Oracle);
+        Assert.Equal(PagingClauseTemplates.SqlServer, PagingClauseTemplates.Db2);
+    }
+
+
+    [Fact]
+    public void SqlServer_does_not_use_LIMIT()
+    {
+        // The specific mistake this class exists to prevent.
+        Assert.DoesNotContain("LIMIT", PagingClauseTemplates.SqlServer, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Stacked on #380 (`fix/374-duplicate-parameter-names`). Review the top commit only.

## Summary

`PagingClauseTemplate` defaults to `LIMIT @PageLimit OFFSET @PageOffset`, which is **not standard SQL**. SQL Server rejects `LIMIT` outright; Oracle 12c+ and Db2 need the SQL:2008 `OFFSET … ROWS FETCH NEXT … ROWS ONLY` form. Today a caller has to know that and hand-write the clause — and a typo surfaces only as a runtime SQL error against a database that may not be exercised locally.

Adds `PagingClauseTemplates`, a static class of presets, per the design agreed on #385:

```csharp
options = options with { PagingClauseTemplate = PagingClauseTemplates.SqlServer };
```

Six get-only `string` properties: `MySql`, `PostgreSql`, `Sqlite` (the `LIMIT/OFFSET` form) and `SqlServer`, `Oracle`, `Db2` (the `OFFSET/FETCH` form).

**Get-only properties rather than `const`** — a `const` bakes its value into every consumer assembly at compile time, so a later correction to a preset would not reach an already-compiled caller until it rebuilt. The set is also deliberately open: the property stays a plain `string`, so a dialect with no preset here can still be supplied directly.

## Documentation gap

Also in scope per the issue. `PagingClauseTemplate` on `DbExtractorOptions`, `DbExtractor`, and `IDbExtractorBuilder` now states the value is dialect-specific, names the presets, and notes that the `OFFSET/FETCH` form requires the base SQL to end with an `ORDER BY` (SQL Server and Oracle both reject it otherwise). That `ORDER BY` caveat already existed on `DbExtractor`'s remarks but was absent from the options record and the builder interface — the two surfaces a caller is most likely to be reading.

## Tests

9 tests. The main one drives the presets **by reflection** rather than a hand-listed set, so a preset added later is covered automatically — that is the case most likely to be forgotten. Each preset must be non-empty and reference both `@PageOffset` and `@PageLimit`. Plus three targeted assertions: the library default matches the `Sqlite` preset (catches the docs silently drifting from the code), the three `OFFSET/FETCH` presets agree with each other, and `SqlServer` does not contain `LIMIT` — the specific mistake this class exists to prevent.

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs (no `CS1574` — the new `<see cref>`s resolve)
- [x] `dotnet test -c Release -f net10.0` — 360 unit tests pass, zero failures across all 7 test projects
- [x] PublicAPI entries recorded for the 6 new members + the type

Note: RS0016 enforcement lands in #383, which is not in this stack, so the build did not force the PublicAPI entries here — they were added deliberately.

Closes #385

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

## Integration tests (added after initial review)

Server-side paging turned out to have **no integration coverage at all** — the existing extractor contract tests cover `SkipItemCount`/`MaximumItemCount`, which are client-side. `ServerOffset`, `ServerLimit` and `PagingClauseTemplate` had never been run against a database, which would have made these presets a set of strings nobody had executed.

`IDbProviderFixture` now declares a `PagingClauseTemplate` per engine, so each fixture asserts its own dialect and **the preset itself is the thing under test**. The property is abstract on `DbProviderFixtureBase`, so a newly added engine has to make an explicit choice rather than silently inheriting a default.

| Fixture | Preset | |
|---|---|---|
| `SqlServerFixture` | `SqlServer` | `OFFSET/FETCH` verified on a real SQL Server |
| `PostgresFixture` | `PostgreSql` | |
| `MySqlFixture` | `MySql` | |
| `SqliteFixture` | `Sqlite` | |
| `MariaDbFixture` | `MySql` | MySQL-compatible for paging syntax |
| `CockroachDbFixture` | `PostgreSql` | PostgreSQL wire-compatible |

Five contract tests inherited by all six engines — 30 cases. Beyond the obvious window check: paging through the whole table yields every row exactly once, with a deliberately partial final page (7 rows in pages of 3), catching gaps, duplicates and ordering drift; a limit past the end returns only what remains; an offset past the last row yields nothing; and setting only `ServerLimit` does not page at all, which is silent behavior today worth pinning.

**Integration suite: 42 → 72 tests, 0 skipped.**

### Negative control

The tests were verified to have teeth rather than assumed to. Giving `SqlServerFixture` the `MySql` preset fails 4 of the 5 with `Incorrect syntax near 'LIMIT'` — the exact error these presets exist to prevent — and correctly leaves the fifth passing, since no clause is appended when only a limit is set.

### Known gap

`PagingClauseTemplates.Oracle` and `.Db2` **ship unverified** — there are no fixtures for those engines (#355, #356). They rest on the `OFFSET/FETCH` form being identical to SQL Server's, which the tests do confirm, rather than on a direct test. Noted on both issues: adding a fixture picks up all 5 paging tests for free.
