### PR TITLE
feat(paging)!: make the template the switch and fold ServerOffset into SkipItemCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -9,11 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `DbExtractor.PageSize` / `DbExtractorOptions.PageSize` — rows per round-trip. A single extractor
+  now walks the whole result set instead of yielding one page, so callers no longer write the page
+  loop themselves ([#410](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/410),
+  [#394](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/394)).
+- `IDbExtractorBuilder.PageSize()`, `.SkipItemCount()` and `.MaximumItemCount()`, so the builder can
+  express the row contract as well as the transport tuning.
+- [ADR-0002](docs/adr/0002-skip-max-and-paging.md) records the model: `SkipItemCount` and
+  `MaximumItemCount` are the contract, `PagingClauseTemplate` and `PageSize` are transport tuning.
+
 ### Changed
+
+- **`PagingClauseTemplate` is now the switch that activates paging.** Left at
+  `PagingClauseTemplates.None` the command runs unchanged; set, the paging clause is applied. With a
+  template and no `PageSize`, the skip and the maximum are pushed into a **single** query — the
+  cheapest path, since it pays the offset once instead of once per page.
+- **`SkipItemCount` is pushed into the query's offset when a template is set**, so the skipped rows
+  are never fetched instead of being fetched and discarded on arrival
+  ([#398](https://github.com/Chris-Wolfgang/Etl-DbClient/issues/398)). Without a template the
+  client-side skip stays, and now logs a warning naming the faster route.
+- A page never asks for more than is still needed: the requested limit is
+  `min(PageSize, MaximumItemCount - rowsYielded)`.
+- `SkipItemCount` with a template is reported through `CurrentSkippedItemCount` as before — the rows
+  were skipped, just not locally.
+- Setting `PageSize` without a `PagingClauseTemplate` throws `InvalidOperationException` rather than
+  silently running unpaged.
+- Paging docs corrected: paging costs *more* total server work, not less. `OFFSET n` is not a seek,
+  so a full walk scans roughly `N² / (2 × PageSize)` rows. The previous claim that paging avoids
+  "streaming everything to the client" was never true — extraction streams off a `DbDataReader`
+  either way. What paging buys is bounded per-query work, shorter transactions and resumability.
 
 ### Deprecated
 
+- `ServerOffset` now forwards to `SkipItemCount` — the two were always the same idea, so there is
+  one value rather than two that can disagree. Out-of-`int` values throw rather than truncating.
+- `ServerLimit` now forwards to `PageSize`. **Its meaning changed** from "total rows to return" to
+  "rows per round-trip"; use `MaximumItemCount` for the total. Renamed rather than reused so the
+  change surfaces at the call site instead of silently returning a different number of rows.
+
 ### Removed
+
+- The `ServerOffset`-without-`ServerLimit` error. An offset no longer needs a page size, because it
+  is now just `SkipItemCount`.
 
 ### Fixed
 

--- a/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Program.cs
+++ b/samples/Wolfgang.Etl.DbClient.Samples.ShadowConsumer/Program.cs
@@ -1,4 +1,4 @@
-// Shadow-testing consumer — realistic DbClient workload for #130.
+﻿// Shadow-testing consumer — realistic DbClient workload for #130.
 //
 // Scenario: a paged extract-transform-load loop. 100k rows in a source
 // SQLite table, paged out 1k at a time via server-side paging on the
@@ -72,36 +72,50 @@ var sw = Stopwatch.StartNew();
 long extracted = 0;
 long loaded = 0;
 
-for (long offset = 0; offset < totalRows; offset += pageSize)
+// One extractor walks the whole table: PageSize is the round-trip size and the extractor
+// advances the offset itself. This used to be a caller-written for-loop rebuilding an extractor
+// per page — when the sample and the tests both hand-roll the same loop, it belongs in the
+// library. See docs/adr/0002-skip-max-and-paging.md.
+var extractor = new DbExtractor<SourceWidget>
+(
+    src,
+    "SELECT id AS Id, name AS Name, price AS Price FROM widget ORDER BY id"
+)
 {
-    var extractor = new DbExtractor<SourceWidget>
-    (
-        src,
-        "SELECT id AS Id, name AS Name, price AS Price FROM widget ORDER BY id"
-    )
-    {
-        // The source here is SQLite. Paging syntax is dialect-specific and the library no
-        // longer guesses one, so the dialect has to be named.
-        PagingClauseTemplate = PagingClauseTemplates.Sqlite,
-        ServerOffset = offset,
-        ServerLimit = pageSize,
-    };
+    // The source here is SQLite. Paging syntax is dialect-specific and the library does not
+    // guess one, so the dialect has to be named.
+    PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+    PageSize = pageSize,
+};
 
-    var page = new List<DestWidget>(pageSize);
-    await foreach (var s in extractor.ExtractAsync())
+var loader = new DbLoader<DestWidget>
+(
+    dest,
+    "INSERT INTO widget_projected (id, upper_name, price) VALUES (@Id, @UpperName, @Price)"
+)
+{
+    InsertBatchSize = batchSize,
+};
+
+var page = new List<DestWidget>(pageSize);
+
+await foreach (var s in extractor.ExtractAsync())
+{
+    page.Add(new DestWidget { Id = s.Id, UpperName = s.Name.ToUpperInvariant(), Price = s.Price });
+    extracted++;
+
+    // Load in batches of the same size, so the allocation profile stays comparable to the
+    // per-page loop this replaced.
+    if (page.Count == pageSize)
     {
-        page.Add(new DestWidget { Id = s.Id, UpperName = s.Name.ToUpperInvariant(), Price = s.Price });
-        extracted++;
+        await loader.LoadAsync(AsAsync(page));
+        loaded += page.Count;
+        page.Clear();
     }
+}
 
-    var loader = new DbLoader<DestWidget>
-    (
-        dest,
-        "INSERT INTO widget_projected (id, upper_name, price) VALUES (@Id, @UpperName, @Price)"
-    )
-    {
-        InsertBatchSize = batchSize,
-    };
+if (page.Count > 0)
+{
     await loader.LoadAsync(AsAsync(page));
     loaded += page.Count;
 }

--- a/src/Wolfgang.Etl.DbClient/DbExtractor.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -78,6 +78,9 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     private readonly ILogger _logger;
     private readonly Stopwatch _stopwatch = new();
     private int? _totalItemCount;
+
+
+    private int? _pageSize;
 
 
 
@@ -586,32 +589,115 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
-    /// When <see cref="ServerLimit"/> is set, the extractor appends
-    /// <see cref="PagingClauseTemplate"/> to the command text before sending it, using this
-    /// offset — or <c>0</c> when this is unset. Default <see langword="null"/> disables
-    /// server-side paging (the v0.4.0 behavior — the full result set comes
-    /// back and <c>SkipItemCount</c>/<c>MaximumItemCount</c> filter
-    /// client-side).
+    /// Rows per round-trip. Setting this makes the extractor walk the result set one page at a
+    /// time; leaving it unset issues a single query.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Use server-side paging for very large tables where streaming
-    /// everything to the client is wasteful. SQL Server requires an
-    /// <c>ORDER BY</c> in the command text for paging to be deterministic;
-    /// SQLite, PostgreSQL, and MySQL don't require it but you should still
-    /// include one — without a stable order, page contents drift.
+    /// Paging is <b>transport tuning</b>, not a row filter. <c>SkipItemCount</c> and
+    /// <c>MaximumItemCount</c> decide which rows are yielded, and they yield the same rows
+    /// whether or not this is set. What changes is the number of round-trips and how much work
+    /// the server does per query.
     /// </para>
     /// <para>
-    /// Defaults to <c>0</c>. Paging is switched on by <see cref="ServerLimit"/>; an offset with no limit throws, since no page size can be inferred.
+    /// Requires <see cref="PagingClauseTemplate"/>, because paging syntax is dialect-specific and
+    /// no portable form exists. A page size without a template throws
+    /// <see cref="InvalidOperationException"/> rather than silently running unpaged.
+    /// </para>
+    /// <para>
+    /// <b>Paging costs more total server work, not less.</b> <c>OFFSET n</c> is not a seek — most
+    /// engines produce the rows in order and discard the first <c>n</c> — so a page at offset
+    /// <c>n</c> costs O(n + pageSize), and walking a table of <c>N</c> rows scans roughly
+    /// <c>N² / (2 × pageSize)</c> rows in total. A larger page reduces that linearly. What paging
+    /// buys is bounded per-query work, shorter transactions and resumability, not less work.
+    /// </para>
+    /// <para>
+    /// <b>Page contents drift under concurrent writes.</b> Rows inserted or deleted between pages
+    /// shift the window, so rows can be missed or returned twice even with an <c>ORDER BY</c>.
+    /// SQL Server requires an <c>ORDER BY</c> for paging to be deterministic at all; the other
+    /// engines do not require one, but you should still supply one.
     /// </para>
     /// </remarks>
-    public long? ServerOffset { get; [Obsolete("Configure ServerOffset through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; }
+    /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 1.</exception>
+    public int? PageSize
+    {
+        get => _pageSize;
+        set
+        {
+            if (value.HasValue && value.Value < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "PageSize cannot be less than 1.");
+            }
+
+            _pageSize = value;
+        }
+    }
 
 
 
-    /// <summary>Page size in rows. See <see cref="ServerOffset"/>.</summary>
-    /// <remarks>Setting this switches server-side paging on. <see cref="ServerOffset"/> defaults to <c>0</c> when not set.</remarks>
-    public long? ServerLimit { get; [Obsolete("Configure ServerLimit through DbExtractorOptions passed to the constructor instead. This setter will be removed in a future release.")] set; }
+    /// <summary>Rows to skip before the first yielded row, expressed as a server-side offset.</summary>
+    /// <remarks>
+    /// Superseded by <c>SkipItemCount</c>, which this property forwards to — the two were
+    /// always the same idea, so there is one value rather than two that can disagree. When a
+    /// paging template is set the skip is pushed into the query's offset, so the skipped rows are
+    /// never fetched.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The specified value does not fit in an <see cref="int"/>.
+    /// </exception>
+    [Obsolete("Use SkipItemCount instead. ServerOffset forwards to it and will be removed in a future release.")]
+    public long? ServerOffset
+    {
+        get => SkipItemCount;
+        set => SkipItemCount = value.HasValue ? ToRowCount(value.Value, nameof(ServerOffset)) : 0;
+    }
+
+
+
+    /// <summary>Rows per round-trip.</summary>
+    /// <remarks>
+    /// Superseded by <see cref="PageSize"/>, which this property forwards to. The name changed
+    /// because the meaning did: this is the size of each round-trip, not a cap on the total number
+    /// of rows returned. Use <c>MaximumItemCount</c> for the total.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The specified value does not fit in an <see cref="int"/>.
+    /// </exception>
+    [Obsolete("Use PageSize instead. ServerLimit forwards to it and will be removed in a future release. Note the meaning changed: this is rows per round-trip, not a cap on the total — use MaximumItemCount for that.")]
+    public long? ServerLimit
+    {
+        get => PageSize;
+        set => PageSize = value.HasValue ? ToRowCount(value.Value, nameof(ServerLimit)) : (int?)null;
+    }
+
+
+
+    /// <summary>
+    /// Narrows a <see cref="long"/> row count from an obsolete property to the <see cref="int"/>
+    /// the base class uses, refusing to truncate silently.
+    /// </summary>
+    /// <param name="value">The row count to narrow.</param>
+    /// <param name="propertyName">The obsolete property the value came from, for the message.</param>
+    /// <returns>The value as an <see cref="int"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="value"/> does not fit in an <see cref="int"/>.
+    /// </exception>
+    private static int ToRowCount(long value, string propertyName)
+    {
+        if (value < int.MinValue || value > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException
+            (
+                nameof(value),
+                value,
+                $"{propertyName} does not fit in an Int32 and cannot be forwarded. Row counts are " +
+                "Int32-wide; see Chris-Wolfgang/ETL-Abstractions#454."
+            );
+        }
+
+        return (int)value;
+    }
+
 
 
 
@@ -774,88 +860,185 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 await DbSchemaValidator.ValidateAsync<TRecord>(_connection, token).ConfigureAwait(false);
             }
 
-            ApplyServerPaging(_commandText, Parameters ?? _dynamicParameters, out var commandText, out var param);
+            var param = Parameters ?? _dynamicParameters;
+
+            // The TEMPLATE is the switch. It names the dialect, and since there is no portable
+            // paging syntax there is nothing to emit without one. PageSize then decides whether
+            // that clause drives a single query or a walk across pages.
+            var templateChosen = !string.IsNullOrWhiteSpace(PagingClauseTemplate);
+
+            EnsurePagingConfigurationValid(templateChosen);
+
+            // A template with nothing to bound is not worth a clause: it would send
+            // "FETCH NEXT 2147483647", which nothing here has verified every engine accepts.
+            var paging = templateChosen
+                && (SkipItemCount > 0 || MaximumItemCount != int.MaxValue || PageSize.HasValue);
+
+            // With a template in hand the skip belongs in the query's offset, so the rows are
+            // never fetched at all. The client-side skip below must then not run, or they would
+            // be skipped twice.
+            var serverSideSkip = paging && SkipItemCount > 0;
+
+            if (paging)
+            {
+                // Runs ONCE, before the first page. Per page it would fail on page two against
+                // paging's own parameter names, which page one just added.
+                EnsurePagingParametersNotAlreadySupplied();
+                param ??= new DynamicParameters();
+            }
+            else if (SkipItemCount > 0)
+            {
+                LogSkipWithoutPaging();
+            }
 
             if (TotalCountQuery != null)
             {
                 _totalItemCount = await TotalCountQuery(token).ConfigureAwait(false);
             }
 
+            if (serverSideSkip)
+            {
+                // The rows genuinely were skipped, just not by us. Leaving the counter at zero
+                // would silently change an observable the moment the skip moved server-side.
+                for (var skipped = 0; skipped < SkipItemCount; skipped++)
+                {
+                    IncrementCurrentSkippedItemCount();
+                }
+            }
+
+            var commandText = paging ? _commandText + " " + PagingClauseTemplate : _commandText;
+
+            // rowsReceived counts rows the READER produced, including ones that failed to parse.
+            // CurrentItemCount counts rows YIELDED. The offset and the short-page test run off
+            // the first; the maximum clamp runs off the second. Conflating them is the whole bug:
+            // advancing the offset by rows yielded re-fetches every row that failed to parse and
+            // duplicates the good rows behind them, and testing the short page against rows
+            // yielded ends the walk at the first page containing one.
+            long rowsReceived = 0;
             long rowIndex = 0;
 
-            // The reader is driven with a manual ReadAsync loop, and row mapping
-            // goes through a standalone Dapper row-parser delegate, rather than
-            // Dapper's own QueryUnbufferedAsync<T> IAsyncEnumerable. That matters:
-            // QueryUnbufferedAsync's read-and-map loop lives inside ONE compiler-
-            // generated async-iterator state machine. When mapping throws mid-loop,
-            // the iterator's finally block runs and the state machine transitions
-            // to "finished" — so even catching the exception at the call site,
-            // the NEXT MoveNextAsync just returns false. Skip would silently
-            // truncate the result set after the first bad row instead of
-            // continuing past it. Reading via our own loop keeps ReadAsync's
-            // cursor alive across a caught mapping failure, so Skip actually
-            // skips-and-continues.
-            var command = new CommandDefinition(commandText, param, _transaction, CommandTimeoutSeconds, CommandType, cancellationToken: token);
-            using var reader = await _connection.ExecuteReaderAsync(command).ConfigureAwait(false);
-            var parseRow = reader.GetRowParser<TRecord>();
-
-            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            while (true)
             {
                 token.ThrowIfCancellationRequested();
 
-                TRecord record;
-                try
+                long requestedLimit = 0;
+
+                if (paging)
                 {
-                    record = parseRow(reader);
-                }
-                catch (System.Data.DataException ex)
-                {
-                    // Scoped to DataException — the type Dapper wraps row-materialization
-                    // failures in (e.g. "Error parsing column N") — so ErrorPolicy only ever
-                    // sees per-row failures. Catching every exception type here would also
-                    // catch connection-level failures (a dropped connection, a syntax error
-                    // surfacing lazily); those aren't per-row, and ReadAsync would likely keep
-                    // throwing the same fault on every subsequent call, so routing them
-                    // through ItemErrorAction.Skip would spin the loop instead of terminating.
-                    rowIndex++;
-                    var action = HandleItemError
-                    (
-                        new ItemErrorContext
-                        (
-                            rowIndex,
-                            ex,
-                            rawContent: null
-                        )
-                    );
-                    if (action == ItemErrorAction.Abort)
+                    // MaximumItemCount defaults to int.MaxValue, so this is "all the rest" when
+                    // the caller set no maximum. Computed in long: the offset can exceed int once
+                    // a skip is added even though both operands fit.
+                    var remaining = (long)MaximumItemCount - CurrentItemCount;
+                    if (remaining <= 0)
                     {
-                        System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+                        break;
                     }
-                    // ItemErrorAction.Skip — HandleItemError already incremented
-                    // the error-item counter on the base. Log and continue.
-                    LogDebugRowErrorSkipped(rowIndex, ex);
-                    continue;
+
+                    requestedLimit = PageSize.HasValue
+                        ? Math.Min((long)PageSize.Value, remaining)
+                        : remaining;
+
+                    SetPagingParameters(param!, (long)SkipItemCount + rowsReceived, requestedLimit);
                 }
 
-                rowIndex++;
+                // The reader is driven with a manual ReadAsync loop, and row mapping
+                // goes through a standalone Dapper row-parser delegate, rather than
+                // Dapper's own QueryUnbufferedAsync<T> IAsyncEnumerable. That matters:
+                // QueryUnbufferedAsync's read-and-map loop lives inside ONE compiler-
+                // generated async-iterator state machine. When mapping throws mid-loop,
+                // the iterator's finally block runs and the state machine transitions
+                // to "finished" — so even catching the exception at the call site,
+                // the NEXT MoveNextAsync just returns false. Skip would silently
+                // truncate the result set after the first bad row instead of
+                // continuing past it. Reading via our own loop keeps ReadAsync's
+                // cursor alive across a caught mapping failure, so Skip actually
+                // skips-and-continues.
+                var command = new CommandDefinition(commandText, param, _transaction, CommandTimeoutSeconds, CommandType, cancellationToken: token);
 
-                if (rowIndex <= SkipItemCount)
+                long rowsThisPage = 0;
+
+                using (var reader = await _connection.ExecuteReaderAsync(command).ConfigureAwait(false))
                 {
-                    IncrementCurrentSkippedItemCount();
-                    LogDebugRowSkipped(rowIndex);
-                    continue;
+                    var parseRow = reader.GetRowParser<TRecord>();
+
+                    while (await reader.ReadAsync(token).ConfigureAwait(false))
+                    {
+                        token.ThrowIfCancellationRequested();
+
+                        // Counted before anything can reject the row, so a row that fails to parse
+                        // still advances the offset. It occupied a position in the source and the
+                        // next page must start after it.
+                        rowIndex++;
+                        rowsThisPage++;
+
+                        TRecord record;
+                        try
+                        {
+                            record = parseRow(reader);
+                        }
+                        catch (System.Data.DataException ex)
+                        {
+                            // Scoped to DataException — the type Dapper wraps row-materialization
+                            // failures in (e.g. "Error parsing column N") — so ErrorPolicy only ever
+                            // sees per-row failures. Catching every exception type here would also
+                            // catch connection-level failures (a dropped connection, a syntax error
+                            // surfacing lazily); those aren't per-row, and ReadAsync would likely keep
+                            // throwing the same fault on every subsequent call, so routing them
+                            // through ItemErrorAction.Skip would spin the loop instead of terminating.
+                            var action = HandleItemError
+                            (
+                                new ItemErrorContext
+                                (
+                                    rowIndex,
+                                    ex,
+                                    rawContent: null
+                                )
+                            );
+                            if (action == ItemErrorAction.Abort)
+                            {
+                                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+                            }
+                            // ItemErrorAction.Skip — HandleItemError already incremented
+                            // the error-item counter on the base. Log and continue.
+                            LogDebugRowErrorSkipped(rowIndex, ex);
+                            continue;
+                        }
+
+                        // Only when the database did not do the skipping for us.
+                        if (!serverSideSkip && rowIndex <= SkipItemCount)
+                        {
+                            IncrementCurrentSkippedItemCount();
+                            LogDebugRowSkipped(rowIndex);
+                            continue;
+                        }
+
+                        if (CurrentItemCount >= MaximumItemCount)
+                        {
+                            LogDebugMaxReached();
+                            LogExtractionCompleted();
+                            yield break;
+                        }
+
+                        LogDebugRowExtracted(rowIndex);
+                        IncrementCurrentItemCount();
+                        yield return record;
+                    }
                 }
 
-                if (CurrentItemCount >= MaximumItemCount)
+                if (!paging)
                 {
-                    LogDebugMaxReached();
-                    LogExtractionCompleted();
-                    yield break;
+                    break;
                 }
 
-                LogDebugRowExtracted(rowIndex);
-                IncrementCurrentItemCount();
-                yield return record;
+                rowsReceived += rowsThisPage;
+
+                // A page that came back short of what it asked for is the last one. Compared
+                // against rows RECEIVED so a page full of unparseable rows does not read as
+                // exhaustion.
+                if (rowsThisPage < requestedLimit)
+                {
+                    break;
+                }
             }
 
             LogExtractionCompleted();
@@ -899,27 +1082,27 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     }
 
     /// <summary>
-    /// Verifies a paging dialect was chosen before server-side paging is applied.
+    /// Verifies the paging knobs are coherent before the first query goes out.
     /// </summary>
+    /// <param name="templateChosen">Whether a paging dialect has been named.</param>
     /// <exception cref="InvalidOperationException">
-    /// Paging is active but <see cref="PagingClauseTemplate"/> is
+    /// <see cref="PageSize"/> is set but <see cref="PagingClauseTemplate"/> is
     /// <see cref="PagingClauseTemplates.None"/>.
     /// </exception>
-    private void EnsurePagingClauseTemplateChosen()
+    private void EnsurePagingConfigurationValid(bool templateChosen)
     {
-        if (!string.IsNullOrWhiteSpace(PagingClauseTemplate))
+        if (!PageSize.HasValue || templateChosen)
         {
             return;
         }
 
         throw new InvalidOperationException
         (
-            "Server-side paging requires PagingClauseTemplate to be set, because paging syntax " +
-            "is dialect-specific and no portable form exists. Choose a preset from " +
+            "PageSize was set without PagingClauseTemplate, so no paging clause can be emitted — " +
+            "paging syntax is dialect-specific and no portable form exists. Choose a preset from " +
             "PagingClauseTemplates (for example PagingClauseTemplates.SqlServer, .PostgreSql, " +
-            ".MySql, .Sqlite, .Oracle or .Db2), or supply your own clause referencing " +
-            "@PageOffset and @PageLimit. To disable paging instead, clear ServerOffset and " +
-            "ServerLimit."
+            ".MySql, .Sqlite, .Oracle or .Db2), or supply your own clause referencing @PageOffset " +
+            "and @PageLimit. To run unpaged instead, clear PageSize."
         );
     }
 
@@ -929,10 +1112,14 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
     /// Rejects a caller-supplied parameter whose name server-side paging also generates.
     /// </summary>
     /// <remarks>
-    /// This cannot live inside either branch of <see cref="ApplyServerPaging"/>.
+    /// It cannot run per page: page one adds the paging parameters, so page two would find them
+    /// already present and reject the query the extractor itself configured. It runs once, before
+    /// the first page.
+    /// <para>
     /// <c>EtlParameterSet</c> can detect a collision itself, but the <c>DynamicParameters</c>
     /// branch cannot — its <c>Add</c> silently overwrites, so the caller's value would disappear
     /// without a word.
+    /// </para>
     /// <para>
     /// Two routes can carry a caller's parameters and both are checked: the constructor
     /// dictionary, and the obsolete <see cref="Parameters"/> property — which takes
@@ -984,8 +1171,8 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
                 (
                     $"Parameter '{generated}' was supplied by the caller and is also generated by " +
                     "server-side paging, so it cannot be applied twice. Either stop supplying " +
-                    $"'{generated}' and let paging provide it, or clear ServerOffset and " +
-                    "ServerLimit and page through the command text yourself."
+                    $"'{generated}' and let paging provide it, or clear PagingClauseTemplate " +
+                    "and page through the command text yourself."
                 );
             }
         }
@@ -993,73 +1180,28 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
     /// <summary>
-    /// If <see cref="ServerLimit"/> is set, append <see cref="PagingClauseTemplate"/> to <paramref name="commandText"/>
-    /// (returned via <paramref name="pagedCommandText"/>) and add
-    /// <c>@PageOffset</c> / <c>@PageLimit</c> to the parameter set (returned
-    /// via <paramref name="pagedParam"/>). Otherwise returns the inputs
-    /// unchanged.
+    /// Points the paging parameters at one page. Called once per round-trip, so it overwrites
+    /// rather than accumulates: both parameter shapes replace an existing value by name.
     /// </summary>
-    /// <remarks>
-    /// out parameters instead of a tuple — net462 doesn't ship
-    /// <c>System.ValueTuple</c> in the base targeting pack and we avoid the
-    /// extra package reference.
-    /// </remarks>
-    /// <param name="commandText">The command text to page.</param>
-    /// <param name="param">The parameter set to add the paging parameters to, or <c>null</c>.</param>
-    /// <param name="pagedCommandText">The command text with the paging clause appended.</param>
-    /// <param name="pagedParam">The parameter set including the paging parameters.</param>
-    /// <exception cref="InvalidOperationException">
-    /// The caller's parameter dictionary already contains <c>@PageOffset</c> or <c>@PageLimit</c>,
-    /// which server-side paging also generates. Emitting both would duplicate the name, and
-    /// silently preferring one would discard either the caller's value or the paging.
-    /// </exception>
-    private void ApplyServerPaging(string commandText, SqlMapper.IDynamicParameters? param, out string pagedCommandText, out SqlMapper.IDynamicParameters? pagedParam)
+    /// <param name="param">The parameter set carrying the query's parameters.</param>
+    /// <param name="offset">Rows for the database to pass over before the first returned row.</param>
+    /// <param name="limit">Rows this round-trip should return at most.</param>
+    private static void SetPagingParameters(SqlMapper.IDynamicParameters param, long offset, long limit)
     {
-        if (!ServerLimit.HasValue)
-        {
-            // An offset with no limit is the mirror of the bug this default fixes: the caller
-            // plainly wants paging, and no limit can be inferred (every template references
-            // @PageLimit). Silently returning every row from the top would ignore what they asked
-            // for, so say so instead.
-            if (ServerOffset.HasValue)
-            {
-                throw new InvalidOperationException
-                (
-                    "ServerOffset was set without ServerLimit, so server-side paging cannot be " +
-                    "applied — a page size is required and cannot be inferred. Set ServerLimit " +
-                    "to the number of rows per page, or clear ServerOffset."
-                );
-            }
-
-            pagedCommandText = commandText;
-            pagedParam = param;
-            return;
-        }
-
-        // ServerLimit alone is enough: an unspecified offset can only mean "start at the top".
-        var serverOffset = ServerOffset ?? 0L;
-
-        EnsurePagingClauseTemplateChosen();
-        EnsurePagingParametersNotAlreadySupplied();
-
         // Both parameter shapes accept additions, by different methods.
         switch (param)
         {
             case EtlParameterSet set:
-                set.Add("@PageOffset", serverOffset);
-                set.Add("@PageLimit", ServerLimit.Value);
-                pagedParam = set;
+                set.Add("@PageOffset", offset);
+                set.Add("@PageLimit", limit);
                 break;
 
             default:
-                var dynamic = param as DynamicParameters ?? new DynamicParameters();
-                dynamic.Add("@PageOffset", serverOffset);
-                dynamic.Add("@PageLimit", ServerLimit.Value);
-                pagedParam = dynamic;
+                var dynamic = (DynamicParameters)param;
+                dynamic.Add("@PageOffset", offset);
+                dynamic.Add("@PageLimit", limit);
                 break;
         }
-
-        pagedCommandText = commandText + " " + PagingClauseTemplate;
     }
 
 
@@ -1171,6 +1313,23 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
 
 
 
+    private void LogSkipWithoutPaging()
+    {
+        if (_logger.IsEnabled(LogLevel.Warning))
+        {
+            _logger.LogWarning
+            (
+                "SkipItemCount={SkipItemCount} is being applied client-side: the database returns " +
+                "those rows and they are discarded on arrival. Set PagingClauseTemplate to your " +
+                "dialect (PagingClauseTemplates.SqlServer, .PostgreSql, .MySql, .Sqlite, .Oracle " +
+                "or .Db2) to push the skip into the query's offset so they are never fetched",
+                SkipItemCount
+            );
+        }
+    }
+
+
+
     private void LogDebugMaxReached()
     {
         if (_logger.IsEnabled(LogLevel.Debug))
@@ -1231,9 +1390,17 @@ public class DbExtractor<TRecord> : ExtractorBase<TRecord, DbReport>
         CommandType = options.CommandType;
         ManageConnection = options.ManageConnection;
         ValidateSchemaOnStart = options.ValidateSchemaOnStart;
-        ServerOffset = options.ServerOffset;
-        ServerLimit = options.ServerLimit;
         PagingClauseTemplate = options.PagingClauseTemplate;
+
+        // PageSize wins over the obsolete ServerLimit; ServerOffset lands on SkipItemCount,
+        // which is the same idea and now the only place it lives.
+        PageSize = options.PageSize
+            ?? (options.ServerLimit.HasValue ? ToRowCount(options.ServerLimit.Value, nameof(DbExtractorOptions.ServerLimit)) : (int?)null);
+
+        if (options.ServerOffset.HasValue)
+        {
+            SkipItemCount = ToRowCount(options.ServerOffset.Value, nameof(DbExtractorOptions.ServerOffset));
+        }
         TotalCountQuery = options.TotalCountQuery;
 #pragma warning restore CS0618
     }

--- a/src/Wolfgang.Etl.DbClient/DbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading;
@@ -83,6 +83,33 @@ internal sealed class DbExtractorBuilder<T> : IDbExtractorBuilder<T>
 
 
 
+    public IDbExtractorBuilder<T> PageSize(int? pageSize)
+    {
+        _extractor.PageSize = pageSize;
+        return this;
+    }
+
+
+
+    /// <inheritdoc/>
+    public IDbExtractorBuilder<T> SkipItemCount(int skip)
+    {
+        _extractor.SkipItemCount = skip;
+        return this;
+    }
+
+
+
+    /// <inheritdoc/>
+    public IDbExtractorBuilder<T> MaximumItemCount(int maximum)
+    {
+        _extractor.MaximumItemCount = maximum;
+        return this;
+    }
+
+
+
+    /// <inheritdoc/>
     public IDbExtractorBuilder<T> ServerLimit(long? limit)
     {
         _extractor.ServerLimit = limit;

--- a/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
+++ b/src/Wolfgang.Etl.DbClient/DbExtractorOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,24 +57,48 @@ public sealed record DbExtractorOptions
 
 
     /// <summary>
-    /// Gets the server-side row offset for paging. Defaults to <see langword="null"/> (no paging).
+    /// Rows per round-trip. Setting this makes the extractor walk the result set one page at a
+    /// time; leaving it unset issues a single query.
     /// </summary>
     /// <remarks>
-    /// The property itself stays <see langword="null"/> unless set; when paging is active an
-    /// unset offset is treated as <c>0</c>. Paging is switched on by <see cref="ServerLimit"/>,
-    /// so an offset with no limit throws — no page size can be inferred.
+    /// <para>
+    /// Paging is transport tuning, not a row filter: <c>SkipItemCount</c> and
+    /// <c>MaximumItemCount</c> decide which rows are yielded and yield the same rows either way.
+    /// What changes is the number of round-trips and the work the server does per query.
+    /// </para>
+    /// <para>
+    /// Requires <see cref="PagingClauseTemplate"/> — paging syntax is dialect-specific and no
+    /// portable form exists, so a page size without a template throws.
+    /// </para>
+    /// <para>
+    /// Paging costs more total server work, not less: <c>OFFSET n</c> is not a seek, so walking a
+    /// table of <c>N</c> rows scans roughly <c>N² / (2 × pageSize)</c> rows. What it buys is
+    /// bounded per-query work, shorter transactions and resumability. See
+    /// <see cref="DbExtractor{TRecord}.PageSize"/> for the full cost note.
+    /// </para>
     /// </remarks>
+    public int? PageSize { get; init; }
+
+
+
+    /// <summary>Rows to skip before the first yielded row, expressed as a server-side offset.</summary>
+    /// <remarks>
+    /// Superseded by <c>SkipItemCount</c>, which this is applied to — the two were always the same
+    /// idea. When a paging template is set the skip is pushed into the query's offset, so the
+    /// skipped rows are never fetched.
+    /// </remarks>
+    [Obsolete("Use SkipItemCount on the extractor instead. ServerOffset is applied to it and will be removed in a future release.")]
     public long? ServerOffset { get; init; }
 
 
 
-    /// <summary>
-    /// Gets the server-side row limit for paging. Defaults to <see langword="null"/> (no paging).
-    /// </summary>
+    /// <summary>Rows per round-trip.</summary>
     /// <remarks>
-    /// Setting this switches server-side paging on. An unset <see cref="ServerOffset"/> is then
-    /// treated as <c>0</c>, though the property itself remains <see langword="null"/>.
+    /// Superseded by <see cref="PageSize"/>, which takes precedence when both are set. The name
+    /// changed because the meaning did: this is the size of each round-trip, not a cap on the
+    /// total number of rows returned — use <c>MaximumItemCount</c> for the total.
     /// </remarks>
+    [Obsolete("Use PageSize instead. ServerLimit is applied to it and will be removed in a future release. Note the meaning changed: this is rows per round-trip, not a cap on the total — use MaximumItemCount for that.")]
     public long? ServerLimit { get; init; }
 
 

--- a/src/Wolfgang.Etl.DbClient/EtlParameterSet.cs
+++ b/src/Wolfgang.Etl.DbClient/EtlParameterSet.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -127,9 +127,9 @@ internal sealed class EtlParameterSet : SqlMapper.IDynamicParameters, SqlMapper.
             (
                 $"Parameter '{name}' was supplied in the parameters dictionary and is also " +
                 "generated automatically, so it cannot be applied twice. Server-side paging " +
-                $"generates '{name}' when ServerLimit is set. Either remove " +
-                $"'{name}' from the dictionary and let paging supply it, or clear ServerLimit " +
-                "and page through the command text yourself."
+                $"generates '{name}' when PagingClauseTemplate is set. Either remove " +
+                $"'{name}' from the dictionary and let paging supply it, or clear " +
+                "PagingClauseTemplate and page through the command text yourself."
             );
         }
 

--- a/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.DbClient/IDbExtractorBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,6 +52,39 @@ public interface IDbExtractorBuilder<T> : IEtlPipeline<T>
     /// </summary>
     /// <remarks>Defaults to <c>0</c>. Paging is switched on by <see cref="ServerLimit"/>; an offset with no limit throws, since no page size can be inferred.</remarks>
     IDbExtractorBuilder<T> ServerOffset(long? offset);
+
+
+    /// <summary>
+    /// Sets <see cref="DbExtractor{TRecord}.PageSize"/> — rows per round-trip.
+    /// </summary>
+    /// <param name="pageSize">Rows per round-trip, or <see langword="null"/> for a single query.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <remarks>
+    /// Transport tuning, not a row filter. Requires
+    /// <see cref="PagingClauseTemplate"/>; use <see cref="MaximumItemCount"/> to cap the total
+    /// number of rows returned.
+    /// </remarks>
+    IDbExtractorBuilder<T> PageSize(int? pageSize);
+
+
+    /// <summary>
+    /// Sets the number of rows to pass over before the first yielded row.
+    /// </summary>
+    /// <param name="skip">Rows to skip.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <remarks>
+    /// Pushed into the query's offset when <see cref="PagingClauseTemplate"/> is set, so the
+    /// skipped rows are never fetched; applied client-side otherwise.
+    /// </remarks>
+    IDbExtractorBuilder<T> SkipItemCount(int skip);
+
+
+    /// <summary>
+    /// Sets the maximum number of rows to yield.
+    /// </summary>
+    /// <param name="maximum">The maximum number of rows.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IDbExtractorBuilder<T> MaximumItemCount(int maximum);
 
 
     /// <summary>

--- a/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.DbClient/PublicAPI.Unshipped.txt
@@ -1,1 +1,8 @@
 #nullable enable
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.PageSize.get -> int?
+Wolfgang.Etl.DbClient.DbExtractor<TRecord>.PageSize.set -> void
+Wolfgang.Etl.DbClient.DbExtractorOptions.PageSize.get -> int?
+Wolfgang.Etl.DbClient.DbExtractorOptions.PageSize.init -> void
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.MaximumItemCount(int maximum) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.PageSize(int? pageSize) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!
+Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>.SkipItemCount(int skip) -> Wolfgang.Etl.DbClient.IDbExtractorBuilder<T>!

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbExtractorTests.cs
@@ -1,4 +1,4 @@
-using Dapper;
+﻿using Dapper;
 using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.ErrorPolicies;
 using Wolfgang.Etl.TestKit.Xunit;
@@ -611,8 +611,7 @@ public class DbExtractorTests
         using var conn = TestDb.CreateConnection();
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People");
 
-        Assert.Null(extractor.ServerOffset);
-        Assert.Null(extractor.ServerLimit);
+        Assert.Null(extractor.PageSize);
         // No dialect is assumed; see PagingClauseTemplates.None.
         Assert.Null(extractor.PagingClauseTemplate);
     }
@@ -620,15 +619,16 @@ public class DbExtractorTests
 
 
     [Fact]
-    public async Task ExtractAsync_with_ServerLimit_caps_rows_at_the_database()
+    public async Task ExtractAsync_with_a_template_and_no_PageSize_pushes_the_maximum_into_one_query()
     {
+        // Template without a page size is the single-query mode: the maximum goes into the
+        // clause, so the database never produces the other 15 rows.
         using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
 
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
         {
             PagingClauseTemplate = PagingClauseTemplates.Sqlite,
-            ServerOffset = 0,
-            ServerLimit = 5
+            MaximumItemCount = 5
         };
 
         var records = await extractor.ExtractAsync().ToListAsync();
@@ -641,20 +641,21 @@ public class DbExtractorTests
 
 
     [Fact]
-    public async Task ExtractAsync_with_ServerOffset_and_ServerLimit_returns_a_page()
+    public async Task ExtractAsync_with_a_template_pushes_SkipItemCount_into_the_offset()
     {
+        // The identity of the first row is the offset assertion: a skip applied client-side or
+        // not at all would start at First1, and a doubled skip would start at First21.
         using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
 
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
         {
             PagingClauseTemplate = PagingClauseTemplates.Sqlite,
-            ServerOffset = 10,
-            ServerLimit = 5
+            SkipItemCount = 10,
+            MaximumItemCount = 5
         };
 
         var records = await extractor.ExtractAsync().ToListAsync();
 
-        // Skipped 10, took 5 → First11..First15.
         Assert.Equal(5, records.Count);
         Assert.Equal("First11", records[0].FirstName);
         Assert.Equal("First15", records[4].FirstName);
@@ -663,17 +664,105 @@ public class DbExtractorTests
 
 
     [Fact]
-    public async Task ExtractAsync_when_paging_is_active_without_a_template_throws_and_names_the_fix()
+    public async Task ExtractAsync_when_the_skip_is_server_side_still_reports_it_as_skipped()
+    {
+        // The rows were skipped, just not by us. Leaving the counter at zero would silently
+        // change an observable the moment the skip moved into the query.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
+        {
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+            SkipItemCount = 4,
+            MaximumItemCount = 2
+        };
+
+        await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(4, extractor.CurrentSkippedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_PageSize_walks_every_page_from_one_extractor()
+    {
+        // The ergonomics gap this closes: one extractor, no caller-written loop.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
+        {
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+            PageSize = 3
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(20, records.Count);
+        Assert.Equal("First1", records[0].FirstName);
+        Assert.Equal("First20", records[19].FirstName);
+
+        // Every row exactly once — a mis-advanced offset would repeat or drop some.
+        Assert.Equal(20, records.Select(r => r.FirstName).Distinct(StringComparer.Ordinal).Count());
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_PageSize_and_a_maximum_stops_at_the_maximum()
+    {
+        // Page size 4 with a maximum of 10 is 4 + 4 + 2: the last page asks for only what is
+        // still needed rather than a full page that would be partly discarded.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
+        {
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+            PageSize = 4,
+            MaximumItemCount = 10
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(10, records.Count);
+        Assert.Equal("First10", records[9].FirstName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_PageSize_and_a_skip_walks_from_the_skip_to_the_end()
+    {
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
+
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
+        {
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
+            SkipItemCount = 15,
+            PageSize = 2
+        };
+
+        var records = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(5, records.Count);
+        Assert.Equal("First16", records[0].FirstName);
+        Assert.Equal("First20", records[4].FirstName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_PageSize_is_set_without_a_template_throws_and_names_the_fix()
     {
         // The whole point of defaulting to None: without this the caller gets a raw provider
         // syntax error ("Incorrect syntax near 'LIMIT'" on SQL Server) instead of being told
-        // what to do. Assert the message actually carries the remedy.
+        // what to do. Silently running unpaged would be worse still — a surprise full-table
+        // scan that looks correct in development.
         using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 5);
 
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People ORDER BY id")
         {
-            ServerOffset = 0,
-            ServerLimit = 2
+            PageSize = 2
         };
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -683,7 +772,7 @@ public class DbExtractorTests
 
         Assert.Contains("PagingClauseTemplate", ex.Message, StringComparison.Ordinal);
         Assert.Contains("PagingClauseTemplates", ex.Message, StringComparison.Ordinal);
-        Assert.Contains("ServerOffset", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("PageSize", ex.Message, StringComparison.Ordinal);
     }
 
 
@@ -706,44 +795,95 @@ public class DbExtractorTests
 
 
     [Fact]
-    public async Task ExtractAsync_with_only_ServerOffset_throws_because_no_page_size_can_be_inferred()
+    public async Task ExtractAsync_with_a_template_but_nothing_to_bound_appends_no_clause()
     {
-        // Reversed: this used to return all 10 rows, silently ignoring the offset the caller
-        // asked for. An offset with no limit is the mirror of the limit-with-no-offset bug —
-        // the caller clearly wants paging, and no page size can be inferred.
-        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 10);
+        // Nothing to page: no skip, no maximum, no page size. Appending the clause would mean
+        // sending "LIMIT 2147483647", which nothing here has verified every engine accepts.
+        // If a clause were emitted with a bad limit this query would fail rather than return 5.
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 5);
 
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
         {
-            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
-            ServerOffset = 5
+            PagingClauseTemplate = PagingClauseTemplates.Sqlite
         };
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-        {
-            await foreach (var _ in extractor.ExtractAsync()) { }
-        });
+        var records = await extractor.ExtractAsync().ToListAsync();
 
-        Assert.Contains("ServerLimit", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(5, records.Count);
     }
 
 
 
     [Fact]
-    public async Task ExtractAsync_with_only_ServerLimit_pages_from_offset_zero()
+    public async Task ExtractAsync_without_a_template_still_applies_Skip_and_Max_client_side()
     {
-        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 10);
+        using var conn = await TestDb.CreateConnectionWithDataAsync(rowCount: 20);
 
         var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName, last_name AS LastName, age AS Age FROM People ORDER BY id")
         {
-            PagingClauseTemplate = PagingClauseTemplates.Sqlite,
-            ServerLimit = 3
+            SkipItemCount = 5,
+            MaximumItemCount = 3
         };
 
         var records = await extractor.ExtractAsync().ToListAsync();
 
         Assert.Equal(3, records.Count);
-        Assert.Equal("First1", records[0].FirstName);
+        Assert.Equal("First6", records[0].FirstName);
+        Assert.Equal(5, extractor.CurrentSkippedItemCount);
+    }
+
+
+
+    [Fact]
+    public void ServerOffset_forwards_to_SkipItemCount()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People");
+
+        extractor.ServerOffset = 7;
+        Assert.Equal(7, extractor.SkipItemCount);
+
+        extractor.SkipItemCount = 9;
+        Assert.Equal(9L, extractor.ServerOffset);
+    }
+
+
+
+    [Fact]
+    public void ServerLimit_forwards_to_PageSize()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People");
+
+        extractor.ServerLimit = 25;
+        Assert.Equal(25, extractor.PageSize);
+
+        extractor.PageSize = 40;
+        Assert.Equal(40L, extractor.ServerLimit);
+    }
+
+
+
+    [Fact]
+    public void ServerOffset_that_does_not_fit_in_an_int_throws_rather_than_truncating()
+    {
+        // Row counts are Int32-wide on the base; a silent truncation here would turn an offset
+        // of 4294967296 into 0 and quietly return the wrong rows.
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => extractor.ServerOffset = (long)int.MaxValue + 1);
+    }
+
+
+
+    [Fact]
+    public void PageSize_below_one_throws()
+    {
+        using var conn = TestDb.CreateConnection();
+        var extractor = new DbExtractor<PersonRecord>(conn, "SELECT first_name AS FirstName FROM People");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => extractor.PageSize = 0);
     }
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbOptionsDefaultsTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/DbOptionsDefaultsTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using Microsoft.Data.Sqlite;
 using Wolfgang.Etl.DbClient;
@@ -84,12 +84,12 @@ public class DbOptionsDefaultsTests
             {
                 CommandTimeout = TimeSpan.FromSeconds(30),
                 ManageConnection = true,
-                ServerLimit = 100
+                PageSize = 100
             }
         );
 
         Assert.Equal(TimeSpan.FromSeconds(30), sut.CommandTimeout);
         Assert.True(sut.ManageConnection);
-        Assert.Equal(100, sut.ServerLimit);
+        Assert.Equal(100, sut.PageSize);
     }
 }

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterBindingTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterBindingTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
@@ -129,8 +129,12 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
             supplied,
-            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
-        );
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite }
+        )
+        {
+            SkipItemCount = 1,
+            MaximumItemCount = 1
+        };
 
         var rows = new List<PersonRecord>();
         await foreach (var r in sut.ExtractAsync()) rows.Add(r);
