### PR TITLE
feat(paging)!: advance through pages instead of one page per extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: server-side paging now advances through pages itself (#394).** `ServerLimit` is
+  the size of each round-trip, not a cap on the total: one extractor walks the whole result set,
+  advancing the offset until the source is exhausted. Previously one extractor returned exactly
+  one page and the caller wrote the loop — as this repo's own sample and integration test both
+  did, which is why the loop moved into the library.
+
+  Cap the total with `MaximumItemCount`. "Exactly 50 rows starting at 25" is
+  `ServerOffset = 25`, `ServerLimit = 50`, `MaximumItemCount = 50`.
+
+  The page actually requested is shortened to what is still needed, so the database never
+  produces rows that would be discarded on arrival: with a page size of 100 and a maximum of
+  150, the requests are 100 then 50. `SkipItemCount` is counted in, since it discards rows
+  client-side after they arrive.
+
+  Two costs are now the library's rather than the caller's, and are documented on
+  `ServerOffset`: `OFFSET n` makes most engines scan and discard `n` rows, so walking a large
+  table is quadratic in server-side work; and offset paging is not stable under concurrent
+  writes, where a row can be skipped or returned twice between pages.
+
 - **BREAKING: `ServerLimit` alone now enables paging; `ServerOffset` defaults to `0` (#393).**
   Setting only `ServerLimit` was previously a silent no-op — a caller who asked for 50 rows got
   *every* row, with no error. `ServerLimit` now switches server-side paging on, and an unset

--- a/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Program.cs
+++ b/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Program.cs
@@ -72,26 +72,28 @@ var sw = Stopwatch.StartNew();
 long extracted = 0;
 long loaded = 0;
 
-for (long offset = 0; offset < totalRows; offset += pageSize)
+// One extractor walks the whole table: it advances the page offset itself, so the caller no
+// longer writes the loop. The source here is SQLite — paging syntax is dialect-specific and
+// the library does not guess one, so the dialect has to be named.
+var extractor = new DbExtractor<SourceWidget>
+(
+    src,
+    "SELECT id AS Id, name AS Name, price AS Price FROM widget ORDER BY id"
+)
 {
-    var extractor = new DbExtractor<SourceWidget>
-    (
-        src,
-        "SELECT id AS Id, name AS Name, price AS Price FROM widget ORDER BY id"
-    )
-    {
-        // The source here is SQLite. Paging syntax is dialect-specific and the library no
-        // longer guesses one, so the dialect has to be named.
-        PagingClauseTemplate = PagingClauseTemplates.Sqlite,
-        ServerOffset = offset,
-        ServerLimit = pageSize,
-    };
+    PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+    ServerLimit = pageSize,
+};
 
-    var page = new List<DestWidget>(pageSize);
-    await foreach (var s in extractor.ExtractAsync())
+// Extraction streams, but the load is still batched — flush a full page at a time so this
+// workload keeps the same allocation shape it had when the paging loop was hand-rolled.
+var page = new List<DestWidget>(pageSize);
+
+async Task FlushAsync()
+{
+    if (page.Count == 0)
     {
-        page.Add(new DestWidget { Id = s.Id, UpperName = s.Name.ToUpperInvariant(), Price = s.Price });
-        extracted++;
+        return;
     }
 
     var loader = new DbLoader<DestWidget>
@@ -104,7 +106,21 @@ for (long offset = 0; offset < totalRows; offset += pageSize)
     };
     await loader.LoadAsync(AsAsync(page));
     loaded += page.Count;
+    page.Clear();
 }
+
+await foreach (var s in extractor.ExtractAsync())
+{
+    page.Add(new DestWidget { Id = s.Id, UpperName = s.Name.ToUpperInvariant(), Price = s.Price });
+    extracted++;
+
+    if (page.Count == pageSize)
+    {
+        await FlushAsync();
+    }
+}
+
+await FlushAsync();
 
 sw.Stop();
 

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -807,6 +807,18 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
             var pageOffset = ServerOffset ?? 0L;
             var pageSize = ServerLimit;
 
+            // Once per extraction, not once per page. ApplyServerPaging adds @PageOffset and
+            // @PageLimit INTO the caller's own DynamicParameters when the obsolete Parameters
+            // property is used, so a per-page collision check would see paging's own names on
+            // the second page and throw — breaking paging for every extractor configured that
+            // way. The question these answer ("did the caller already supply these?") is settled
+            // before the first page and cannot change afterwards.
+            if (pageSize.HasValue)
+            {
+                EnsurePagingClauseTemplateChosen();
+                EnsurePagingParametersNotAlreadySupplied();
+            }
+
             while (true)
             {
                 // Ask the database only for rows that can still be used: anything past
@@ -1118,9 +1130,6 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
             pagedParam = param;
             return;
         }
-
-        EnsurePagingClauseTemplateChosen();
-        EnsurePagingParametersNotAlreadySupplied();
 
         // Both parameter shapes accept additions, by different methods.
         switch (param)

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -595,11 +595,24 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Use server-side paging for very large tables where streaming
-    /// everything to the client is wasteful. SQL Server requires an
-    /// <c>ORDER BY</c> in the command text for paging to be deterministic;
-    /// SQLite, PostgreSQL, and MySQL don't require it but you should still
+    /// Extraction reads through a <see cref="System.Data.Common.DbDataReader"/> and streams row
+    /// by row whether paging is on or not, so paging is <b>not</b> what keeps memory bounded.
+    /// What it buys is bounded work per query: no single long-running statement over a huge
+    /// table, and therefore fewer server-side timeouts and shorter-lived read locks.
+    /// </para>
+    /// <para>
+    /// SQL Server requires an <c>ORDER BY</c> in the command text for paging to be
+    /// deterministic; SQLite, PostgreSQL, and MySQL don't require it but you should still
     /// include one — without a stable order, page contents drift.
+    /// </para>
+    /// <para>
+    /// <b>Two costs to know about.</b> Most engines implement <c>OFFSET n</c> by scanning and
+    /// discarding those <c>n</c> rows, so walking a large table page by page is quadratic in
+    /// server-side work; a keyset ("seek") predicate on the command text is the cheaper shape
+    /// where the query allows it. And paging by offset is not stable under concurrent writes:
+    /// rows inserted or deleted between pages shift the window, so a row can be skipped or
+    /// returned twice even with an <c>ORDER BY</c>. Neither matters for a static table; both
+    /// matter for a live one.
     /// </para>
     /// <para>
     /// Defaults to <c>0</c>. Paging is switched on by <see cref="ServerLimit"/>; an offset with no limit throws, since no page size can be inferred.
@@ -609,8 +622,15 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
 
-    /// <summary>Page size in rows. See <see cref="ServerOffset"/>.</summary>
-    /// <remarks>Setting this switches server-side paging on. <see cref="ServerOffset"/> defaults to <c>0</c> when not set.</remarks>
+    /// <summary>Rows per page. See <see cref="ServerOffset"/>.</summary>
+    /// <remarks>
+    /// Setting this switches server-side paging on; <see cref="ServerOffset"/> defaults to
+    /// <c>0</c>. This is the size of each round-trip, <b>not</b> a cap on the total — the
+    /// extractor advances the offset itself and keeps requesting pages until the source is
+    /// exhausted. To cap the total, set <c>MaximumItemCount</c>; the page actually requested is
+    /// then shortened to whatever is still needed, so the database never produces rows that
+    /// would be discarded on arrival.
+    /// </remarks>
     public long? ServerLimit { get; [Obsolete("Configure ServerLimit through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; }
 
 
@@ -774,88 +794,146 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 await DbSchemaValidator.ValidateAsync<TRecord>(_connection, token).ConfigureAwait(false);
             }
 
-            ApplyServerPaging(_commandText, Parameters ?? _dynamicParameters, out var commandText, out var param);
-
             if (TotalCountQuery != null)
             {
                 _totalItemCount = await TotalCountQuery(token).ConfigureAwait(false);
             }
 
+            // rowIndex counts rows RECEIVED from the database across every page — not rows
+            // yielded. SkipItemCount is applied client-side below, so the two diverge the moment
+            // a skip is configured, and clamping the page size against the yielded count is how
+            // a paged extract silently returns too few rows.
             long rowIndex = 0;
+            var pageOffset = ServerOffset ?? 0L;
+            var pageSize = ServerLimit;
 
-            // The reader is driven with a manual ReadAsync loop, and row mapping
-            // goes through a standalone Dapper row-parser delegate, rather than
-            // Dapper's own QueryUnbufferedAsync<T> IAsyncEnumerable. That matters:
-            // QueryUnbufferedAsync's read-and-map loop lives inside ONE compiler-
-            // generated async-iterator state machine. When mapping throws mid-loop,
-            // the iterator's finally block runs and the state machine transitions
-            // to "finished" — so even catching the exception at the call site,
-            // the NEXT MoveNextAsync just returns false. Skip would silently
-            // truncate the result set after the first bad row instead of
-            // continuing past it. Reading via our own loop keeps ReadAsync's
-            // cursor alive across a caught mapping failure, so Skip actually
-            // skips-and-continues.
-            var command = new CommandDefinition(commandText, param, _transaction, CommandTimeoutSeconds, CommandType, cancellationToken: token);
-            using var reader = await _connection.ExecuteReaderAsync(command).ConfigureAwait(false);
-            var parseRow = reader.GetRowParser<TRecord>();
-
-            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            while (true)
             {
-                token.ThrowIfCancellationRequested();
-
-                TRecord record;
-                try
+                // Ask the database only for rows that can still be used: anything past
+                // SkipItemCount + MaximumItemCount would be fetched and then thrown away here.
+                // Computed in long deliberately — MaximumItemCount defaults to int.MaxValue, so
+                // adding SkipItemCount to it overflows int whenever a skip is configured.
+                var pageLimit = pageSize;
+                if (pageSize.HasValue)
                 {
-                    record = parseRow(reader);
-                }
-                catch (System.Data.DataException ex)
-                {
-                    // Scoped to DataException — the type Dapper wraps row-materialization
-                    // failures in (e.g. "Error parsing column N") — so ErrorPolicy only ever
-                    // sees per-row failures. Catching every exception type here would also
-                    // catch connection-level failures (a dropped connection, a syntax error
-                    // surfacing lazily); those aren't per-row, and ReadAsync would likely keep
-                    // throwing the same fault on every subsequent call, so routing them
-                    // through ItemErrorAction.Skip would spin the loop instead of terminating.
-                    rowIndex++;
-                    var action = HandleItemError
-                    (
-                        new ItemErrorContext
-                        (
-                            rowIndex,
-                            ex,
-                            rawContent: null
-                        )
-                    );
-                    if (action == ItemErrorAction.Abort)
+                    var stillNeeded = (long)SkipItemCount + MaximumItemCount - rowIndex;
+                    if (stillNeeded <= 0)
                     {
-                        System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+                        break;
                     }
-                    // ItemErrorAction.Skip — HandleItemError already incremented
-                    // the error-item counter on the base. Log and continue.
-                    LogDebugRowErrorSkipped(rowIndex, ex);
-                    continue;
+
+                    pageLimit = Math.Min(pageSize.Value, stillNeeded);
                 }
 
-                rowIndex++;
-
-                if (rowIndex <= SkipItemCount)
+                if (pageLimit.HasValue)
                 {
-                    IncrementCurrentSkippedItemCount();
-                    LogDebugRowSkipped(rowIndex);
-                    continue;
+                    LogDebugPageRequested(pageOffset, pageLimit.Value);
                 }
 
+                ApplyServerPaging(_commandText, Parameters ?? _dynamicParameters, pageOffset, pageLimit, out var commandText, out var param);
+
+                long rowsThisPage = 0;
+
+                // The reader is driven with a manual ReadAsync loop, and row mapping
+                // goes through a standalone Dapper row-parser delegate, rather than
+                // Dapper's own QueryUnbufferedAsync<T> IAsyncEnumerable. That matters:
+                // QueryUnbufferedAsync's read-and-map loop lives inside ONE compiler-
+                // generated async-iterator state machine. When mapping throws mid-loop,
+                // the iterator's finally block runs and the state machine transitions
+                // to "finished" — so even catching the exception at the call site,
+                // the NEXT MoveNextAsync just returns false. Skip would silently
+                // truncate the result set after the first bad row instead of
+                // continuing past it. Reading via our own loop keeps ReadAsync's
+                // cursor alive across a caught mapping failure, so Skip actually
+                // skips-and-continues.
+                var command = new CommandDefinition(commandText, param, _transaction, CommandTimeoutSeconds, CommandType, cancellationToken: token);
+                using var reader = await _connection.ExecuteReaderAsync(command).ConfigureAwait(false);
+                var parseRow = reader.GetRowParser<TRecord>();
+
+                while (await reader.ReadAsync(token).ConfigureAwait(false))
+                {
+                    token.ThrowIfCancellationRequested();
+
+                    rowsThisPage++;
+
+                    TRecord record;
+                    try
+                    {
+                        record = parseRow(reader);
+                    }
+                    catch (System.Data.DataException ex)
+                    {
+                        // Scoped to DataException — the type Dapper wraps row-materialization
+                        // failures in (e.g. "Error parsing column N") — so ErrorPolicy only ever
+                        // sees per-row failures. Catching every exception type here would also
+                        // catch connection-level failures (a dropped connection, a syntax error
+                        // surfacing lazily); those aren't per-row, and ReadAsync would likely keep
+                        // throwing the same fault on every subsequent call, so routing them
+                        // through ItemErrorAction.Skip would spin the loop instead of terminating.
+                        rowIndex++;
+                        var action = HandleItemError
+                        (
+                            new ItemErrorContext
+                            (
+                                rowIndex,
+                                ex,
+                                rawContent: null
+                            )
+                        );
+                        if (action == ItemErrorAction.Abort)
+                        {
+                            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+                        }
+                        // ItemErrorAction.Skip — HandleItemError already incremented
+                        // the error-item counter on the base. Log and continue.
+                        LogDebugRowErrorSkipped(rowIndex, ex);
+                        continue;
+                    }
+
+                    rowIndex++;
+
+                    if (rowIndex <= SkipItemCount)
+                    {
+                        IncrementCurrentSkippedItemCount();
+                        LogDebugRowSkipped(rowIndex);
+                        continue;
+                    }
+
+                    if (CurrentItemCount >= MaximumItemCount)
+                    {
+                        LogDebugMaxReached();
+                        LogExtractionCompleted();
+                        yield break;
+                    }
+
+                    LogDebugRowExtracted(rowIndex);
+                    IncrementCurrentItemCount();
+                    yield return record;
+                }
+
+                // Paging off: the single pass above was the whole extraction.
+                if (!pageLimit.HasValue)
+                {
+                    break;
+                }
+
+                // Order matters. The clamp above deliberately shortens the final page, so a short
+                // page no longer implies the source ran out — checking exhaustion first would read
+                // a clamped last page as "no more rows" and be right by accident, then wrong the
+                // moment the clamp is not what ended it.
                 if (CurrentItemCount >= MaximumItemCount)
                 {
                     LogDebugMaxReached();
-                    LogExtractionCompleted();
-                    yield break;
+                    break;
                 }
 
-                LogDebugRowExtracted(rowIndex);
-                IncrementCurrentItemCount();
-                yield return record;
+                // Fewer rows than asked for means the source is exhausted.
+                if (rowsThisPage < pageLimit.Value)
+                {
+                    break;
+                }
+
+                pageOffset += rowsThisPage;
             }
 
             LogExtractionCompleted();
@@ -993,12 +1071,11 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
-    /// If <see cref="ServerOffset"/> and <see cref="ServerLimit"/> are both
-    /// set, append <see cref="PagingClauseTemplate"/> to <paramref name="commandText"/>
-    /// (returned via <paramref name="pagedCommandText"/>) and add
-    /// <c>@PageOffset</c> / <c>@PageLimit</c> to the parameter set (returned
-    /// via <paramref name="pagedParam"/>). Otherwise returns the inputs
-    /// unchanged.
+    /// Builds the command for one page: appends <see cref="PagingClauseTemplate"/> to
+    /// <paramref name="commandText"/> (returned via <paramref name="pagedCommandText"/>) and adds
+    /// <c>@PageOffset</c> / <c>@PageLimit</c> to the parameter set (returned via
+    /// <paramref name="pagedParam"/>). With no <paramref name="pageLimit"/> paging is off and the
+    /// inputs come back unchanged.
     /// </summary>
     /// <remarks>
     /// out parameters instead of a tuple — net462 doesn't ship
@@ -1007,6 +1084,11 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// </remarks>
     /// <param name="commandText">The command text to page.</param>
     /// <param name="param">The parameter set to add the paging parameters to, or <c>null</c>.</param>
+    /// <param name="pageOffset">Zero-based row offset for this page.</param>
+    /// <param name="pageLimit">
+    /// Rows to request for this page, already clamped to what is still needed, or <c>null</c>
+    /// when paging is off.
+    /// </param>
     /// <param name="pagedCommandText">The command text with the paging clause appended.</param>
     /// <param name="pagedParam">The parameter set including the paging parameters.</param>
     /// <exception cref="InvalidOperationException">
@@ -1014,9 +1096,9 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// which server-side paging also generates. Emitting both would duplicate the name, and
     /// silently preferring one would discard either the caller's value or the paging.
     /// </exception>
-    private void ApplyServerPaging(string commandText, SqlMapper.IDynamicParameters? param, out string pagedCommandText, out SqlMapper.IDynamicParameters? pagedParam)
+    private void ApplyServerPaging(string commandText, SqlMapper.IDynamicParameters? param, long pageOffset, long? pageLimit, out string pagedCommandText, out SqlMapper.IDynamicParameters? pagedParam)
     {
-        if (!ServerLimit.HasValue)
+        if (!pageLimit.HasValue)
         {
             // An offset with no limit is the mirror of the bug this default fixes: the caller
             // plainly wants paging, and no limit can be inferred (every template references
@@ -1037,9 +1119,6 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
             return;
         }
 
-        // ServerLimit alone is enough: an unspecified offset can only mean "start at the top".
-        var serverOffset = ServerOffset ?? 0L;
-
         EnsurePagingClauseTemplateChosen();
         EnsurePagingParametersNotAlreadySupplied();
 
@@ -1047,15 +1126,15 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         switch (param)
         {
             case EtlParameterSet set:
-                set.Add("@PageOffset", serverOffset);
-                set.Add("@PageLimit", ServerLimit.Value);
+                set.Add("@PageOffset", pageOffset);
+                set.Add("@PageLimit", pageLimit.Value);
                 pagedParam = set;
                 break;
 
             default:
                 var dynamic = param as DynamicParameters ?? new DynamicParameters();
-                dynamic.Add("@PageOffset", serverOffset);
-                dynamic.Add("@PageLimit", ServerLimit.Value);
+                dynamic.Add("@PageOffset", pageOffset);
+                dynamic.Add("@PageLimit", pageLimit.Value);
                 pagedParam = dynamic;
                 break;
         }
@@ -1166,6 +1245,21 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 rowIndex,
                 CurrentSkippedItemCount,
                 SkipItemCount
+            );
+        }
+    }
+
+
+
+    private void LogDebugPageRequested(long pageOffset, long pageLimit)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug
+            (
+                "Requesting page: PageOffset={PageOffset}, PageLimit={PageLimit}",
+                pageOffset,
+                pageLimit
             );
         }
     }

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -67,7 +67,12 @@ public sealed record DbExtractorOptions
     /// <summary>
     /// Gets the server-side row limit for paging. Defaults to <see langword="null"/> (no paging).
     /// </summary>
