### PR TITLE
ci: add the Docker preflight and integration-ran assertion guards

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -968,6 +968,15 @@ jobs:
             echo "project=$proj" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify Docker is available
+        if: steps.locate.outputs.found == 'true'
+        # Preflight so an unavailable daemon fails LOUDLY here. Without it the
+        # fixtures degrade to Skip.IfNot(...) on every test, dotnet test exits 0,
+        # and the whole chain reports success with zero DB round-trips (#357).
+        run: |
+          docker version
+          docker info
+
       - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
         if: steps.locate.outputs.found == 'true'
         run: |
@@ -982,6 +991,41 @@ jobs:
             --logger "console;verbosity=normal" \
             --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
             --results-directory "./TestResults-Integration"
+
+
+      - name: Assert integration tests actually ran
+        if: steps.locate.outputs.found == 'true'
+        # Second guard, independent of the Docker preflight: a run where every
+        # test reported Skipped exits 0 and looks identical to a passing run.
+        # Fail if nothing executed, or if anything was skipped on CI.
+        shell: bash
+        run: |
+          trx=$(find . -name 'integration-*.trx' -print -quit)
+          if [ -z "$trx" ]; then
+            echo "::error::No .trx produced - the integration run did not execute."
+            exit 1
+          fi
+          # Runner images are not consistent about whether `python` is on PATH; `python3`
+          # is the reliable name. Same fallback shadow-regression.yaml already uses.
+          PYTHON_BIN=python3
+          command -v python3 >/dev/null 2>&1 || PYTHON_BIN=python
+          "$PYTHON_BIN" - "$trx" <<'PY'
+          import re, sys, xml.etree.ElementTree as ET
+          root = ET.parse(sys.argv[1]).getroot()
+          ns = {'t': re.match(r'\{(.*)\}', root.tag).group(1)} if root.tag.startswith('{') else {}
+          c = root.find('.//t:Counters', ns) if ns else root.find('.//Counters')
+          if c is None:
+              print('::error::No <Counters> in the .trx - cannot verify the run.'); sys.exit(1)
+          total = int(c.get('total', 0)); executed = int(c.get('executed', 0))
+          passed = int(c.get('passed', 0)); skipped = total - executed
+          print(f'total={total} executed={executed} passed={passed} skipped={skipped}')
+          if total == 0:
+              print('::error::Zero tests in the .trx.'); sys.exit(1)
+          if executed == 0:
+              print('::error::Every test was skipped - Docker or the fixture is unavailable.'); sys.exit(1)
+          if skipped:
+              print(f'::error::{skipped} test(s) skipped on CI; integration tests must not skip here.'); sys.exit(1)
+          PY
 
       - name: Upload integration test results
         if: always() && steps.locate.outputs.found == 'true'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1000,7 +1000,9 @@ jobs:
         # Fail if nothing executed, or if anything was skipped on CI.
         shell: bash
         run: |
-          trx=$(find . -name 'integration-*.trx' -print -quit)
+          # Scoped to the directory the test step actually writes to, and tolerant of it
+          # missing so the explicit message below is what surfaces, not a find error.
+          trx=$(find ./TestResults-Integration -name 'integration-*.trx' -print -quit 2>/dev/null || true)
           if [ -z "$trx" ]; then
             echo "::error::No .trx produced - the integration run did not execute."
             exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -654,7 +654,9 @@ jobs:
         # Fail if nothing executed, or if anything was skipped on CI.
         shell: bash
         run: |
-          trx=$(find . -name 'integration-*.trx' -print -quit)
+          # Scoped to the directory the test step actually writes to, and tolerant of it
+          # missing so the explicit message below is what surfaces, not a find error.
+          trx=$(find ./TestResults-Integration -name 'integration-*.trx' -print -quit 2>/dev/null || true)
           if [ -z "$trx" ]; then
             echo "::error::No .trx produced - the integration run did not execute."
             exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -625,6 +625,15 @@ jobs:
             echo "project=$proj" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify Docker is available
