### PR TITLE
fix(paging)!: ServerLimit alone enables paging; ServerOffset defaults to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `ServerLimit` alone now enables paging; `ServerOffset` defaults to `0` (#393).**
+  Setting only `ServerLimit` was previously a silent no-op — a caller who asked for 50 rows got
+  *every* row, with no error. `ServerLimit` now switches server-side paging on, and an unset
+  `ServerOffset` means "start at the top".
+
+  The mirror case is now loud too: setting `ServerOffset` without `ServerLimit` throws
+  `InvalidOperationException` instead of silently ignoring the offset, since no page size can be
+  inferred (every template in `PagingClauseTemplates` references `@PageLimit`).
+
+  Every paging caller must already revisit this code in this release to satisfy #391's template
+  requirement, so neither change can be reached silently.
+
 - **BREAKING: `PagingClauseTemplate` now defaults to `PagingClauseTemplates.None` (`null`)
   instead of the `LIMIT`/`OFFSET` form (#391).** There is no portable paging syntax, so any
   default privileges some engines and breaks the rest: the old default produced

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -602,7 +602,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// include one — without a stable order, page contents drift.
     /// </para>
     /// <para>
-    /// Paging is applied only when <b>both</b> this and <see cref="ServerLimit"/> are set; setting one alone is a silent no-op.
+    /// Defaults to <c>0</c>. Paging is switched on by <see cref="ServerLimit"/>; an offset with no limit throws, since no page size can be inferred.
     /// </para>
     /// </remarks>
     public long? ServerOffset { get; [Obsolete("Configure ServerOffset through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; }
@@ -610,7 +610,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>Page size in rows. See <see cref="ServerOffset"/>.</summary>
-    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerOffset"/> are set; setting one alone is a silent no-op.</remarks>
+    /// <remarks>Setting this switches server-side paging on. <see cref="ServerOffset"/> defaults to <c>0</c> when not set.</remarks>
     public long? ServerLimit { get; [Obsolete("Configure ServerLimit through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; }
 
 
@@ -1016,12 +1016,29 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// </exception>
     private void ApplyServerPaging(string commandText, SqlMapper.IDynamicParameters? param, out string pagedCommandText, out SqlMapper.IDynamicParameters? pagedParam)
     {
-        if (!ServerOffset.HasValue || !ServerLimit.HasValue)
+        if (!ServerLimit.HasValue)
         {
+            // An offset with no limit is the mirror of the bug this default fixes: the caller
+            // plainly wants paging, and no limit can be inferred (every template references
+            // @PageLimit). Silently returning every row from the top would ignore what they asked
+            // for, so say so instead.
+            if (ServerOffset.HasValue)
+            {
+                throw new InvalidOperationException
+                (
+                    "ServerOffset was set without ServerLimit, so server-side paging cannot be " +
+                    "applied — a page size is required and cannot be inferred. Set ServerLimit " +
+                    "to the number of rows per page, or clear ServerOffset."
+                );
+            }
+
             pagedCommandText = commandText;
             pagedParam = param;
             return;
         }
+
+        // ServerLimit alone is enough: an unspecified offset can only mean "start at the top".
+        var serverOffset = ServerOffset ?? 0L;
 
         EnsurePagingClauseTemplateChosen();
         EnsurePagingParametersNotAlreadySupplied();
@@ -1030,14 +1047,14 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         switch (param)
         {
             case EtlParameterSet set:
-                set.Add("@PageOffset", ServerOffset.Value);
+                set.Add("@PageOffset", serverOffset);
                 set.Add("@PageLimit", ServerLimit.Value);
                 pagedParam = set;
                 break;
 
             default:
                 var dynamic = param as DynamicParameters ?? new DynamicParameters();
-                dynamic.Add("@PageOffset", ServerOffset.Value);
+                dynamic.Add("@PageOffset", serverOffset);
                 dynamic.Add("@PageLimit", ServerLimit.Value);
                 pagedParam = dynamic;
                 break;

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -59,7 +59,7 @@ public sealed record DbExtractorOptions
     /// <summary>
     /// Gets the server-side row offset for paging. Defaults to <see langword="null"/> (no paging).
     /// </summary>
-    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerLimit"/> are set; setting one alone is a silent no-op.</remarks>
+    /// <remarks>Defaults to <c>0</c>. Paging is switched on by <see cref="ServerLimit"/>; an offset with no limit throws, since no page size can be inferred.</remarks>
     public long? ServerOffset { get; init; }
 
 
@@ -67,7 +67,7 @@ public sealed record DbExtractorOptions
     /// <summary>
     /// Gets the server-side row limit for paging. Defaults to <see langword="null"/> (no paging).
     /// </summary>
-    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerOffset"/> are set; setting one alone is a silent no-op.</remarks>
+    /// <remarks>Setting this switches server-side paging on. <see cref="ServerOffset"/> defaults to <c>0</c> when not set.</remarks>
     public long? ServerLimit { get; init; }
 
 

--- a/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
@@ -50,14 +50,14 @@ public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
     /// <see cref="PagingClauseTemplate"/>, the extractor appends the paging clause
     /// to the caller's SQL.
     /// </summary>
-    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerLimit"/> are set; setting one alone is a silent no-op.</remarks>
+    /// <remarks>Defaults to <c>0</c>. Paging is switched on by <see cref="ServerLimit"/>; an offset with no limit throws, since no page size can be inferred.</remarks>
     IDbExtractorBuilder<T> ServerOffset(long? offset);
 
 
     /// <summary>
     /// Sets <see cref="DbExtractor{TRecord}.ServerLimit"/> for server-side paging.
     /// </summary>
-    /// <remarks>Paging is applied only when <b>both</b> this and <see cref="ServerOffset"/> are set; setting one alone is a silent no-op.</remarks>
+    /// <remarks>Setting this switches server-side paging on. <see cref="ServerOffset"/> defaults to <c>0</c> when not set.</remarks>
     IDbExtractorBuilder<T> ServerLimit(long? limit);
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
@@ -229,7 +229,7 @@ public abstract class DbExtractorIntegrationTestsBase
 
 
     [SkippableFact]
-    public async Task ExtractAsync_when_only_ServerLimit_is_set_does_not_page_at_all()
+    public async Task ExtractAsync_when_only_ServerLimit_is_set_pages_from_the_top()
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
 
@@ -237,9 +237,9 @@ public abstract class DbExtractorIntegrationTestsBase
         await Fixture.ResetSchemaAsync(conn);
         await Fixture.SeedAsync(conn, rowCount: 5);
 
-        // Paging is all-or-nothing: ApplyServerPaging is a no-op unless BOTH ServerOffset
-        // and ServerLimit are set. Pinning it because the failure mode is silent — a caller
-        // who sets only a limit gets every row rather than an error.
+        // Reversed deliberately. This previously asserted that a limit with no offset was a
+        // silent no-op returning all 5 rows — the caller asking for 2 and getting everything.
+        // ServerLimit now switches paging on and an unset offset means 0.
         var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
         {
             PagingClauseTemplate = Fixture.PagingClauseTemplate,
@@ -248,6 +248,8 @@ public abstract class DbExtractorIntegrationTestsBase
 
         var results = await extractor.ExtractAsync().ToListAsync();
 
-        Assert.Equal(5, results.Count);
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Item1", results[0].Name);
+        Assert.Equal("Item2", results[1].Name);
     }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -706,19 +706,44 @@ public class DbExtractorTests
 
 
     [Fact]
-    public async Task ExtractAsync_with_only_ServerOffset_does_not_apply_paging()
+    public async Task ExtractAsync_with_only_ServerOffset_throws_because_no_page_size_can_be_inferred()
     {
-        // The clause is only appended when BOTH are set.
+        // Reversed: this used to return all 10 rows, silently ignoring the offset the caller
+        // asked for. An offset with no limit is the mirror of the limit-with-no-offset bug —
+        // the caller clearly wants paging, and no page size can be inferred.
         using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 10);
 
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
         {
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
             ServerOffset = 5
+        };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in extractor.ExtractAsync()) { }
+        });
+
+        Assert.Contains("ServerLimit", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_only_ServerLimit_pages_from_offset_zero()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 10);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
+        {
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+            ServerLimit = 3
         };
 
         var records = await extractor.ExtractAsync().ToListAsync();
 
-        Assert.Equal(10, records.Count); // all rows — paging disabled
+        Assert.Equal(3, records.Count);
+        Assert.Equal("First1", records[0].FirstName);
     }
 
 


### PR DESCRIPTION
Closes #393.

## The bug

Setting only `ServerLimit` was a **silent no-op**. `ApplyServerPaging` returned early unless *both* values were present, so a caller who asked for 50 rows got **every** row — no error, no warning.

#386 pinned that behavior across all six engines in `ExtractAsync_when_only_ServerLimit_is_set_does_not_page_at_all`. The test was accurate; the behavior was the bug.

## The fix

**`ServerLimit` switches paging on. `ServerOffset` defaults to 0** — an unset offset can only mean "start at the top".

The mirror case is now loud rather than silent: `ServerOffset` with no `ServerLimit` **throws** instead of ignoring the offset. No page size can be inferred — every template in `PagingClauseTemplates` references `@PageLimit` — and a caller who sets an offset plainly wants paging, so silently returning every row from row 0 ignores what they asked for. Same reasoning as #391 preferring a loud error to a silent guess.

## Breaking, but not reachable silently

Both changes alter behavior for existing callers. The mitigation is timing: **#391 ships in this same release** and makes paging throw without a `PagingClauseTemplate`, so every paging caller must already revisit this exact code. Nobody arrives at the new offset semantics without passing through that gate first.

## Two tests reversed — please review these

Both asserted the old bug, so both had to flip:

- `ExtractAsync_when_only_ServerLimit_is_set_does_not_page_at_all` → `..._pages_from_the_top` (integration, **six engines**)
- `ExtractAsync_with_only_ServerOffset_does_not_apply_paging` → `..._throws_because_no_page_size_can_be_inferred` (unit)

Plus a new unit test for the offset-zero default.

I also unwound the "paging applies only when **both** are set" wording at all five doc surfaces where I had added it earlier this cycle — it is no longer true.

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs
- [x] Full suite: **462 tests, 0 failures**
- [x] Integration 72/72 across all six engines, including the reversed contract test
- [x] CHANGELOG entry

Next: #394 (paging advances through pages itself), which builds directly on this.