-    /// <remarks>Setting this switches server-side paging on. <see cref="ServerOffset"/> defaults to <c>0</c> when not set.</remarks>
+    /// <remarks>
+    /// Setting this switches server-side paging on; <see cref="ServerOffset"/> defaults to
+    /// <c>0</c>. This is the size of each round-trip, <b>not</b> a cap on the total — the
+    /// extractor advances the offset itself until the source is exhausted. Cap the total with
+    /// <c>MaximumItemCount</c>.
+    /// </remarks>
     public long? ServerLimit { get; init; }
 
 

--- a/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
@@ -57,7 +57,12 @@ public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
     /// <summary>
     /// Sets <see cref="DbExtractor{TRecord}.ServerLimit"/> for server-side paging.
     /// </summary>
-    /// <remarks>Setting this switches server-side paging on. <see cref="ServerOffset"/> defaults to <c>0</c> when not set.</remarks>
+    /// <remarks>
+    /// Setting this switches server-side paging on; <see cref="ServerOffset"/> defaults to
+    /// <c>0</c>. This is the size of each round-trip, <b>not</b> a cap on the total — the
+    /// extractor advances the offset itself until the source is exhausted. Cap the total with
+    /// <c>MaximumItemCount</c>.
+    /// </remarks>
     IDbExtractorBuilder<T> ServerLimit(long? limit);
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
@@ -125,11 +125,14 @@ public abstract class DbExtractorIntegrationTestsBase
         await Fixture.ResetSchemaAsync(conn);
         await Fixture.SeedAsync(conn, rowCount: 5);
 