@@ -164,8 +168,12 @@ public class EtlParameterBindingTests
                 ["@min"] = new EtlParameter<int> { Value = 0 },
                 ["@PageOffset"] = 99          // the name paging also generates
             },
-            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
-        );
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite }
+        )
+        {
+            SkipItemCount = 1,
+            MaximumItemCount = 1
+        };
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
@@ -173,7 +181,7 @@ public class EtlParameterBindingTests
         });
 
         Assert.Contains("@PageOffset", ex.Message, StringComparison.Ordinal);
-        Assert.Contains("ServerOffset", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("PagingClauseTemplate", ex.Message, StringComparison.Ordinal);
     }
 
 
@@ -209,8 +217,12 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
             new Dictionary<string, object> { ["@min"] = 0 },
-            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
-        );
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite }
+        )
+        {
+            SkipItemCount = 1,
+            MaximumItemCount = 1
+        };
 
         var rows = new List<PersonRecord>();
         await foreach (var r in sut.ExtractAsync()) rows.Add(r);
@@ -236,8 +248,12 @@ public class EtlParameterBindingTests
                 ["@min"] = 0,
                 ["@PageOffset"] = 99
             },
-            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
-        );
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite }
+        )
+        {
+            SkipItemCount = 1,
+            MaximumItemCount = 1
+        };
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
@@ -260,8 +276,12 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
             new Dictionary<string, object> { ["@min"] = 0, ["@PageLimit"] = 5 },
