### PR TITLE
docs(paging): state the both-or-neither paging rule at every surface

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -601,12 +601,16 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// SQLite, PostgreSQL, and MySQL don't require it but you should still
     /// include one — without a stable order, page contents drift.
     /// </para>
+    /// <para>
+    /// Paging is applied only when <b>both</b> this and <see cref="ServerLimit"/> are set; setting one alone is a silent no-op.
+    /// </para>
     /// </remarks>
     public long? ServerOffset { get; [Obsolete("Configure ServerOffset through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; }
 
 
 
     /// <summary>Page size in rows. See <see cref="ServerOffset"/>.</summary>
+    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerOffset"/> are set; setting one alone is a silent no-op.</remarks>
     public long? ServerLimit { get; [Obsolete("Configure ServerLimit through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -59,6 +59,7 @@ public sealed record DbExtractorOptions
     /// <summary>
     /// Gets the server-side row offset for paging. Defaults to <see langword="null"/> (no paging).
     /// </summary>
+    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerLimit"/> are set; setting one alone is a silent no-op.</remarks>
     public long? ServerOffset { get; init; }
 
 
@@ -66,6 +67,7 @@ public sealed record DbExtractorOptions
     /// <summary>
     /// Gets the server-side row limit for paging. Defaults to <see langword="null"/> (no paging).
     /// </summary>
+    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerOffset"/> are set; setting one alone is a silent no-op.</remarks>
     public long? ServerLimit { get; init; }
 
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -87,8 +87,10 @@ public sealed record DbExtractorOptions
     /// dialect with no preset can be supplied directly.
     /// </para>
     /// <para>
-    /// The <c>OFFSET … FETCH</c> form additionally requires the base SQL to end with an
-    /// <c>ORDER BY</c> — SQL Server and Oracle both reject it otherwise.
+    /// The <c>OFFSET … FETCH</c> form additionally requires an <c>ORDER BY</c> at the end of the
+    /// command text <i>you supply</i> — the paging clause is appended after it, so the finished
+    /// statement ends with the paging clause, not the <c>ORDER BY</c>. SQL Server and Oracle both
+    /// reject the form otherwise.
     /// </para>
     /// <para>
     /// A custom template must reference both <c>@PageOffset</c> and <c>@PageLimit</c> — those are

--- a/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
@@ -72,8 +72,10 @@ public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
     /// Use a preset from <see cref="PagingClauseTemplates"/>, e.g.
     /// <c>.PagingClauseTemplate(PagingClauseTemplates.SqlServer)</c>.
     /// <para>
-    /// The <c>OFFSET … FETCH</c> form additionally requires the command text to end with an
-    /// <c>ORDER BY</c> — SQL Server and Oracle both reject it otherwise.
+    /// The <c>OFFSET … FETCH</c> form additionally requires an <c>ORDER BY</c> at the end of the
+    /// command text <i>you supply</i> — the paging clause is appended after it, so the finished
+    /// statement ends with the paging clause, not the <c>ORDER BY</c>. SQL Server and Oracle both
+    /// reject the form otherwise.
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="template"/> is <see langword="null"/>.</exception>

--- a/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
@@ -50,18 +50,20 @@ public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
     /// <see cref="PagingClauseTemplate"/>, the extractor appends the paging clause
     /// to the caller's SQL.
     /// </summary>
+    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerLimit"/> are set; setting one alone is a silent no-op.</remarks>
     IDbExtractorBuilder<T> ServerOffset(long? offset);
 
 
     /// <summary>
     /// Sets <see cref="DbExtractor{TRecord}.ServerLimit"/> for server-side paging.
     /// </summary>
+    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerOffset"/> are set; setting one alone is a silent no-op.</remarks>
     IDbExtractorBuilder<T> ServerLimit(long? limit);
 
 
     /// <summary>
     /// Sets <see cref="DbExtractor{TRecord}.PagingClauseTemplate"/> — the SQL
-    /// snippet appended when <see cref="ServerOffset"/> and/or
+    /// snippet appended when <b>both</b> <see cref="ServerOffset"/> and
     /// <see cref="ServerLimit"/> are set. Default:
     /// <c>LIMIT @PageLimit OFFSET @PageOffset</c>.
     /// </summary>
@@ -69,6 +71,10 @@ public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
     /// The clause is dialect-specific — the default does not work on SQL Server, Oracle or Db2.
     /// Use a preset from <see cref="PagingClauseTemplates"/>, e.g.
     /// <c>.PagingClauseTemplate(PagingClauseTemplates.SqlServer)</c>.
+    /// <para>
+    /// The <c>OFFSET … FETCH</c> form additionally requires the command text to end with an
+    /// <c>ORDER BY</c> — SQL Server and Oracle both reject it otherwise.
+    /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="template"/> is <see langword="null"/>.</exception>
     IDbExtractorBuilder<T> PagingClauseTemplate(string template);

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 
@@ -13,8 +14,13 @@ public class PagingClauseTemplatesTests
 {
     public static IEnumerable<object[]> AllPresets()
     {
+        // Filter to non-indexed string properties rather than casting blindly: if a
+        // non-string or indexed public static member is added later, an unconditional
+        // cast would throw inside the data generator and the whole theory would fail
+        // to report which preset is actually wrong.
         foreach (var property in typeof(PagingClauseTemplates)
-            .GetProperties(BindingFlags.Public | BindingFlags.Static))
+            .GetProperties(BindingFlags.Public | BindingFlags.Static)
+            .Where(p => p.PropertyType == typeof(string) && p.GetIndexParameters().Length == 0))
         {
             yield return new object[] { property.Name, (string)property.GetValue(null)! };
         }
@@ -31,6 +37,21 @@ public class PagingClauseTemplatesTests
         Assert.Contains("@PageOffset", template, StringComparison.Ordinal);
         Assert.Contains("@PageLimit", template, StringComparison.Ordinal);
     }
+
+
+    [Fact]
+    public void AllPresets_discovers_every_preset()
+    {
+        // The filter in AllPresets() could in principle exclude everything, which would
+        // leave the theory above passing vacuously. Pin the count so a preset that stops
+        // being discovered fails loudly instead of silently going untested.
+        var discovered = AllPresets().Select(row => (string)row[0]).ToList();
+
+        Assert.Equal(6, discovered.Count);
+        Assert.Contains(nameof(PagingClauseTemplates.SqlServer), discovered);
+        Assert.Contains(nameof(PagingClauseTemplates.MySql), discovered);
+    }
+
 
 
     [Fact]

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
@@ -42,14 +42,27 @@ public class PagingClauseTemplatesTests
     [Fact]
     public void AllPresets_discovers_every_preset()
     {
-        // The filter in AllPresets() could in principle exclude everything, which would
-        // leave the theory above passing vacuously. Pin the count so a preset that stops
-        // being discovered fails loudly instead of silently going untested.
-        var discovered = AllPresets().Select(row => (string)row[0]).ToList();
+        // The filter in AllPresets() could in principle exclude everything, which would leave
+        // the theory above passing vacuously. Assert the exact set rather than a count plus a
+        // couple of names: a count alone still passes if one preset disappears and an unrelated
+        // string property takes its place, which is precisely the substitution worth catching.
+        var discovered = AllPresets()
+            .Select(row => (string)row[0])
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
 
-        Assert.Equal(6, discovered.Count);
-        Assert.Contains(nameof(PagingClauseTemplates.SqlServer), discovered);
-        Assert.Contains(nameof(PagingClauseTemplates.MySql), discovered);
+        var expected = new[]
+        {
+            nameof(PagingClauseTemplates.Db2),
+            nameof(PagingClauseTemplates.MySql),
+            nameof(PagingClauseTemplates.Oracle),
+            nameof(PagingClauseTemplates.PostgreSql),
+            nameof(PagingClauseTemplates.Sqlite),
+            nameof(PagingClauseTemplates.SqlServer)
+        }.OrderBy(name => name, StringComparer.Ordinal).ToList();
+
+        // Adding a preset is a deliberate act, so updating this list is part of that act.
+        Assert.Equal(expected, discovered);
     }
 
 


### PR DESCRIPTION
Addresses the two review comments left on #386, which merged before they were handled. Both were valid. Docs and tests only — no signature or behavior change, so no PublicAPI delta.

## 1. `and/or` was factually wrong

`IDbExtractorBuilder.PagingClauseTemplate` said the clause is appended when `ServerOffset` **and/or** `ServerLimit` is set. `ApplyServerPaging` returns early unless *both* are present:

```csharp
if (!ServerOffset.HasValue || !ServerLimit.HasValue)
{
    pagedCommandText = commandText;
    pagedParam = param;
    return;
}
```

#386's own integration test — `ExtractAsync_when_only_ServerLimit_is_set_does_not_page_at_all` — asserts the opposite of what the doc claimed, across all six engines. So this is confirmed by a passing test, not just by reading.

**The reviewer pointed at one line; the gap was in five places.** None of `ServerOffset`/`ServerLimit` on `IDbExtractorBuilder`, `DbExtractorOptions`, or `DbExtractor` mentioned that setting one alone is a silent no-op — the failure mode is that the caller gets *every row* rather than an error, which is worth stating wherever someone might look. All five now say so.

Also carried the `ORDER BY` caveat onto the builder's `PagingClauseTemplate` remarks. It was on `DbExtractorOptions` but not the fluent surface, which is what a builder user actually reads — the reviewer's second point.

## 2. Reflection test cast blindly

`AllPresets()` cast every public static property on `PagingClauseTemplates` to `string`. A non-string or indexed member added later would throw inside the data generator, taking out the theory before it could report which preset was wrong. Now filtered to non-indexed `string` properties.

**That fix introduces a risk of its own,** which the review didn't raise: an over-broad filter would silently leave the theory covering nothing and still pass. `AllPresets_discovers_every_preset` now pins the discovered count at 6, so a preset that stops being discovered fails loudly.

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs — no `CS1574`, so every new `<see cref>` resolves
- [x] Unit: 362 pass (361 + the new count guard), 0 failures
- [x] DocExamples 3/3 and Snapshots 5/5 — the two suites sensitive to XML-doc changes
- [ ] Integration unchanged by this PR; note it has still never run in CI on this stack (`pr.yaml` only triggers on PRs targeting `main`)

Refs #385