+        // A bounded window is offset + page size + MaximumItemCount. ServerLimit alone would
+        // page on to the end of the table, so the cap is what makes this a window.
         var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
         {
             PagingClauseTemplate = Fixture.PagingClauseTemplate,
             ServerOffset = 1,
-            ServerLimit = 2
+            ServerLimit = 2,
+            MaximumItemCount = 2
         };
 
         var results = await extractor.ExtractAsync().ToListAsync();
@@ -150,31 +153,19 @@ public abstract class DbExtractorIntegrationTestsBase
         await Fixture.ResetSchemaAsync(conn);
         await Fixture.SeedAsync(conn, rowCount: 7);
 
-        // 7 rows in pages of 3 deliberately leaves a partial final page.
-        const int pageSize = 3;
-        var seen = new List<int>();
-
-        for (var offset = 0; ; offset += pageSize)
+        // 7 rows in pages of 3 deliberately leaves a partial final page. The loop this test
+        // used to hand-roll now lives in the extractor — one extractor walks the whole table.
+        var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
         {
-            var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
-            {
-                PagingClauseTemplate = Fixture.PagingClauseTemplate,
-                ServerOffset = offset,
-                ServerLimit = pageSize
-            };
+            PagingClauseTemplate = Fixture.PagingClauseTemplate,
+            ServerLimit = 3
+        };
 