-            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
-        );
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite }
+        )
+        {
+            SkipItemCount = 1,
+            MaximumItemCount = 1
+        };
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
@@ -289,9 +309,11 @@ public class EtlParameterBindingTests
         (
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
-            options: new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
+            options: new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite }
         )
         {
+            SkipItemCount = 1,
+            MaximumItemCount = 1,
             Parameters = dynamic
         };
 #pragma warning restore CS0618
@@ -323,8 +345,12 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @min ORDER BY age",
             new Dictionary<string, object> { ["@min"] = 0, [suppliedName] = 99 },
-            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
-        );
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite }
+        )
+        {
+            SkipItemCount = 1,
+            MaximumItemCount = 1
+        };
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
@@ -348,8 +374,12 @@ public class EtlParameterBindingTests
             conn,
             "SELECT first_name, last_name, age FROM People WHERE age > @PageOffsetCutoff ORDER BY age",
             new Dictionary<string, object> { ["@PageOffsetCutoff"] = 0 },
-            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite, ServerOffset = 1, ServerLimit = 1 }
-        );
+            new DbExtractorOptions { PagingClauseTemplate = PagingClauseTemplates.Sqlite }
+        )
+        {
+            SkipItemCount = 1,
+            MaximumItemCount = 1
+        };
 
         var results = await sut.ExtractAsync().ToListAsync();
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterSetDirectTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlParameterSetDirectTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using Microsoft.Data.Sqlite;
@@ -130,7 +130,7 @@ public class EtlParameterSetDirectTests
         var ex = Assert.Throws<InvalidOperationException>(() => sut.Add("@PageOffset", 0L));
 
         Assert.Contains("@PageOffset", ex.Message, StringComparison.Ordinal);
