### PR TITLE
feat(paging)!: default PagingClauseTemplate to None instead of a dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `PagingClauseTemplate` now defaults to `PagingClauseTemplates.None` (`null`)
+  instead of the `LIMIT`/`OFFSET` form (#391).** There is no portable paging syntax, so any
+  default privileges some engines and breaks the rest: the old default produced
+  `Incorrect syntax near 'LIMIT'` on SQL Server, Oracle and Db2. Activating server-side paging
+  (setting **both** `ServerOffset` and `ServerLimit`) without choosing a template now throws
+  `InvalidOperationException` naming the presets, instead of emitting SQL only some engines
+  accept.
+
+  Callers on SQLite, PostgreSQL or MySQL who relied on the implicit default must name a
+  template — a one-line change, e.g. `PagingClauseTemplate = PagingClauseTemplates.Sqlite`.
+  `DbExtractor<TRecord>.PagingClauseTemplate` changed from `string` to `string?`, and the
+  builder's `PagingClauseTemplate(string?)` now accepts `null`, meaning `None`.
+
 - **Source-compatibility note: a positional `null` in the transaction argument is now ambiguous.**
   The new options overloads sit in the same position as the optional `DbTransaction?`, so a call
   passing an untyped `null` there — `new DbExtractor<T>(conn, "SELECT 1", null)` — no longer compiles

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ await EtlPipeline
     .Create()
     .DbExtractor<Invoice>(sourceConn, "SELECT * FROM Invoices WHERE Status = @Status")
     .Parameters(new DynamicParameters(new { Status = "paid" }))
+    .PagingClauseTemplate(PagingClauseTemplates.SqlServer)  // required: paging syntax is dialect-specific
     .ServerOffset(0)
     .ServerLimit(1000)
     .DbLoader<Invoice>(destConn, "INSERT INTO PaidInvoices (Id, Total) VALUES (@Id, @Total)")

--- a/docfx_project/docs/etl-pipeline.md
+++ b/docfx_project/docs/etl-pipeline.md
@@ -107,6 +107,7 @@ var extractor = serviceProvider.GetRequiredService<DbExtractor<Person>>();
 await EtlPipeline
     .Create()
     .DbExtractor(extractor)           // reuse the DI-registered instance
+    .PagingClauseTemplate(PagingClauseTemplates.PostgreSql)
     .ServerOffset(0)                  // mutates `extractor.ServerOffset`
     .ServerLimit(500)
     .DbLoader<Person>(destConn, insertSql)
@@ -120,6 +121,7 @@ await EtlPipeline
     .Create()
     .DbExtractor<Invoice>(conn, "SELECT * FROM Invoices WHERE Status = @Status")
     .Parameters(new DynamicParameters(new { Status = "paid" }))
+    .PagingClauseTemplate(PagingClauseTemplates.PostgreSql)
     .ServerOffset(1000)
     .ServerLimit(500)
     .DbLoader<Invoice>(destConn, "INSERT INTO PaidInvoicesPage2 ...")
@@ -127,10 +129,14 @@ await EtlPipeline
 ```
 
 When both `ServerOffset` and `ServerLimit` are set, the extractor appends
-`PagingClauseTemplate` (default `LIMIT @PageLimit OFFSET @PageOffset`) to the
-command text and adds `@PageOffset` / `@PageLimit` to the parameter set. For
-databases that use a different paging dialect (e.g. SQL Server's
-`OFFSET n ROWS FETCH NEXT m ROWS ONLY`), override the template:
+`PagingClauseTemplate` to the command text and adds `@PageOffset` / `@PageLimit`
+to the parameter set.
+
+`PagingClauseTemplate` **must be set** — it defaults to `PagingClauseTemplates.None`.
+Paging syntax is dialect-specific and no portable form exists, so the library does
+not guess one; activating paging without a template throws
+`InvalidOperationException` rather than emitting SQL only some engines accept.
+Use a preset, or supply your own clause referencing `@PageOffset` and `@PageLimit`:
 
 ```csharp
 await EtlPipeline
@@ -138,7 +144,7 @@ await EtlPipeline
     .DbExtractor<Invoice>(conn, "SELECT * FROM Invoices ORDER BY Id")
     .ServerOffset(0)
     .ServerLimit(500)
-    .PagingClauseTemplate("OFFSET @PageOffset ROWS FETCH NEXT @PageLimit ROWS ONLY")
+    .PagingClauseTemplate(PagingClauseTemplates.SqlServer)
     .DbLoader<Invoice>(destConn, "...")
     .RunAsync();
 ```

--- a/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
+++ b/examples/Wolfgang.Etl.DbClient.Example.EtlPipeline/Program.cs
@@ -92,6 +92,7 @@ using (var cmd = page.CreateCommand())
 await EtlPipeline
     .Create()
     .DbExtractor<Order>(src, "SELECT Id, Customer, Total FROM Orders ORDER BY Id")
+    .PagingClauseTemplate(PagingClauseTemplates.Sqlite)
     .ServerOffset(5)
     .ServerLimit(5)
     .DbLoader<Order>(page, "INSERT INTO OrdersPage (Id, Customer, Total) VALUES (@Id, @Customer, @Total)")

--- a/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Program.cs
+++ b/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Program.cs
@@ -80,6 +80,9 @@ for (long offset = 0; offset < totalRows; offset += pageSize)
         "SELECT id AS Id, name AS Name, price AS Price FROM widget ORDER BY id"
     )
     {
+        // The source here is SQLite. Paging syntax is dialect-specific and the library no
+        // longer guesses one, so the dialect has to be named.
+        PagingClauseTemplate = PagingClauseTemplates.Sqlite,
         ServerOffset = offset,
         ServerLimit = pageSize,
     };

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -899,25 +899,6 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     }
 
     /// <summary>
-    /// Rejects a caller-supplied parameter whose name server-side paging also generates.
-    /// </summary>
-    /// <remarks>
-    /// This cannot live inside either branch of <see cref="ApplyServerPaging"/>.
-    /// <c>EtlParameterSet</c> can detect a collision itself, but the <c>DynamicParameters</c>
-    /// branch cannot — its <c>Add</c> silently overwrites, so the caller's value would disappear
-    /// without a word.
-    /// <para>
-    /// Two routes can carry a caller's parameters and both are checked: the constructor
-    /// dictionary, and the obsolete <see cref="Parameters"/> property — which takes
-    /// <em>precedence</em> over the dictionary where the parameter set is resolved, so checking
-    /// only the dictionary would miss it entirely. Dapper stores names without the leading
-    /// <c>@</c>, hence both spellings are compared.
-    /// </para>
-    /// </remarks>
-    /// <exception cref="InvalidOperationException">
-    /// A generated paging parameter name was already supplied by the caller.
-    /// </exception>
-    /// <summary>
     /// Verifies a paging dialect was chosen before server-side paging is applied.
     /// </summary>
     /// <exception cref="InvalidOperationException">
@@ -944,6 +925,25 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
 
+    /// <summary>
+    /// Rejects a caller-supplied parameter whose name server-side paging also generates.
+    /// </summary>
+    /// <remarks>
+    /// This cannot live inside either branch of <see cref="ApplyServerPaging"/>.
+    /// <c>EtlParameterSet</c> can detect a collision itself, but the <c>DynamicParameters</c>
+    /// branch cannot — its <c>Add</c> silently overwrites, so the caller's value would disappear
+    /// without a word.
+    /// <para>
+    /// Two routes can carry a caller's parameters and both are checked: the constructor
+    /// dictionary, and the obsolete <see cref="Parameters"/> property — which takes
+    /// <em>precedence</em> over the dictionary where the parameter set is resolved, so checking
+    /// only the dictionary would miss it entirely. Dapper stores names without the leading
+    /// <c>@</c>, hence both spellings are compared.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// A generated paging parameter name was already supplied by the caller.
+    /// </exception>
     private void EnsurePagingParametersNotAlreadySupplied()
     {
         foreach (var generated in new[] { "@PageOffset", "@PageLimit" })

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -622,8 +622,8 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Defaults to <see cref="PagingClauseTemplates.Sqlite"/>
-    /// (<c>LIMIT @PageLimit OFFSET @PageOffset</c>) — the SQLite / PostgreSQL / MySQL syntax.
+    /// Defaults to <see cref="PagingClauseTemplates.None"/>: no dialect is assumed, because
+    /// there is no portable paging syntax. Activating paging without choosing a template throws.
     /// </para>
     /// <para>
     /// For SQL Server, set to <c>OFFSET @PageOffset ROWS FETCH NEXT @PageLimit ROWS ONLY</c>
@@ -633,7 +633,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// Prefer the presets on <see cref="PagingClauseTemplates"/> over writing the clause by hand.
     /// </para>
     /// </remarks>
-    public string PagingClauseTemplate { get; [Obsolete("Configure PagingClauseTemplate through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; } = PagingClauseTemplates.Sqlite;
+    public string? PagingClauseTemplate { get; [Obsolete("Configure PagingClauseTemplate through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; } = PagingClauseTemplates.None;
 
 
 
@@ -917,6 +917,33 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// <exception cref="InvalidOperationException">
     /// A generated paging parameter name was already supplied by the caller.
     /// </exception>
+    /// <summary>
+    /// Verifies a paging dialect was chosen before server-side paging is applied.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Paging is active but <see cref="PagingClauseTemplate"/> is
+    /// <see cref="PagingClauseTemplates.None"/>.
+    /// </exception>
+    private void EnsurePagingClauseTemplateChosen()
+    {
+        if (!string.IsNullOrWhiteSpace(PagingClauseTemplate))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException
+        (
+            "Server-side paging requires PagingClauseTemplate to be set, because paging syntax " +
+            "is dialect-specific and no portable form exists. Choose a preset from " +
+            "PagingClauseTemplates (for example PagingClauseTemplates.SqlServer, .PostgreSql, " +
+            ".MySql, .Sqlite, .Oracle or .Db2), or supply your own clause referencing " +
+            "@PageOffset and @PageLimit. To disable paging instead, clear ServerOffset and " +
+            "ServerLimit."
+        );
+    }
+
+
+
     private void EnsurePagingParametersNotAlreadySupplied()
     {
         foreach (var generated in new[] { "@PageOffset", "@PageLimit" })
@@ -996,6 +1023,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
             return;
         }
 
+        EnsurePagingClauseTemplateChosen();
         EnsurePagingParametersNotAlreadySupplied();
 
         // Both parameter shapes accept additions, by different methods.

--- a/src/Wolfgang.Etl.DbClient/DbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorBuilder.cs
@@ -91,13 +91,10 @@ internal sealed class DbExtractorBuilder<T> : IDbExtractorBuilder<T>
 
 
 
-    public IDbExtractorBuilder<T> PagingClauseTemplate(string template)
+    public IDbExtractorBuilder<T> PagingClauseTemplate(string? template)
     {
-        if (template is null)
-        {
-            throw new ArgumentNullException(nameof(template));
-        }
-
+        // null is meaningful here: it is PagingClauseTemplates.None, "no dialect chosen".
+        // Rejecting it would make .PagingClauseTemplate(PagingClauseTemplates.None) throw.
         _extractor.PagingClauseTemplate = template;
         return this;
     }

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -74,8 +74,7 @@ public sealed record DbExtractorOptions
 
     /// <summary>
     /// Gets the dialect-specific paging clause appended when server paging is active.
-    /// Defaults to <see cref="PagingClauseTemplates.Sqlite"/>
-    /// (<c>"LIMIT @PageLimit OFFSET @PageOffset"</c>).
+    /// Defaults to <see cref="PagingClauseTemplates.None"/> — no dialect chosen.
     /// </summary>
     /// <remarks>
     /// <b>This is dialect-specific, not standard SQL.</b> The default is the PostgreSQL / MySQL /
@@ -99,7 +98,7 @@ public sealed record DbExtractorOptions
     /// are set.
     /// </para>
     /// </remarks>
-    public string PagingClauseTemplate { get; init; } = PagingClauseTemplates.Sqlite;
+    public string? PagingClauseTemplate { get; init; } = PagingClauseTemplates.None;
 
 
 

--- a/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
@@ -64,12 +64,20 @@ public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
     /// <summary>
     /// Sets <see cref="DbExtractor{TRecord}.PagingClauseTemplate"/> — the SQL
     /// snippet appended when <b>both</b> <see cref="ServerOffset"/> and
-    /// <see cref="ServerLimit"/> are set. Default:
-    /// <c>LIMIT @PageLimit OFFSET @PageOffset</c>.
+    /// <see cref="ServerLimit"/> are set. Defaults to
+    /// <see cref="PagingClauseTemplates.None"/>.
     /// </summary>
+    /// <param name="template">
+    /// The paging clause, normally a preset from <see cref="PagingClauseTemplates"/>.
+    /// <see langword="null"/> is accepted and means <see cref="PagingClauseTemplates.None"/> —
+    /// no dialect chosen — which is the default.
+    /// </param>
     /// <remarks>
-    /// The clause is dialect-specific — the default does not work on SQL Server, Oracle or Db2.
-    /// Use a preset from <see cref="PagingClauseTemplates"/>, e.g.
+    /// The clause is dialect-specific and there is no portable form, so this library does not
+    /// guess one. Activating paging (setting <b>both</b> <see cref="ServerOffset"/> and
+    /// <see cref="ServerLimit"/>) while no template has been chosen throws
+    /// <see cref="System.InvalidOperationException"/> rather than emitting SQL that only some
+    /// engines accept. Use a preset, e.g.
     /// <c>.PagingClauseTemplate(PagingClauseTemplates.SqlServer)</c>.
     /// <para>
     /// The <c>OFFSET … FETCH</c> form additionally requires an <c>ORDER BY</c> at the end of the

--- a/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
@@ -78,8 +78,7 @@ public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
     /// reject the form otherwise.
     /// </para>
     /// </remarks>
-    /// <exception cref="ArgumentNullException"><paramref name="template"/> is <see langword="null"/>.</exception>
-    IDbExtractorBuilder<T> PagingClauseTemplate(string template);
+    IDbExtractorBuilder<T> PagingClauseTemplate(string? template);
 
 
     /// <summary>

--- a/src/Wolfgang.Etl.DbClient/PagingClauseTemplates.cs
+++ b/src/Wolfgang.Etl.DbClient/PagingClauseTemplates.cs
@@ -35,6 +35,20 @@ public static class PagingClauseTemplates
     private const string OffsetFetch = "OFFSET @PageOffset ROWS FETCH NEXT @PageLimit ROWS ONLY";
 
 
+    /// <summary>
+    /// No dialect chosen. This is the default, and it is <see langword="null"/>.
+    /// </summary>
+    /// <remarks>
+    /// This does NOT disable paging — paging is controlled by <c>ServerOffset</c> and
+    /// <c>ServerLimit</c>, and applies only when both are set. <see cref="None"/> means the
+    /// dialect has not been named yet, so activating paging while it is in effect is an error
+    /// rather than a silent guess: there is no portable paging syntax, and any default this
+    /// library picked would be wrong on half the engines it supports.
+    /// </remarks>
+    public static string? None { get; }
+
+
+
     /// <summary>MySQL and MariaDB — <c>LIMIT … OFFSET …</c>.</summary>
     public static string MySql { get; } = LimitOffset;
 

--- a/src/Wolfgang.Etl.DbClient/PagingClauseTemplates.cs
+++ b/src/Wolfgang.Etl.DbClient/PagingClauseTemplates.cs
@@ -45,7 +45,7 @@ public static class PagingClauseTemplates
     /// rather than a silent guess: there is no portable paging syntax, and any default this
     /// library picked would be wrong on half the engines it supports.
     /// </remarks>
-    public static string? None { get; }
+    public static string? None => null;
 
 
 

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -20,7 +20,7 @@ Wolfgang.Etl.DbClient.DbExtractorOptions.CommandType.get -> System.Data.CommandT
 Wolfgang.Etl.DbClient.DbExtractorOptions.CommandType.init -> void
 Wolfgang.Etl.DbClient.DbExtractorOptions.ManageConnection.get -> bool
 Wolfgang.Etl.DbClient.DbExtractorOptions.ManageConnection.init -> void
-Wolfgang.Etl.DbClient.DbExtractorOptions.PagingClauseTemplate.get -> string!
+Wolfgang.Etl.DbClient.DbExtractorOptions.PagingClauseTemplate.get -> string?
 Wolfgang.Etl.DbClient.DbExtractorOptions.PagingClauseTemplate.init -> void
 Wolfgang.Etl.DbClient.DbExtractorOptions.ServerLimit.get -> long?
 Wolfgang.Etl.DbClient.DbExtractorOptions.ServerLimit.init -> void
@@ -77,7 +77,7 @@ Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.ManageConnection(bool manage) -> Wo
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.Parameters(Dapper.DynamicParameters! parameters) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.ServerOffset(long? offset) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.ServerLimit(long? limit) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
-Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.PagingClauseTemplate(string! template) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.PagingClauseTemplate(string? template) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
 Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.TotalCountQuery(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<int>!>! countQuery) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
 Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>
 Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>.CommandType(System.Data.CommandType commandType) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!
@@ -89,3 +89,6 @@ static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbExtractor<T>(this W
 static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.Data.Common.DbConnection! connection, string! commandText, System.Data.Common.DbTransaction? transaction = null) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!
 static Wolfgang.Etl.DbClient.EtlPipelineDbClientExtensions.DbLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, Wolfgang.Etl.DbClient.DbLoader<T>! loader) -> Wolfgang.Etl.DbClient.IDbLoaderBuilder<T>!
 Wolfgang.Etl.DbClient.PagingClauseTemplates
+*REMOVED*Wolfgang.Etl.DbClient.DbExtractor<TRecord>.PagingClauseTemplate.get -> string!
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.PagingClauseTemplate.get -> string?
+static Wolfgang.Etl.DbClient.PagingClauseTemplates.None.get -> string?

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -613,7 +613,8 @@ public class DbExtractorTests
 
         Assert.Null(extractor.ServerOffset);
         Assert.Null(extractor.ServerLimit);
-        Assert.Equal("LIMIT @PageLimit OFFSET @PageOffset", extractor.PagingClauseTemplate);
+        // No dialect is assumed; see PagingClauseTemplates.None.
+        Assert.Null(extractor.PagingClauseTemplate);
     }
 
 
@@ -625,6 +626,7 @@ public class DbExtractorTests
 
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
         {
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
             ServerOffset = 0,
             ServerLimit = 5
         };
@@ -645,6 +647,7 @@ public class DbExtractorTests
 
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
         {
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
             ServerOffset = 10,
             ServerLimit = 5
         };
@@ -655,6 +658,49 @@ public class DbExtractorTests
         Assert.Equal(5, records.Count);
         Assert.Equal("First11", records[0].FirstName);
         Assert.Equal("First15", records[4].FirstName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_paging_is_active_without_a_template_throws_and_names_the_fix()
+    {
+        // The whole point of defaulting to None: without this the caller gets a raw provider
+        // syntax error ("Incorrect syntax near 'LIMIT'" on SQL Server) instead of being told
+        // what to do. Assert the message actually carries the remedy.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 5);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People ORDER BY id")
+        {
+            ServerOffset = 0,
+            ServerLimit = 2
+        };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in extractor.ExtractAsync()) { }
+        });
+
+        Assert.Contains("PagingClauseTemplate", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("PagingClauseTemplates", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("ServerOffset", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_paging_is_inactive_does_not_require_a_template()
+    {
+        // None is only an error when paging is actually switched on. Leaving it at the default
+        // while not paging must stay silent, or every non-paging caller would break.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 5);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People ORDER BY id");
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(5, records.Count);
+        Assert.Null(extractor.PagingClauseTemplate);
     }
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbOptionsDefaultsTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbOptionsDefaultsTests.cs
@@ -65,7 +65,8 @@ public class DbOptionsDefaultsTests
 
         Assert.Null(sut.CommandTimeout);
         Assert.Equal(CommandType.Text, sut.CommandType);
-        Assert.Equal("LIMIT @PageLimit OFFSET @PageOffset", sut.PagingClauseTemplate);
+        // No dialect is assumed; see PagingClauseTemplates.None.
+        Assert.Null(sut.PagingClauseTemplate);
         Assert.False(sut.ManageConnection);
     }
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterBindingTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterBindingTests.cs
@@ -129,7 +129,7 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
             supplied,
-            new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
         );
 
         var rows = new List<PersonRecord>();
@@ -164,7 +164,7 @@ public class EtlParameterBindingTests
                 ["@min"] = new EtlParameter<int> { Value = 0 },
                 ["@PageOffset"] = 99          // the name paging also generates
             },
-            new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
         );
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -209,7 +209,7 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
             new Dictionary<string, object> { ["@min"] = 0 },
-            new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
         );
 
         var rows = new List<PersonRecord>();
@@ -236,7 +236,7 @@ public class EtlParameterBindingTests
                 ["@min"] = 0,
                 ["@PageOffset"] = 99
             },
-            new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
         );
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -260,7 +260,7 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
             new Dictionary<string, object> { ["@min"] = 0, ["@PageLimit"] = 5 },
-            new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
         );
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -289,7 +289,7 @@ public class EtlParameterBindingTests
         (
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
-            options: new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+            options: new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
         )
         {
             Parameters = dynamic
@@ -323,7 +323,7 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
             new Dictionary<string, object> { ["@min"] = 0, [suppliedName] = 99 },
-            new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
         );
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -348,7 +348,7 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @PageOffsetCutoff ORDER BY age",
             new Dictionary<string, object> { ["@PageOffsetCutoff"] = 0 },
-            new DbExtractorOptions { ServerOffset = 1, ServerLimit = 1 }
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
         );
 
         var results = await sut.ExtractAsync().ToListAsync();

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs
@@ -113,6 +113,7 @@ public class EtlPipelineDbClientExtensionsTests
         await EtlPipeline
             .Create()
             .DbExtractor<Widget>(src, "SELECT Id, Name FROM source ORDER BY Id")
+            .PagingClauseTemplate(PagingClauseTemplates.Sqlite)
             .ServerOffset(1)
             .ServerLimit(2)
             .DbLoader<Widget>(dest, "INSERT INTO dest (Id, Name) VALUES (@Id, @Name)")
@@ -201,6 +202,7 @@ public class EtlPipelineDbClientExtensionsTests
         await EtlPipeline
             .Create()
             .DbExtractor(extractor)
+            .PagingClauseTemplate(PagingClauseTemplates.Sqlite)
             .ServerOffset(0)
             .ServerLimit(2)
             .DbLoader<Widget>(dest, "INSERT INTO dest (Id, Name) VALUES (@Id, @Name)")
@@ -343,14 +345,19 @@ public class EtlPipelineDbClientExtensionsTests
 
 
     [Fact]
-    public void Extractor_builder_PagingClauseTemplate_null_throws_ArgumentNullException()
+    public void Extractor_builder_PagingClauseTemplate_accepts_null_as_None()
     {
+        // Reversed deliberately. null is no longer invalid — it is PagingClauseTemplates.None,
+        // "no dialect chosen". Rejecting it would make .PagingClauseTemplate(None) throw, which
+        // would be an obvious trap given None is the default.
         using var src = CreateSourceWithRows(1);
         var builder = EtlPipeline
             .Create()
             .DbExtractor<Widget>(src, "SELECT 1");
 
-        Assert.Throws<System.ArgumentNullException>(() => builder.PagingClauseTemplate(null!));
+        var returned = builder.PagingClauseTemplate(PagingClauseTemplates.None);
+
+        Assert.Same(builder, returned);
     }
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClauseTemplatesTests.cs
@@ -20,7 +20,9 @@ public class PagingClauseTemplatesTests
         // to report which preset is actually wrong.
         foreach (var property in typeof(PagingClauseTemplates)
             .GetProperties(BindingFlags.Public | BindingFlags.Static)
-            .Where(p => p.PropertyType == typeof(string) && p.GetIndexParameters().Length == 0))
+            .Where(p => p.PropertyType == typeof(string)
+                && p.GetIndexParameters().Length == 0
+                && p.GetValue(null) is not null))
         {
             yield return new object[] { property.Name, (string)property.GetValue(null)! };
         }
@@ -68,12 +70,24 @@ public class PagingClauseTemplatesTests
 
 
     [Fact]
-    public void The_library_default_is_still_the_LimitOffset_form()
+    public void None_is_null_and_is_the_library_default()
     {
-        // DbExtractorOptions now initialises from PagingClauseTemplates.Sqlite, so comparing the
-        // two would be tautological. Assert the literal shape instead: changing the Sqlite preset
-        // silently changes the library-wide default, and that should be a deliberate act.
-        Assert.Equal("LIMIT @PageLimit OFFSET @PageOffset", new DbExtractorOptions().PagingClauseTemplate);
+        // There is no portable paging syntax, so the library does not guess a dialect. Any
+        // non-null default would be wrong on half the supported engines.
+        Assert.Null(PagingClauseTemplates.None);
+        Assert.Null(new DbExtractorOptions().PagingClauseTemplate);
+    }
+
+
+
+    [Fact]
+    public void None_is_excluded_from_the_discovered_presets()
+    {
+        // None is a public static string property but not a dialect, so the contract theory
+        // above must not try to assert @PageOffset/@PageLimit against it.
+        var discovered = AllPresets().Select(row => (string)row[0]).ToList();
+
+        Assert.DoesNotContain(nameof(PagingClauseTemplates.None), discovered);
     }
 
 


### PR DESCRIPTION
Stacked on #389. Closes #391.

## Why

There is no portable paging syntax — that is the whole reason `PagingClauseTemplates` exists. So **any** non-null default privileges three engines and breaks the other three. A caller on SQL Server who sets `ServerOffset`/`ServerLimit` without knowing `PagingClauseTemplate` exists gets this, from the database, at runtime:

```
Incorrect syntax near 'LIMIT'
```

That is not hypothetical — it is the exact error the #386 negative control produced. **Having a default was the bug**, not the ergonomics win.

`PagingClauseTemplates.None` (a `string?` that is `null`) is now the default. Activating paging without a dialect throws and names the remedy:

> Server-side paging requires PagingClauseTemplate to be set, because paging syntax is dialect-specific and no portable form exists. Choose a preset from PagingClauseTemplates (for example PagingClauseTemplates.SqlServer, .PostgreSql, .MySql, .Sqlite, .Oracle or .Db2), or supply your own clause referencing @PageOffset and @PageLimit. To disable paging instead, clear ServerOffset and ServerLimit.

`None`, not `NoPaging`, per your call — and the naming matters: the template does not control *whether* paging happens, `ServerOffset`/`ServerLimit` do. `NoPaging` would wrongly imply assigning it switches paging off.

The builder now takes `string?` and no longer rejects null. Otherwise `.PagingClauseTemplate(PagingClauseTemplates.None)` would throw — an obvious trap given `None` is the default.

## Breaking change

Callers on SQLite / PostgreSQL / MySQL relying on the implicit default must now name a template. Intentional: an immediate error stating the fix beats the same code silently doing the wrong thing on half the fleet. Only `DbExtractor.PagingClauseTemplate` was shipped (`string!` → `string?`, a nullability change rather than a binary break, and its setter is already `[Obsolete]` per #378); the options record and builder overload are unshipped this cycle.

## Test changes — please review these specifically

All are consequences of the change, but two are worth your eyes:

1. **`Extractor_builder_PagingClauseTemplate_null_throws_ArgumentNullException` is reversed** and renamed to `..._accepts_null_as_None`. It asserted the opposite of the new design.

2. **All 8 paging setups in `EtlParameterBindingTests` gained a template — not just the 3 that failed.** The other 5 are collision tests asserting the message contains `@PageOffset`, and the *new* template error also contains `@PageOffset`. They kept passing while no longer reaching the collision guard at all — passing for the wrong reason. Worth flagging since a green run concealed it.

Also: two default assertions now assert null; `AllPresets()` skips null-valued properties so `None` isn't treated as a dialect; new tests pin the thrown message and pin that paging left *inactive* does **not** require a template.

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs
- [x] Full suite: **461 tests, 0 failures**
- [x] **Integration needed no changes at all** — fixtures already declare their own dialect, so 72/72 passed untouched. That is the confirmation that the fixture-declares-its-dialect design from #386 was the right shape.
- [x] PublicAPI updated: `*REMOVED*` for the shipped getter's old nullability, plus the new entries

Closes #391