-            var page = await extractor.ExtractAsync().ToListAsync();
+        var seen = await extractor.ExtractAsync().Select(item => item.Value).ToListAsync();
 
-            if (page.Count == 0)
-            {
-                break;
-            }
-
-            Assert.True(page.Count <= pageSize, $"page at offset {offset} returned {page.Count} rows");
-            seen.AddRange(page.Select(item => item.Value));
-        }
-
-        // No gaps, no duplicates, and in order — the three ways paging goes wrong.
+        // No gaps, no duplicates, and in order — the three ways paging goes wrong. Now it also
+        // covers the page-advance itself: a bad offset step would show up here as a gap or a
+        // repeat, on every engine.
         Assert.Equal(Enumerable.Range(1, 7).Select(i => i * 10), seen);
     }
 
@@ -229,7 +220,7 @@ public abstract class DbExtractorIntegrationTestsBase
 
 
     [SkippableFact]
-    public async Task ExtractAsync_when_only_ServerLimit_is_set_pages_from_the_top()
+    public async Task ExtractAsync_when_only_ServerLimit_is_set_pages_from_the_top_to_the_end()
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
 
@@ -237,9 +228,8 @@ public abstract class DbExtractorIntegrationTestsBase
         await Fixture.ResetSchemaAsync(conn);
         await Fixture.SeedAsync(conn, rowCount: 5);
 