-        Assert.Contains("ServerLimit", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("PagingClauseTemplate", ex.Message, StringComparison.Ordinal);
     }
 
 

--- a/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.DbClient.Tests.Unit/EtlPipelineDbClientExtensionsTests.cs
@@ -1,4 +1,4 @@
-// End-to-end tests for the EtlPipeline DbClient extensions (#280).
+﻿// End-to-end tests for the EtlPipeline DbClient extensions (#280).
 //
 // Coverage:
 //   1. Round-trip fixture: DbExtractor → DbLoader against the same
@@ -105,8 +105,8 @@ public class EtlPipelineDbClientExtensionsTests
     [Fact]
     public async Task Extractor_builder_setters_propagate_to_the_underlying_extractor()
     {
-        // Server-side paging via the builder: ServerLimit=2, ServerOffset=1 →
-        // pipeline yields exactly rows 2 and 3.
+        // Server-side paging via the builder: skip 1, take 2 → rows 2 and 3. The skip goes
+        // into the query's offset because a template is set.
         using var src = CreateSourceWithRows(5);
         using var dest = CreateEmptyDestination();
 
@@ -114,8 +114,8 @@ public class EtlPipelineDbClientExtensionsTests
             .Create()
             .DbExtractor<Widget>(src, "SELECT Id, Name FROM source ORDER BY Id")
             .PagingClauseTemplate(PagingClauseTemplates.Sqlite)
-            .ServerOffset(1)
-            .ServerLimit(2)
+            .SkipItemCount(1)
+            .MaximumItemCount(2)
             .DbLoader<Widget>(dest, "INSERT INTO dest (Id, Name) VALUES (@Id, @Name)")
             .RunAsync()
             ;
@@ -194,24 +194,24 @@ public class EtlPipelineDbClientExtensionsTests
         using var dest = CreateEmptyDestination();
 
         var extractor = new DbExtractor<Widget>(src, "SELECT Id, Name FROM source ORDER BY Id");
-        Assert.Null(extractor.ServerLimit);
+        Assert.Null(extractor.PageSize);
 
-        // DbExtractor's paging is gated on BOTH ServerOffset AND ServerLimit
-        // being set (see DbExtractor.ApplyServerPaging), so setting both
-        // proves the setter path AND exercises paging end-to-end.
+        // Paging is gated on the template; PageSize tunes the round-trip and MaximumItemCount
+        // caps the total. Setting all three proves the setter path AND exercises paging
+        // end-to-end.
         await EtlPipeline
             .Create()
             .DbExtractor(extractor)
             .PagingClauseTemplate(PagingClauseTemplates.Sqlite)
-            .ServerOffset(0)
-            .ServerLimit(2)
+            .PageSize(2)
+            .MaximumItemCount(2)
             .DbLoader<Widget>(dest, "INSERT INTO dest (Id, Name) VALUES (@Id, @Name)")
             .RunAsync()
             ;
 
         // Setter on the builder mutated the caller's extractor.
-        Assert.Equal(0L, extractor.ServerOffset);
-        Assert.Equal(2L, extractor.ServerLimit);
+        Assert.Equal(2, extractor.PageSize);
+        Assert.Equal(2, extractor.MaximumItemCount);
         Assert.Equal(2L, CountRows(dest, "dest"));
     }
 


