### PR TITLE
feat(paging): let the database do the skipping when paging is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`SkipItemCount` is now applied by the database when paging is active (#398).** It was
+  applied client-side, so every skipped row was fetched and discarded — `SkipItemCount = 1_000_000`
+  dragged a million rows across the wire to throw them all away. With paging on, the skip is
+  folded into the starting offset (`ServerOffset + SkipItemCount`) and those rows are never sent.
+
+  Without paging there is no offset to fold into, so the client-side path remains and a warning
+  is logged naming `ServerLimit` + `PagingClauseTemplate` as the faster route.
+
+  `CurrentSkippedItemCount` still reports the skip, so progress reporting is unchanged. One
+  behavioural difference: a row that fails to parse inside the skip window used to consume a
+  skip slot; skipped server-side, such rows never materialise, so the window is measured purely
+  in source rows.
+
 - **BREAKING: server-side paging now advances through pages itself (#394).** `ServerLimit` is
   the size of each round-trip, not a cap on the total: one extractor walks the whole result set,
   advancing the offset until the source is exhausted. Previously one extractor returned exactly

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -606,6 +606,14 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// include one — without a stable order, page contents drift.
     /// </para>
     /// <para>
+    /// <b>Skipping is done by the database when paging is on.</b> <c>SkipItemCount</c> is
+    /// normally applied here, after the rows arrive — so a large skip drags every skipped row
+    /// across the wire only to discard it. With paging active the skip is folded into the
+    /// starting offset instead (<see cref="ServerOffset"/> + <c>SkipItemCount</c>) and those
+    /// rows are never sent. Without paging there is no offset to fold into, so the rows are
+    /// fetched and discarded as before and a warning is logged.
+    /// </para>
+    /// <para>
     /// <b>Two costs to know about.</b> Most engines implement <c>OFFSET n</c> by scanning and
     /// discarding those <c>n</c> rows, so walking a large table page by page is quadratic in
     /// server-side work; a keyset ("seek") predicate on the command text is the cheaper shape
@@ -807,6 +815,33 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
             var pageOffset = ServerOffset ?? 0L;
             var pageSize = ServerLimit;
 
+            // The database can do the skipping for us whenever paging is active: start at
+            // ServerOffset + SkipItemCount and the skipped rows are never sent at all. Without
+            // paging there is no offset to fold into, so they have to be fetched and discarded
+            // one by one — which for a large skip is worth warning about.
+            var skipServerSide = pageSize.HasValue && SkipItemCount > 0;
+            if (skipServerSide)
+            {
+                pageOffset += SkipItemCount;
+
+                // Those rows were skipped, just not here. Leaving the counter at zero would make
+                // the progress report say "skipped 0" to someone who asked to skip a million,
+                // which reads as the setting having been ignored.
+                //
+                // ExtractorBase only exposes a parameterless increment, so this is O(SkipItemCount)
+                // — roughly 10ms for a million, against the seconds saved by not transferring
+                // those rows. A bulk increment upstream would remove the loop; until then a
+                // truthful report is worth more than the microseconds.
+                for (var skipped = 0; skipped < SkipItemCount; skipped++)
+                {
+                    IncrementCurrentSkippedItemCount();
+                }
+            }
+            else if (SkipItemCount > 0)
+            {
+                LogWarningClientSideSkip();
+            }
+
             // Once per extraction, not once per page. ApplyServerPaging adds @PageOffset and
             // @PageLimit INTO the caller's own DynamicParameters when the obsolete Parameters
             // property is used, so a per-page collision check would see paging's own names on
@@ -828,7 +863,12 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 var pageLimit = pageSize;
                 if (pageSize.HasValue)
                 {
-                    var stillNeeded = (long)SkipItemCount + MaximumItemCount - rowIndex;
+                    // Skipping server-side means nothing is fetched-then-discarded, so the
+                    // SkipItemCount term simply does not apply — the rows we receive are the
+                    // rows we yield.
+                    var stillNeeded = skipServerSide
+                        ? MaximumItemCount - CurrentItemCount
+                        : (long)SkipItemCount + MaximumItemCount - rowIndex;
                     if (stillNeeded <= 0)
                     {
                         break;
@@ -904,7 +944,7 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
                     rowIndex++;
 
-                    if (rowIndex <= SkipItemCount)
+                    if (!skipServerSide && rowIndex <= SkipItemCount)
                     {
                         IncrementCurrentSkippedItemCount();
                         LogDebugRowSkipped(rowIndex);
@@ -1253,6 +1293,22 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 "Skipping row {RowIndex} ({SkippedCount}/{SkipItemCount})",
                 rowIndex,
                 CurrentSkippedItemCount,
+                SkipItemCount
+            );
+        }
+    }
+
+
+
+    private void LogWarningClientSideSkip()
+    {
+        if (_logger.IsEnabled(LogLevel.Warning))
+        {
+            _logger.LogWarning
+            (
+                "SkipItemCount ({SkipItemCount}) is being applied client-side: every skipped row " +
+                "is fetched from the database and discarded. Set ServerLimit and " +
+                "PagingClauseTemplate to have the database skip them instead.",
                 SkipItemCount
             );
         }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Integration/DbExtractorIntegrationTestsBase.cs
@@ -172,6 +172,35 @@ public abstract class DbExtractorIntegrationTestsBase
 
 
     [SkippableFact]
+    public async Task ExtractAsync_when_paging_folds_SkipItemCount_into_the_offset()
+    {
+        Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);
+
+        using var conn = await Fixture.OpenConnectionAsync();
+        await Fixture.ResetSchemaAsync(conn);
+        await Fixture.SeedAsync(conn, rowCount: 10);
+
+        // The skip is applied by the database, not here — but the observable result must be
+        // identical on every dialect, which is what this checks. A dialect where OFFSET means
+        // something subtly different would show up as the wrong first row.
+        var extractor = new DbExtractor<ContractItem>(conn, OrderedSelect)
+        {
+            PagingClauseTemplate = Fixture.PagingClauseTemplate,
+            ServerLimit = 3,
+            SkipItemCount = 4
+        };
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(6, results.Count);
+        Assert.Equal("Item5", results[0].Name);
+        Assert.Equal("Item10", results[5].Name);
+        Assert.Equal(4, extractor.CurrentSkippedItemCount);
+    }
+
+
+
+    [SkippableFact]
     public async Task ExtractAsync_when_ServerLimit_exceeds_the_rows_remaining_returns_only_what_is_left()
     {
         Skip.IfNot(Fixture.Available, Fixture.UnavailableReason);

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClampTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/PagingClampTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
@@ -94,11 +95,12 @@ public class PagingClampTests
 
 
     [Fact]
-    public async Task SkipItemCount_is_included_in_what_the_page_asks_for()
+    public async Task SkipItemCount_is_pushed_into_the_offset_instead_of_being_fetched()
     {
-        // The trap. SkipItemCount is applied client-side AFTER the rows arrive, so a run that
-        // needs 30 yielded rows with 10 skipped must fetch 40. Clamping to MaximumItemCount
-        // alone would request 30, silently yield 20, and still look plausible.
+        // Reversed by #398. This used to request (0, 40) — fetch the 10 skipped rows and throw
+        // them away here. The database can skip them instead, so the request is (10, 30) and
+        // those rows never cross the wire. The SkipItemCount term in the clamp disappears with
+        // them: nothing is fetched-then-discarded, so received == yielded.
         var logger = new SpyLogger<DbExtractor<PersonRecord>>();
         using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 500);
 
@@ -122,7 +124,7 @@ public class PagingClampTests
 
         Assert.Equal(30, records.Count);
         Assert.Equal("First11", records[0].FirstName);
-        Assert.Equal(new[] { (0L, 40L) }, RequestedPages(logger));
+        Assert.Equal(new[] { (10L, 30L) }, RequestedPages(logger));
     }
 
 
@@ -156,5 +158,99 @@ public class PagingClampTests
         Assert.Equal(17, records.Count);
         Assert.Equal("First4", records[0].FirstName);
         Assert.All(RequestedPages(logger), page => Assert.Equal(5L, page.Limit));
+    }
+
+
+    [Fact]
+    public async Task Server_side_skip_composes_with_ServerOffset()
+    {
+        // Start at 25, then skip 10 more → the database is asked for offset 35.
+        var logger = new SpyLogger<DbExtractor<PersonRecord>>();
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 500);
+
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id",
+            new DbExtractorOptions
+            {
+                PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+                ServerOffset = 25,
+                ServerLimit = 10
+            },
+            logger: logger
+        )
+        {
+            SkipItemCount = 10,
+            MaximumItemCount = 5
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        // Rows are 1-based, so offset 35 is First36.
+        Assert.Equal(5, records.Count);
+        Assert.Equal("First36", records[0].FirstName);
+        Assert.Equal(new[] { (35L, 5L) }, RequestedPages(logger));
+    }
+
+
+
+    [Fact]
+    public async Task Server_side_skip_still_reports_the_skipped_count()
+    {
+        // The rows were skipped, just not locally. Reporting 0 here would read as the setting
+        // having been ignored.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 50);
+
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id",
+            new DbExtractorOptions
+            {
+                PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+                ServerLimit = 10
+            }
+        )
+        {
+            SkipItemCount = 7
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(43, records.Count);
+        Assert.Equal("First8", records[0].FirstName);
+        Assert.Equal(7, extractor.CurrentSkippedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task Skipping_without_paging_warns_that_it_is_the_slow_path()
+    {
+        // No ServerLimit means no offset to fold into, so the rows have to be fetched and
+        // discarded. That still works — it is just worth telling the caller there is a faster way.
+        var logger = new SpyLogger<DbExtractor<PersonRecord>>();
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
+
+        var extractor = new DbExtractor<PersonRecord>
+        (
+            conn,
+            "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id",
+            new DbExtractorOptions(),
+            logger: logger
+        )
+        {
+            SkipItemCount = 5
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(15, records.Count);
+        Assert.Equal("First6", records[0].FirstName);
+
+        var warning = Assert.Single(logger.Entries.Where(e => e.Level == LogLevel.Warning));
+        Assert.Contains("ServerLimit", warning.Message, StringComparison.Ordinal);
+        Assert.Contains("PagingClauseTemplate", warning.Message, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
Stacked on #396. Closes #398 — your point on that PR's thread.

## Why

`SkipItemCount` was applied **client-side**: rows fetched, then discarded on arrival. With paging that is pathological — `SkipItemCount = 1_000_000` drags a million rows across the wire, page by page, to throw every one away.

When paging is active the skip is folded into the starting offset (`ServerOffset + SkipItemCount`) and those rows are never sent. The client-side skip block is bypassed in that mode so rows are not skipped twice.

**#394's trap disappears with it.** The `SkipItemCount` term in the clamp existed *only* because skipped rows had to be fetched. Server-side, received == yielded, so it is just `MaximumItemCount - CurrentItemCount`. The clamp test flipped exactly as predicted — skip 10 / max 30 went from requesting `(0, 40)` to `(10, 30)`.

## Two judgment calls — you may see these differently

**The trigger is "paging is active", not "a template is set."** Your comment said the latter, but a template alone cannot carry a skip: every template references `@PageOffset` **and** `@PageLimit`, so there is no clause to emit without `ServerLimit`. Auto-enabling paging just because a template exists would also page when you did not ask to. So the warning names `ServerLimit` **and** `PagingClauseTemplate`, not just the template.

**`CurrentSkippedItemCount` is still incremented by `SkipItemCount`.** It feeds the progress report; leaving it at zero would tell someone who asked to skip a million that nothing was skipped, which reads as the setting being ignored. `ExtractorBase` exposes only a parameterless increment, so this is `O(SkipItemCount)` — roughly 10ms per million, against the seconds saved by not transferring those rows. I judged a truthful report worth more, but a bulk-increment overload upstream would remove the loop if you would rather not pay it.

## A behavioural difference, not just an optimisation

A row that fails to parse **inside the skip window** used to consume a skip slot — the `DataException` path increments `rowIndex` before the skip check. Skipped server-side, such rows never materialise, so the window is measured purely in source rows. Arguably more correct; documented either way rather than left to be discovered.

## Tests

- `SkipItemCount_is_included_in_what_the_page_asks_for` renamed and reversed — it asserted the old fetch-and-discard request
- The skip composes with `ServerOffset`: start 25, skip 10 → the database is asked for offset **35**
- `CurrentSkippedItemCount` still reports the skip
- No paging ⇒ warning naming both settings, and the rows still come out right
- **All six engines**: `OFFSET` semantics are exactly the kind of thing that could differ per dialect, so the fold is checked to produce identical results everywhere

Negative control: disabling the fold fails the two offset assertions, while the skipped-count and warning tests correctly still pass — those contracts hold in both modes, which is the point.

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs
- [x] Full suite: **477 tests, 0 failures**
- [x] Integration **78/78** across all six engines (72 → 78 with the new per-engine test)
- [x] Negative control confirms the new assertions have teeth
- [x] CHANGELOG entry

Closes #398