-        // Reversed deliberately. This previously asserted that a limit with no offset was a
-        // silent no-op returning all 5 rows — the caller asking for 2 and getting everything.
-        // ServerLimit now switches paging on and an unset offset means 0.
+        // ServerLimit switches paging on, an unset offset means 0, and paging advances — so
+        // all 5 rows arrive in pages of 2, the last page short.
         var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
         {
             PagingClauseTemplate = Fixture.PagingClauseTemplate,
@@ -248,8 +238,8 @@ public abstract class DbExtractorIntegrationTestsBase
 
         var results = await extractor.ExtractAsync().ToListAsync();
 
-        Assert.Equal(2, results.Count);
+        Assert.Equal(5, results.Count);
         Assert.Equal("Item1", results[0].Name);
-        Assert.Equal("Item2", results[1].Name);
+        Assert.Equal("Item5", results[4].Name);
     }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -620,8 +620,10 @@ public class DbExtractorTests
 
 
     [Fact]
-    public async Task ExtractAsync_with_ServerLimit_caps_rows_at_the_database()
+    public async Task ExtractAsync_with_ServerLimit_pages_through_the_whole_table()
     {
+        // ServerLimit is the page size, not a cap: the extractor keeps requesting pages until
+        // the source runs out. Capping the total is MaximumItemCount's job — see the test below.
         using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
 
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
@@ -633,15 +635,35 @@ public class DbExtractorTests
 
         var records = await extractor.ExtractAsync().ToListAsync();
 
-        Assert.Equal(5, records.Count);
+        Assert.Equal(20, records.Count);
         Assert.Equal("First1", records[0].FirstName);
-        Assert.Equal("First5", records[4].FirstName);
+        Assert.Equal("First20", records[19].FirstName);
     }
 
 
 
     [Fact]
