### PR TITLE
fix(paging): match parameter names the way providers do

### DIFF
--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -921,7 +921,20 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     {
         foreach (var generated in new[] { "@PageOffset", "@PageLimit" })
         {
-            var suppliedByDictionary = _parameters?.ContainsKey(generated) == true;
+            // ContainsKey would use the caller's own comparer, which is ordinal by default and
+            // so would miss "@pagelimit". Scan explicitly with provider semantics instead.
+            var suppliedByDictionary = false;
+            if (_parameters is not null)
+            {
+                foreach (var key in _parameters.Keys)
+                {
+                    if (ParameterName.Matches(key, generated))
+                    {
+                        suppliedByDictionary = true;
+                        break;
+                    }
+                }
+            }
 
             var suppliedByProperty = false;
             var names = Parameters?.ParameterNames;
@@ -929,8 +942,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
             {
                 foreach (var name in names)
                 {
-                    if (string.Equals(name, generated, StringComparison.Ordinal)
-                        || string.Equals("@" + name, generated, StringComparison.Ordinal))
+                    if (ParameterName.Matches(name, generated))
                     {
                         suppliedByProperty = true;
                         break;

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -921,8 +921,9 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     {
         foreach (var generated in new[] { "@PageOffset", "@PageLimit" })
         {
-            // ContainsKey would use the caller's own comparer, which is ordinal by default and
-            // so would miss "@pagelimit". Scan explicitly with provider semantics instead.
+            // ContainsKey resolves against _parameters' own comparer, which is deliberately
+            // StringComparer.Ordinal, so it would miss "@pagelimit" and the leading-@ variants.
+            // Scan explicitly with the collision-safe comparison instead.
             var suppliedByDictionary = false;
             if (_parameters is not null)
             {

--- a/src/Wolfgang.Etl.DbClient/EtlParameterSet.cs
+++ b/src/Wolfgang.Etl.DbClient/EtlParameterSet.cs
@@ -112,8 +112,10 @@ internal sealed class EtlParameterSet : SqlMapper.IDynamicParameters, SqlMapper.
     /// SQL Server, PostgreSQL and MySQL resolve parameter names case-insensitively and quietly
     /// use whichever arrived last, so the query returns wrong rows with no error at all. Silently
     /// preferring one here would mean the caller's value or the extractor's paging is discarded
-    /// just as quietly. Names are matched with provider semantics — case-insensitive, leading
-    /// <c>@</c> optional — so <c>@pagelimit</c> collides with <c>@PageLimit</c>. A caller who
+    /// just as quietly. Names are matched conservatively — case-insensitive, leading <c>@</c>
+    /// optional — so <c>@pagelimit</c> collides with <c>@PageLimit</c>. That is stricter than
+    /// SQLite, which alone treats the two as distinct; see <see cref="ParameterName"/> for why
+    /// the stricter rule is preferred. A caller who
     /// supplies this name AND configures the feature that generates it has expressed two
     /// conflicting intentions, and only they can say which was meant.
     /// </remarks>

--- a/src/Wolfgang.Etl.DbClient/EtlParameterSet.cs
+++ b/src/Wolfgang.Etl.DbClient/EtlParameterSet.cs
@@ -108,15 +108,18 @@ internal sealed class EtlParameterSet : SqlMapper.IDynamicParameters, SqlMapper.
     /// The caller's dictionary already contains <paramref name="name"/>.
     /// </exception>
     /// <remarks>
-    /// A collision is rejected rather than resolved. Emitting both would produce a duplicate
-    /// parameter name and the provider would reject the command; silently preferring one would
-    /// mean either the caller's value or the extractor's paging is quietly discarded. A caller who
+    /// A collision is rejected rather than resolved. Emitting both does NOT reliably fail:
+    /// SQL Server, PostgreSQL and MySQL resolve parameter names case-insensitively and quietly
+    /// use whichever arrived last, so the query returns wrong rows with no error at all. Silently
+    /// preferring one here would mean the caller's value or the extractor's paging is discarded
+    /// just as quietly. Names are matched with provider semantics — case-insensitive, leading
+    /// <c>@</c> optional — so <c>@pagelimit</c> collides with <c>@PageLimit</c>. A caller who
     /// supplies this name AND configures the feature that generates it has expressed two
     /// conflicting intentions, and only they can say which was meant.
     /// </remarks>
     internal void Add(string name, object value)
     {
-        if (_source.ContainsKey(name))
+        if (ContainsMatching(name))
         {
             throw new InvalidOperationException
             (
@@ -129,6 +132,21 @@ internal sealed class EtlParameterSet : SqlMapper.IDynamicParameters, SqlMapper.
         }
 
         _added[name] = value;
+    }
+
+
+
+    private bool ContainsMatching(string name)
+    {
+        foreach (var key in _source.Keys)
+        {
+            if (ParameterName.Matches(key, name))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 

--- a/src/Wolfgang.Etl.DbClient/ParameterName.cs
+++ b/src/Wolfgang.Etl.DbClient/ParameterName.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Wolfgang.Etl.DbClient;
+
+/// <summary>
+/// Compares parameter names the way a database provider does.
+/// </summary>
+/// <remarks>
+/// Providers do not agree with .NET's default string comparison here, and the disagreement
+/// is silent. Supplying both <c>@PageLimit</c> and <c>@pagelimit</c> to one command was
+/// measured against live engines: SQL Server, PostgreSQL and MySQL all resolve the name
+/// case-insensitively and quietly use whichever arrived last, returning wrong rows with no
+/// error; only SQLite treats the two as distinct. An ordinal comparison therefore lets a
+/// caller-supplied name shadow a generated one on three of the four engines the suite covers.
+/// <para>
+/// The leading <c>@</c> is optional on both sides because Dapper stores names without it,
+/// so <c>PageLimit</c> and <c>@PageLimit</c> reach the provider as the same parameter.
+/// </para>
+/// </remarks>
+internal static class ParameterName
+{
+    /// <summary>
+    /// Determines whether two parameter names would reach the provider as the same parameter.
+    /// </summary>
+    /// <param name="left">The first name, with or without a leading <c>@</c>.</param>
+    /// <param name="right">The second name, with or without a leading <c>@</c>.</param>
+    /// <returns><see langword="true"/> when the provider would treat them as one parameter.</returns>
+    public static bool Matches(string? left, string? right)
+    {
+        return string.Equals(Normalize(left), Normalize(right), StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    private static string Normalize(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return string.Empty;
+        }
+
+        return name![0] == '@' ? name.Substring(1) : name;
+    }
+}

--- a/src/Wolfgang.Etl.DbClient/ParameterName.cs
+++ b/src/Wolfgang.Etl.DbClient/ParameterName.cs
@@ -3,15 +3,24 @@ using System;
 namespace Wolfgang.Etl.DbClient;
 
 /// <summary>
-/// Compares parameter names the way a database provider does.
+/// Compares parameter names conservatively enough to be safe on every supported provider.
 /// </summary>
 /// <remarks>
-/// Providers do not agree with .NET's default string comparison here, and the disagreement
-/// is silent. Supplying both <c>@PageLimit</c> and <c>@pagelimit</c> to one command was
-/// measured against live engines: SQL Server, PostgreSQL and MySQL all resolve the name
-/// case-insensitively and quietly use whichever arrived last, returning wrong rows with no
-/// error; only SQLite treats the two as distinct. An ordinal comparison therefore lets a
-/// caller-supplied name shadow a generated one on three of the four engines the suite covers.
+/// This deliberately does NOT reproduce any one provider's rules — no single provider behaves
+/// exactly like this. It is the union: a name pair is treated as colliding if <i>any</i>
+/// supported provider would treat it as one parameter.
+/// <para>
+/// Supplying both <c>@PageLimit</c> and <c>@pagelimit</c> to one command was measured against
+/// live engines. SQL Server, PostgreSQL and MySQL all resolve the name case-insensitively and
+/// quietly use whichever arrived last, returning wrong rows with no error at all. Only SQLite
+/// treats the two as distinct. An ordinal comparison therefore lets a caller-supplied name
+/// shadow a generated one on three of the four engines the suite covers.
+/// </para>
+/// <para>
+/// The trade-off is accepted knowingly: on SQLite this rejects a pair the engine would have
+/// accepted. Refusing an ambiguous name there is a loud, immediate error the caller can fix,
+/// whereas the alternative is silently wrong results on the other three engines.
+/// </para>
 /// <para>
 /// The leading <c>@</c> is optional on both sides because Dapper stores names without it,
 /// so <c>PageLimit</c> and <c>@PageLimit</c> reach the provider as the same parameter.
@@ -20,11 +29,14 @@ namespace Wolfgang.Etl.DbClient;
 internal static class ParameterName
 {
     /// <summary>
-    /// Determines whether two parameter names would reach the provider as the same parameter.
+    /// Determines whether two parameter names could reach any supported provider as one parameter.
     /// </summary>
     /// <param name="left">The first name, with or without a leading <c>@</c>.</param>
     /// <param name="right">The second name, with or without a leading <c>@</c>.</param>
-    /// <returns><see langword="true"/> when the provider would treat them as one parameter.</returns>
+    /// <returns>
+    /// <see langword="true"/> when at least one supported provider would treat them as a single
+    /// parameter. Case-insensitive, so this is stricter than SQLite alone — see the type remarks.
+    /// </returns>
     public static bool Matches(string? left, string? right)
     {
         return string.Equals(Normalize(left), Normalize(right), StringComparison.OrdinalIgnoreCase);

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterBindingTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterBindingTests.cs
@@ -303,4 +303,56 @@ public class EtlParameterBindingTests
 
         Assert.Contains("@PageOffset", ex.Message, StringComparison.Ordinal);
     }
+
+
+    [Theory]
+    [InlineData("@pageoffset")]   // lower
+    [InlineData("@PAGEOFFSET")]   // upper
+    [InlineData("PageOffset")]    // no leading @, as Dapper stores it
+    [InlineData("pageoffset")]    // both at once
+    public async Task A_caller_supplied_name_collides_regardless_of_case_or_at_sign(string suppliedName)
+    {
+        // Measured against live engines: SQL Server, PostgreSQL and MySQL all resolve parameter
+        // names case-insensitively and quietly use whichever value arrived last, so an ordinal
+        // guard lets the caller's "@pageoffset" shadow the generated "@PageOffset" and the query
+        // returns wrong rows with NO error. Only SQLite treats the two as distinct.
+        using var conn = Seeded();
+
+        var sut = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
+            new Dictionary<string, object> { ["@min"] = 0, [suppliedName] = 99 },
+            new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+        );
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in sut.ExtractAsync()) { }
+        });
+
+        Assert.Contains("@PageOffset", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    [Fact]
+    public async Task A_caller_supplied_name_that_merely_shares_a_prefix_is_not_rejected()
+    {
+        // The guard must not over-reach: normalising the leading @ and ignoring case should not
+        // make "@PageOffsetCutoff" look like "@PageOffset".
+        using var conn = Seeded();
+
+        var sut = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name, last_name, age FROM People WHERE age > @PageOffsetCutoff ORDER BY age",
+            new Dictionary<string, object> { ["@PageOffsetCutoff"] = 0 },
+            new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+        );
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Single(results);
+    }
 }


### PR DESCRIPTION
Stacked on #388. Answers your review comment on #380 (`DbExtractor.cs:920` — "Do we need case incentive compare").

**Yes — and the failure mode is worse than an error.** I couldn't answer this by reading, because it hinges on whether providers treat `@pageoffset` and `@PageOffset` as the *same* parameter. If they were distinct, a case-insensitive guard would throw a false positive. So I measured it: supplying both `@PageLimit`=2 and `@pagelimit`=3 to one command, against the live containers.

| Engine | Result |
|---|---|
| SQL Server | **3 rows** — lowercase silently won |
| PostgreSQL | **3 rows** — lowercase silently won |
| MySQL | **3 rows** — lowercase silently won |
| SQLite | 2 rows — case-sensitive, correct value |

**No error on any of them.** On three of the four engines the suite covers, a caller-supplied `@pagelimit` silently shadows paging's generated `@PageLimit` and the query returns wrong rows with no signal at all. The ordinal guard let it straight through.

## The fix

`ParameterName.Matches` compares with provider semantics: case-insensitive, leading `@` optional. The `@` half matters independently — Dapper stores names without it, so `PageOffset` and `@PageOffset` reach the provider as one parameter, and the old dictionary check would have missed that too.

Applied at **both** guard sites — `EnsurePagingParametersNotAlreadySupplied` and `EtlParameterSet.Add`. The dictionary check no longer uses `ContainsKey`, which resolved against the *caller's* comparer (ordinal by default) rather than the provider's.

## A doc that was wrong

`EtlParameterSet.Add`'s remarks claimed a duplicate name means "the provider would reject the command". The measurements above disprove that — it silently picks one. Corrected, since that sentence was the stated justification for rejecting rather than resolving a collision, and the real justification is stronger.

## Tests

A theory over `@pageoffset`, `@PAGEOFFSET`, `PageOffset` and `pageoffset`, plus `A_caller_supplied_name_that_merely_shares_a_prefix_is_not_rejected` — `@PageOffsetCutoff` must still work, so the normalisation can't over-reach.

Verified by negative control rather than assumed: reverting to `StringComparison.Ordinal` fails 3 of the 4 cases, and the 4th still passes because `@`-normalisation is independent of case. Both halves are separately covered.

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs
- [x] Full suite: **458 tests, 0 failures** across all 7 projects
- [x] Integration 72/72 — the guard change doesn't disturb the paging contract tests
- [x] Negative control confirms the tests fail without the fix

Refs #385