### PR TITLE
chore(pack): advance PackageValidation baseline to 0.10.0

### DIFF
--- a/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
+++ b/src/Wolfgang.Etl.DbClient/Wolfgang.Etl.DbClient.csproj
@@ -48,7 +48,7 @@
          once the version being released here is live on the flatcontainer CDN,
          never to the in-flight version (the pack step downloads the baseline). -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.9.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.10.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Post-release follow-up for **v0.10.0**. Single line: `PackageValidationBaselineVersion` 0.9.1 → 0.10.0.

## Why this waits until now

`dotnet pack` **downloads** the baseline package to compare against, so bumping it before NuGet's CDN serves 0.10.0 fails restore with `NU1102`. That is the ordering constraint this PR was held for, not ceremony.

## Verified, not assumed

- `0.10.0` present in the flatcontainer index for `wolfgang.etl.dbclient`
- A local `dotnet pack` **resolved 0.10.0 as the baseline** — it now sits in the local NuGet cache alongside 0.7.0–0.9.1, which is the direct evidence the download happened
- Pack completed with **zero errors and no `NU1102`**, producing both `.nupkg` and `.snupkg`

Worth noting the verification took two attempts: my first "confirmation" ran `dotnet pack` with `--no-incremental`, which is a `dotnet build` switch — MSBuild rejected the command outright (`MSB1001`) and nothing was packed. The run above is the real one.

## Nothing else to fold

`PublicAPI.Unshipped.txt` is empty apart from its `#nullable enable` header — the release cut already folded 90 entries into `Shipped`. Checked rather than presumed, since a hotfix landing between the release merge and the tag is exactly how stragglers appear.

## Remaining post-release items (tracked in #406)

- **Main-branch ruleset `14462276` is `disabled`** and needs re-enabling — seven rules off including `pull_request` and `non_fast_forward`. Requires the repo owner; the API call is blocked for the agent as a security-settings mutation.
- **SourceLink symbol-server smoke** failed in `release.yaml` — NuGet symbol ingestion exceeded the job's 1800s poll. Not a release defect: the pre-publish structural verify on the `.snupkg` passed and the package published fine. Re-run just that job once symbols land.
- Issue sweep for the 12 `in vNext` issues — #372 excluded, its policy asks for 100% test-code line coverage and the release reached 99.9%.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>