-    public async Task ExtractAsync_with_ServerOffset_and_ServerLimit_returns_a_page()
+    public async Task ExtractAsync_with_MaximumItemCount_caps_the_total_across_pages()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
+        {
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+            ServerLimit = 5,
+            MaximumItemCount = 12
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(12, records.Count);
+        Assert.Equal("First12", records[11].FirstName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_ServerOffset_pages_from_there_to_the_end()
     {
         using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
 
@@ -654,10 +676,10 @@ public class DbExtractorTests
 
         var records = await extractor.ExtractAsync().ToListAsync();
 
-        // Skipped 10, took 5 → First11..First15.
-        Assert.Equal(5, records.Count);
+        // Starts at row 11 and pages to the end in chunks of 5 → First11..First20.
+        Assert.Equal(10, records.Count);
         Assert.Equal("First11", records[0].FirstName);
-        Assert.Equal("First15", records[4].FirstName);
+        Assert.Equal("First20", records[9].FirstName);
     }
 
 
@@ -742,8 +764,11 @@ public class DbExtractorTests
 
         var records = await extractor.ExtractAsync().ToListAsync();
 
-        Assert.Equal(3, records.Count);
+        // Offset defaults to 0 and paging advances, so all 10 arrive in pages of 3 —
+        // including a final short page of 1.
+        Assert.Equal(10, records.Count);
         Assert.Equal("First1", records[0].FirstName);
+        Assert.Equal("First10", records[9].FirstName);
     }
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterBindingTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterBindingTests.cs
@@ -355,4 +355,36 @@ public class EtlParameterBindingTests
 
         Assert.Single(results);
     }
