### PR TITLE
refactor(paging): initialise the default paging clause from the preset

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -622,8 +622,8 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Defaults to <c>LIMIT @PageLimit OFFSET @PageOffset</c> — the SQLite /
-    /// PostgreSQL / MySQL syntax.
+    /// Defaults to <see cref="PagingClauseTemplates.Sqlite"/>
+    /// (<c>LIMIT @PageLimit OFFSET @PageOffset</c>) — the SQLite / PostgreSQL / MySQL syntax.
     /// </para>
     /// <para>
     /// For SQL Server, set to <c>OFFSET @PageOffset ROWS FETCH NEXT @PageLimit ROWS ONLY</c>
@@ -633,7 +633,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// Prefer the presets on <see cref="PagingClauseTemplates"/> over writing the clause by hand.
     /// </para>
     /// </remarks>
-    public string PagingClauseTemplate { get; [Obsolete("Configure PagingClauseTemplate through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; } = "LIMIT @PageLimit OFFSET @PageOffset";
+    public string PagingClauseTemplate { get; [Obsolete("Configure PagingClauseTemplate through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; } = PagingClauseTemplates.Sqlite;
 
 
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -74,7 +74,8 @@ public sealed record DbExtractorOptions
 
     /// <summary>
     /// Gets the dialect-specific paging clause appended when server paging is active.
-    /// Defaults to <c>"LIMIT @PageLimit OFFSET @PageOffset"</c>.
+    /// Defaults to <see cref="PagingClauseTemplates.Sqlite"/>
+    /// (<c>"LIMIT @PageLimit OFFSET @PageOffset"</c>).
     /// </summary>
     /// <remarks>
     /// <b>This is dialect-specific, not standard SQL.</b> The default is the PostgreSQL / MySQL /
@@ -98,7 +99,7 @@ public sealed record DbExtractorOptions
     /// are set.
     /// </para>
     /// </remarks>
-    public string PagingClauseTemplate { get; init; } = "LIMIT @PageLimit OFFSET @PageOffset";
+    public string PagingClauseTemplate { get; init; } = PagingClauseTemplates.Sqlite;
 
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
@@ -68,11 +68,12 @@ public class PagingClauseTemplatesTests
 
 
     [Fact]
-    public void The_library_default_matches_the_Sqlite_preset()
+    public void The_library_default_is_still_the_LimitOffset_form()
     {
-        // The documented default is the LIMIT/OFFSET form; if one drifts from the other the docs
-        // become wrong silently.
-        Assert.Equal(PagingClauseTemplates.Sqlite, new DbExtractorOptions().PagingClauseTemplate);
+        // DbExtractorOptions now initialises from PagingClauseTemplates.Sqlite, so comparing the
+        // two would be tautological. Assert the literal shape instead: changing the Sqlite preset
+        // silently changes the library-wide default, and that should be a deliberate act.
+        Assert.Equal("LIMIT @PageLimit OFFSET @PageOffset", new DbExtractorOptions().PagingClauseTemplate);
     }
 
 


### PR DESCRIPTION
Stacked on #387. Answers your review comment on #380 (`DbExtractorOptions.cs:97` — "This should now use one of the predefined templates").

The `LIMIT @PageLimit OFFSET @PageOffset` string was written out **three times**: in `PagingClauseTemplates`, in `DbExtractorOptions.PagingClauseTemplate`, and in `DbExtractor.PagingClauseTemplate`. Both defaults now initialise from `PagingClauseTemplates.Sqlite`.

This is exactly why the presets are get-only properties rather than `const` — these initialisers read the value at runtime, so a correction to the preset reaches both defaults. Had they been `const`, the literal would have been baked back in at each site and the duplication would have survived the refactor in all but appearance.

**No behavior change** — the resulting default string is byte-identical.

## One test had to change

`The_library_default_matches_the_Sqlite_preset` asserted `PagingClauseTemplates.Sqlite == new DbExtractorOptions().PagingClauseTemplate`. After this change that is `Sqlite == Sqlite` — tautological, and it would keep passing no matter what either value became.

Replaced with `The_library_default_is_still_the_LimitOffset_form`, which pins the literal shape. Changing the `Sqlite` preset now silently changes the library-wide default for every consumer, so that should be a deliberate act rather than a side effect of editing a preset.

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs
- [x] Unit: 362 pass, 0 failures

Refs #385