### PR DESCRIPTION
Implements #410 — the model recorded in ADR-0002. **Stacked on #411**; review that first for the reasoning, this for the code.

## What changed

**The template is the switch.** `PagingClauseTemplates.None` runs the command unchanged with `Skip`/`Max` client-side. A template that is set applies the paging clause.

**`ServerOffset` stops existing** — it forwards to `SkipItemCount`, which was always the same idea. **`ServerLimit` forwards to the new `PageSize`.** Renamed rather than reused, because the meaning changed from "total rows to return" to "rows per round-trip"; keeping the name would let existing code compile and quietly return a different number of rows.

Because `Skip` and `Max` are non-nullable `int`s with meaningful defaults (`0`, `int.MaxValue`), the three modes fall out of one formula rather than three branches:

```
offset = SkipItemCount + rowsReceived
limit  = PageSize.HasValue ? min(PageSize, Max - rowsYielded) : Max - rowsYielded
```

| configuration | behaviour |
|---|---|
| no template | execute as-is; `Skip`/`Max` client-side, with a warning when a skip is set |
| template, no `PageSize` | **single query**, skip and max pushed server-side |
| template + `PageSize` | one extractor walks every page |

## Two counters, deliberately distinct

`rowsReceived` counts rows the reader produced **including ones that failed to parse**, and drives the offset and the short-page test. `CurrentItemCount` counts rows yielded, and drives the clamp.