+
+
+    [Fact]
+    public async Task Paging_across_multiple_pages_works_when_configured_via_the_Parameters_property()
+    {
+        // Regression guard. ApplyServerPaging adds @PageOffset/@PageLimit INTO the caller's
+        // DynamicParameters when the obsolete Parameters property is used. Running the collision
+        // guard once per page then sees paging's own names in Parameters.ParameterNames on the
+        // second page and throws — breaking paging for every extractor configured this way,
+        // stored procedures with OUT params included. The guard belongs before the page loop.
+        using var conn = Seeded();
+
+        var dynamic = new Dapper.DynamicParameters();
+        dynamic.Add("@min", 0);
+
+#pragma warning disable CS0618
+        var sut = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
+            options: new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerLimit = 1 }
+        )
+        {
+            Parameters = dynamic
+        };
+#pragma warning restore CS0618
+
+        // Seeded() has 2 rows, so a page size of 1 forces a second page — where the bug bit.
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(2, results.Count);
+    }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs
@@ -105,8 +105,8 @@ public class EtlPipelineDbClientExtensionsTests
     [Fact]
     public async Task Extractor_builder_setters_propagate_to_the_underlying_extractor()
     {
-        // Server-side paging via the builder: ServerLimit=2, ServerOffset=1 →
-        // pipeline yields exactly rows 2 and 3.
+        // Server-side paging via the builder: page size 2 starting at offset 1, which now
+        // advances to the end → rows 2..5.
         using var src = CreateSourceWithRows(5);
         using var dest = CreateEmptyDestination();
 
@@ -120,7 +120,7 @@ public class EtlPipelineDbClientExtensionsTests
             .RunAsync()
             ;
 
-        Assert.Equal(2L, CountRows(dest, "dest"));
+        Assert.Equal(4L, CountRows(dest, "dest"));
 
         using var check = dest.CreateCommand();
         check.CommandText = "SELECT Id FROM dest ORDER BY Id;";
@@ -196,9 +196,8 @@ public class EtlPipelineDbClientExtensionsTests
         var extractor = new DbExtractor<Widget>(src, "SELECT Id, Name FROM source ORDER BY Id");
         Assert.Null(extractor.ServerLimit);
 
-        // DbExtractor's paging is gated on BOTH ServerOffset AND ServerLimit
-        // being set (see DbExtractor.ApplyServerPaging), so setting both
-        // proves the setter path AND exercises paging end-to-end.
+        // Setting the paging knobs through the builder proves the setter path AND exercises
+        // paging end-to-end: 3 rows in pages of 2 means two round-trips, the second short.
         await EtlPipeline
             .Create()
             .DbExtractor(extractor)
@@ -212,7 +211,9 @@ public class EtlPipelineDbClientExtensionsTests
         // Setter on the builder mutated the caller's extractor.
         Assert.Equal(0L, extractor.ServerOffset);
         Assert.Equal(2L, extractor.ServerLimit);
-        Assert.Equal(2L, CountRows(dest, "dest"));
+
+        // All 3 rows, not one page of 2 — paging advances to the end.
+        Assert.Equal(3L, CountRows(dest, "dest"));
     }
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClampTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClampTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.DbClient.Tests.Unit;
+
+/// <summary>
+/// The page size sent to the database is clamped to what is still needed, so the server never
+/// produces rows that would be discarded on arrival.
+/// </summary>
+/// <remarks>
+/// These assert the <b>requested</b> limits, not the row counts. A wrong limit usually still
+/// returns the right rows — asking for 100 and discarding 25 yields the same 75 as asking for
+/// 75 — so a count-only test would pass while the optimisation did nothing.
+/// </remarks>
+public class PagingClampTests
+{
+    private static IReadOnlyList<(long Offset, long Limit)> RequestedPages(SpyLogger<DbExtractor<PersonRecord>> logger)
+    {
+        var pattern = new Regex(@"PageOffset=(\d+), PageLimit=(\d+)", RegexOptions.CultureInvariant);
+
+        return logger.Entries
+            .Select(entry => pattern.Match(entry.Message))
+            .Where(match => match.Success)
+            .Select(match => (long.Parse(match.Groups[1].Value), long.Parse(match.Groups[2].Value)))
+            .ToList();
+    }
+
+
+
+    [Fact]
+    public async Task A_page_larger_than_the_remaining_maximum_is_shortened_to_it()
+    {
+        // Chris's case: offset 25, page size 100, maximum 75. Asking for 100 would have the
+        // database produce 25 rows that are thrown away here.
+        var logger = new SpyLogger<DbExtractor<PersonRecord>>();
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 500);
+
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id",
+            new DbExtractorOptions
+            {
+                PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+                ServerOffset = 25,
+                ServerLimit = 100
+            },
+            logger: logger
+        )
+        {
+            MaximumItemCount = 75
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(75, records.Count);
+        Assert.Equal(new[] { (25L, 75L) }, RequestedPages(logger));
+    }
+
+
+
+    [Fact]
+    public async Task The_final_page_shrinks_to_the_remaining_maximum()
+    {
+        // Maximum 150 with page size 100: 100, then 50 — not 100 twice.
+        var logger = new SpyLogger<DbExtractor<PersonRecord>>();
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 500);
+
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id",
+            new DbExtractorOptions
+            {
+                PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+                ServerLimit = 100
+            },
+            logger: logger
+        )
+        {
+            MaximumItemCount = 150
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(150, records.Count);
+        Assert.Equal(new[] { (0L, 100L), (100L, 50L) }, RequestedPages(logger));
+    }
+
+
+
+    [Fact]
+    public async Task SkipItemCount_is_included_in_what_the_page_asks_for()
+    {
+        // The trap. SkipItemCount is applied client-side AFTER the rows arrive, so a run that
+        // needs 30 yielded rows with 10 skipped must fetch 40. Clamping to MaximumItemCount
+        // alone would request 30, silently yield 20, and still look plausible.
+        var logger = new SpyLogger<DbExtractor<PersonRecord>>();
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 500);
+
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id",
+            new DbExtractorOptions
+            {
+                PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+                ServerLimit = 1000
+            },
+            logger: logger
+        )
+        {
+            SkipItemCount = 10,
+            MaximumItemCount = 30
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(30, records.Count);
+        Assert.Equal("First11", records[0].FirstName);
+        Assert.Equal(new[] { (0L, 40L) }, RequestedPages(logger));
+    }
+
+
+
+    [Fact]
+    public async Task No_maximum_and_a_skip_does_not_overflow_the_clamp()
+    {
+        // MaximumItemCount defaults to int.MaxValue, so SkipItemCount + MaximumItemCount
+        // overflows int the moment a skip is set. The clamp computes in long; if it did not,
+        // stillNeeded would go negative and the extraction would return nothing.
+        var logger = new SpyLogger<DbExtractor<PersonRecord>>();
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
+
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id",
+            new DbExtractorOptions
+            {
+                PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+                ServerLimit = 5
+            },
+            logger: logger
+        )
+        {
+            SkipItemCount = 3
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(17, records.Count);
+        Assert.Equal("First4", records[0].FirstName);
+        Assert.All(RequestedPages(logger), page => Assert.Equal(5L, page.Limit));
+    }
+}


