### PR TITLE
ci: stop the trusted-config fetch from collapsing files to one line

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -418,7 +418,7 @@ jobs:
             git cat-file -e "main-branch:$configFile" 2>&1 | Out-Null
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
+              git show "main-branch:$configFile" | Set-Content -Path $configFile -Encoding utf8NoBOM
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -432,7 +432,7 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
+                git show "main-branch:$file" | Set-Content -Path $file -Encoding utf8NoBOM
               }
             }
           }
@@ -1128,7 +1128,7 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
+              git show "main-branch:$configFile" | Set-Content -Path $configFile -Encoding utf8NoBOM
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -1143,7 +1143,7 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
+                git show "main-branch:$file" | Set-Content -Path $file -Encoding utf8NoBOM
               }
             }
           }
@@ -1173,7 +1173,7 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
+              git show "main-branch:$configFile" | Set-Content -Path $configFile -Encoding utf8NoBOM
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -1188,7 +1188,7 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
+                git show "main-branch:$file" | Set-Content -Path $file -Encoding utf8NoBOM
               }
             }
           }


### PR DESCRIPTION
**This is what is failing InspectCode on the release PR (#405), and it is a CI bug rather than a code problem.** Protected-file split, so it needs an admin-bypass merge.

## The bug

The "Fetch trusted configuration files from main branch" step copies config from `main` so a PR cannot weaken its own analysis. It wrote each file with:

```powershell
git show "main-branch:$f" | Out-File -FilePath $f -Encoding UTF8NoBOM -NoNewline
```

`git show` emits an **array of lines**, and `Out-File -NoNewline` writes them with **no separator between elements** — so every copied file lands as a single line. Measured directly:

```
original: 491 lines
after Out-File -NoNewline: 1 line
```

That destroys every severity setting in `.editorconfig`, including the blanket `dotnet_analyzer_diagnostic.severity = suggestion` and every explicit `dotnet_diagnostic.SXXXX.severity` line. All analyzers then fall back to their **default** severities, and under Release's `TreatWarningsAsErrors` those become build errors.

## Why it surfaced now

It has been latent because nothing in the codebase tripped a default-severity rule. v0.10.0 adds **25 `[Obsolete]` markers**, and `S1133` ("Do not forget to remove this deprecated code someday") fires on every one — **550 errors** across the TFM matrix, plus `S3267` and `S1939` from the new `EtlParameterSet`.

Note this could not have been fixed by editing `.editorconfig`: that file is destroyed *inside the job*, so no change to it has any effect there.

## Scope

Six occurrences across three jobs. The same step also corrupts `Directory.Build.props`, `Directory.Build.targets`, `BannedSymbols.txt`, `*.globalconfig`, `*.ruleset` and the workflow files it copies. `release.yaml` does not use this pattern.

`Set-Content` writes the array with newlines between elements, which is the behaviour that was intended.

## Verified

- 491 lines in → **491 lines out**, blanket severity line intact
- `pr.yaml` still parses; 13 jobs
- Diff is exactly the six lines, nothing else

## Worth knowing beyond the fix

InspectCode has been analysing with destroyed configuration for as long as this step has existed, so its results to date reflect **default** severities rather than this repo's tuned ones. Its historical green runs were green because nothing happened to trip a default-severity rule — not because the configuration was being honoured.

## Test plan

- [ ] `Detect .NET Projects` will fail — this is a protected file; that is why it is split out
- [ ] After merge: `main` → `vNext`, then #405's InspectCode re-runs with intact config

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>