+        if: steps.locate.outputs.found == 'true'
+        # Preflight so an unavailable daemon fails LOUDLY here. Without it the
+        # fixtures degrade to Skip.IfNot(...) on every test, dotnet test exits 0,
+        # and the whole chain reports success with zero DB round-trips (#357).
+        run: |
+          docker version
+          docker info
+
       - name: Run ${{ matrix.rdbms }} integration tests (${{ matrix.tfm }})
         if: steps.locate.outputs.found == 'true'
         run: |
@@ -636,6 +645,41 @@ jobs:
             --logger "console;verbosity=normal" \
             --logger "trx;LogFileName=integration-${{ matrix.rdbms }}-${{ matrix.tfm }}.trx" \
             --results-directory "./TestResults-Integration"
+
+
+      - name: Assert integration tests actually ran
+        if: steps.locate.outputs.found == 'true'
+        # Second guard, independent of the Docker preflight: a run where every
+        # test reported Skipped exits 0 and looks identical to a passing run.
+        # Fail if nothing executed, or if anything was skipped on CI.
+        shell: bash
+        run: |
+          trx=$(find . -name 'integration-*.trx' -print -quit)
+          if [ -z "$trx" ]; then
+            echo "::error::No .trx produced - the integration run did not execute."
+            exit 1
+          fi
+          # Runner images are not consistent about whether `python` is on PATH; `python3`
+          # is the reliable name. Same fallback shadow-regression.yaml already uses.
+          PYTHON_BIN=python3
+          command -v python3 >/dev/null 2>&1 || PYTHON_BIN=python
+          "$PYTHON_BIN" - "$trx" <<'PY'
+          import re, sys, xml.etree.ElementTree as ET
+          root = ET.parse(sys.argv[1]).getroot()
+          ns = {'t': re.match(r'\{(.*)\}', root.tag).group(1)} if root.tag.startswith('{') else {}
+          c = root.find('.//t:Counters', ns) if ns else root.find('.//Counters')
+          if c is None:
+              print('::error::No <Counters> in the .trx - cannot verify the run.'); sys.exit(1)
+          total = int(c.get('total', 0)); executed = int(c.get('executed', 0))
+          passed = int(c.get('passed', 0)); skipped = total - executed
+          print(f'total={total} executed={executed} passed={passed} skipped={skipped}')
+          if total == 0:
+              print('::error::Zero tests in the .trx.'); sys.exit(1)
+          if executed == 0:
+              print('::error::Every test was skipped - Docker or the fixture is unavailable.'); sys.exit(1)
+          if skipped:
+              print(f'::error::{skipped} test(s) skipped on CI; integration tests must not skip here.'); sys.exit(1)
+          PY
 
       - name: Upload integration test results
         if: always() && steps.locate.outputs.found == 'true'


### PR DESCRIPTION
Protected-file split ahead of the **v0.10.0** release.

## Why this is separate

vNext's delta against main is 66 files, two of which are workflows. Bundling them into the release PR would fail `Detect .NET Projects` and push us toward an admin bypass — which waives **all** ruleset rules for the whole PR, including `required_review_thread_resolution`, for the other 64 files too. Splitting costs one small PR and keeps the release merging through the full ruleset.

## What's in it

Two guards against the same silent failure (#357): an integration run where every test reports `Skipped` **exits 0 and looks identical to a passing run**.

- **Docker preflight** — fails loudly when the daemon is unreachable, instead of letting the fixtures degrade to `Skip.IfNot(...)` on every test
- **`.trx` assertion** — fails when nothing executed, or when anything was skipped on CI; independent of the preflight, so neither alone is load-bearing

Also switches to `python3` with a `python` fallback, since runner images aren't consistent about which name is on PATH.

**Additive only: 88 insertions, 0 deletions.** No existing step is altered. Extracted verbatim from vNext (#367, #382).

## Test plan

- [ ] `Detect .NET Projects` will fail — that is the point of this PR; it needs an admin-bypass merge
- [ ] Diff is exactly two files, both under `.github/workflows/`
- [ ] After merge: `main` → `vNext` reconcile drops the protected delta, and the release PR opens clean

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>