### PR DESCRIPTION
Closes #394.

## Why

`ApplyServerPaging` ran **once** and fed a single `ExecuteReaderAsync`, so one extractor yielded exactly one page and the caller wrote the loop. This repo's own sample and its integration contract test both did. When the sample *and* the tests hand-roll the same loop, the loop belongs in the library — both now drop it.

## The three knobs

| Knob | Meaning |
|---|---|
| `ServerOffset` | where to start (0 by default, per #393) |
| `ServerLimit` | rows per round-trip |
| `MaximumItemCount` | total rows returned |

"Exactly 50 rows from row 25" is `ServerOffset = 25`, `ServerLimit = 50`, `MaximumItemCount = 50`.

## The clamp

The page requested is shortened to what is still needed, so the database never produces rows discarded on arrival. Page size 100 with a maximum of 150 requests **100 then 50**; offset 25 / page 100 / max 75 requests **75 once**.

**`SkipItemCount` is the trap.** It is applied client-side *after* rows arrive, so skip 10 with a maximum of 30 must request **40**. Clamping to `MaximumItemCount` alone would request 30, yield 20, and look entirely plausible. So `rowIndex` counts rows **received**, deliberately distinct from `CurrentItemCount` (rows **yielded**) — clamping against the wrong counter is the whole bug. The arithmetic is in `long`, because `MaximumItemCount` defaults to `int.MaxValue` and adding `SkipItemCount` overflows `int` the moment a skip is set.

Termination checks the maximum **before** exhaustion: the clamp deliberately shortens the final page, so "a short page means the source ran out" is no longer sufficient by itself.

## How the clamp is tested — worth a look

Row counts **cannot** verify a clamp. Asking for 100 and discarding 25 returns the same 75 rows as asking for 75, so a count-only test passes while the optimisation does nothing — the same "green for the wrong reason" failure that bit the collision tests on #392.

So this adds a `Debug` log of each page request (`PageOffset=…, PageLimit=…`), which is genuinely useful for diagnosing paging in the field and is the only external view of the clamped limit. The four tests in `PagingClampTests` assert the **requested limits**, not the rows.

Verified by sabotage rather than assumed: replacing the clamp with the raw page size fails **3 of 4** — and the fourth correctly still passes, because with no maximum the clamp is a no-op.

## Test changes — please review these specifically

**Seven existing tests changed, five because they asserted one-extractor-one-page.** Two integration contract tests changed likewise, each across **six engines**. The notable one: `ExtractAsync_when_server_paging_is_configured_returns_the_expected_window` now sets `MaximumItemCount`, because a bounded *window* needs the cap once `ServerLimit` means page size.

## A doc claim that was already false

`ServerOffset`'s remarks justified paging as being for "very large tables where streaming everything to the client is wasteful". Extraction runs off a `DbDataReader` and streams row by row whether paging is on or not, so that was never true. The real benefit is bounded per-query work — no long-running statement, fewer timeouts, shorter read locks. Corrected, and the two costs the library now owns are documented on the public surface: `OFFSET n` makes most engines scan and discard `n` rows (a full walk is quadratic), and offset paging can skip or duplicate rows under concurrent writes.

## Regression-gate workload

`ShadowConsumer`'s loop also batched the *load*, so deleting it naively would have buffered 100k rows and changed the very thing that workload measures. It keeps batching via a flush-at-page-size buffer. Measured after: **268.4 MB allocated vs 269.2 MB before** — slightly lower, shape preserved.

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs
- [x] Full suite: **467 tests, 0 failures**
- [x] Integration **72/72 across all six engines**, including the whole-table walk now driven by the extractor rather than the test
- [x] Negative control confirms the clamp tests fail without the clamp
- [x] `ShadowConsumer` runs 100k rows, exit 0, allocations verified
- [x] CHANGELOG entry

Closes #394