They diverge under `ErrorPolicy = Skip`, and conflating them is silently destructive both ways: advancing the offset by rows *yielded* makes a 100-row page with 3 bad rows advance by 97, re-fetching those 3 and duplicating the 97 good rows behind them; testing the short page against rows yielded sees 97 < 100 and ends the walk at the first page containing a bad row.

The paging guards also moved **outside** the page loop — run per page, the collision guard rejects page two against paging's own parameter names, which page one just added.

## Also here

- `IDbExtractorBuilder.PageSize()`, `.SkipItemCount()`, `.MaximumItemCount()` — the builder could express transport tuning but not the row contract.
- No clause is appended when there is nothing to page, rather than sending `FETCH NEXT 2147483647` — no test here shows every engine accepts that.
- `ShadowConsumer` drops its hand-rolled page loop. That loop existing in both the sample and the tests was the evidence the loop belonged in the library.
- Paging docs corrected: paging costs *more* total server work, not less, with the `N² / (2 × PageSize)` figure on the public surface. The old claim that it avoids "streaming everything to the client" was never true — extraction streams off a `DbDataReader` either way.

## Test-code changes — please review these specifically

Some existing tests asserted behaviour this design deliberately removes, so they are not mechanical edits:

- **`ExtractAsync_with_only_ServerOffset_throws_because_no_page_size_can_be_inferred` is gone.** That error no longer exists: an offset is now just `SkipItemCount` and needs no page size.
- `ExtractAsync_with_ServerLimit_caps_rows_at_the_database` and `..._returns_a_page` are replaced — `ServerLimit` no longer caps the total, so expressing their intent needs `MaximumItemCount`.
- Eight sites in `EtlParameterBindingTests` used `ServerOffset = 1, ServerLimit = 1` to mean "skip one, take one"; they now say `SkipItemCount = 1, MaximumItemCount = 1`. A straight rename to `PageSize = 1` would have walked the whole table — it did, and the tests caught it.
- Two `EtlPipelineDbClientExtensionsTests` cases now drive the builder's new contract methods.
- Collision-guard messages moved from naming `ServerLimit` to naming `PagingClauseTemplate`, with their assertions.

Roughly a dozen new tests cover the modes, the clamp, the short-page test, the forwarders, and the checked narrowing.

## Verification

- `dotnet build -c Release` across the whole solution: **0 Error(s), 0 Warning(s)** (TreatWarningsAsErrors is on).
- `dotnet test -c Release -f net10.0` unit suite: **393 passed, 0 failed**.
- Integration suite not run locally (needs Docker); CI covers the six engines.

## Still to do in this cycle

- Integration coverage for the new modes across all six engines (#410 AC).
- `docfx_project/docs/etl-pipeline.md` and `README.md` still describe `ServerOffset`/`ServerLimit` with the old meaning.
- `IDbExtractorBuilder.ServerOffset()`/`.ServerLimit()` still exist un-obsoleted; they forward correctly, but should carry `[Obsolete]` alongside the properties.

Closes #410.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
